### PR TITLE
Show toast when uploaded homebrew files do not contain valid JSON

### DIFF
--- a/js/bestiary-encounterbuilder.js
+++ b/js/bestiary-encounterbuilder.js
@@ -79,7 +79,7 @@ class EncounterBuilder extends ProxyBase {
 		});
 		$(`.ecgen__sv_file`).click(() => DataUtil.userDownload(`encounter`, this.getSaveableState(), {fileType: "encounter"}));
 		$(`.ecgen__ld_file`).click(async () => {
-			const jsons = await DataUtil.pUserUpload({expectedFileType: "encounter"});
+			const [jsons, ] = await DataUtil.pUserUpload({expectedFileType: "encounter"});
 			if (jsons?.length && jsons[0].items && jsons[0].sources) { // if it's a bestiary sublist
 				jsons.l = {
 					items: jsons.items,

--- a/js/blacklist.js
+++ b/js/blacklist.js
@@ -444,7 +444,7 @@ class Blacklist {
 	}
 
 	static async _pImport (evt) {
-		const files = await DataUtil.pUserUpload({expectedFileType: "content-blacklist"});
+		const [files, ] = await DataUtil.pUserUpload({expectedFileType: "content-blacklist"});
 
 		if (!files?.length) return;
 

--- a/js/dmscreen-initiativetracker.js
+++ b/js/dmscreen-initiativetracker.js
@@ -100,7 +100,7 @@ class InitiativeTracker {
 			new ContextUtil.Action(
 				"From Bestiary Encounter File",
 				async () => {
-					const jsons = await DataUtil.pUserUpload();
+					const [jsons, ] = await DataUtil.pUserUpload();
 					if (jsons?.length) await pConvertAndLoadBestiaryList(jsons[0]);
 				},
 			),

--- a/js/dmscreen-timetracker.js
+++ b/js/dmscreen-timetracker.js
@@ -2167,7 +2167,7 @@ class TimeTrackerRoot_Calendar extends TimeTrackerComponent {
 					break;
 				}
 				case 2: {
-					const jsons = await DataUtil.pUserUpload({expectedFileType: "encounter"});
+					const [jsons, ] = await DataUtil.pUserUpload({expectedFileType: "encounter"});
 					if (jsons?.length) {
 						const json = jsons[0];
 						const name = await InputUiUtil.pGetUserString({

--- a/js/dmscreen.js
+++ b/js/dmscreen.js
@@ -643,7 +643,7 @@ class SideMenu {
 		});
 		const $btnLoadFile = $(`<button class="btn btn-primary">Load from File</button>`).appendTo($wrpSaveLoadFile);
 		$btnLoadFile.on("click", async () => {
-			const jsons = await DataUtil.pUserUpload({expectedFileType: "dm-screen"});
+			const [jsons, ] = await DataUtil.pUserUpload({expectedFileType: "dm-screen"});
 			if (!jsons?.length) return;
 			this.board.doReset();
 			await this.board.pDoLoadStateFrom(jsons[0]);

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -552,7 +552,7 @@ NavBar.InteractionManager = class {
 
 	static async _pOnClick_button_loadStateFile (evt) {
 		evt.preventDefault();
-		const jsons = await DataUtil.pUserUpload({expectedFileType: "5etools"});
+		const [jsons, ] = await DataUtil.pUserUpload({expectedFileType: "5etools"});
 		if (!jsons?.length) return;
 		const dump = jsons[0];
 

--- a/js/statgen.js
+++ b/js/statgen.js
@@ -57,7 +57,7 @@ class StatGenPage {
 						html: `<span class="glyphicon glyphicon-upload"></span>`,
 						title: "Load from File",
 						pFnClick: async () => {
-							const jsons = await DataUtil.pUserUpload({expectedFileType: "statgen"});
+							const [jsons, ] = await DataUtil.pUserUpload({expectedFileType: "statgen"});
 							if (!jsons?.length) return;
 							this._statGenUi.setStateFrom(jsons[0]);
 						},

--- a/js/utils-list.js
+++ b/js/utils-list.js
@@ -338,7 +338,7 @@ const ListUtil = {
 			const action = new ContextUtil.Action(
 				"Upload Pinned List (SHIFT for Add Only)",
 				async evt => {
-					const files = await DataUtil.pUserUpload({expectedFileType: ListUtil._getDownloadName()});
+					const [files, ] = await DataUtil.pUserUpload({expectedFileType: ListUtil._getDownloadName()});
 					if (!files?.length) return;
 
 					const json = files[0];


### PR DESCRIPTION
Uploading homebrew with invalid JSON logs an error to the console but otherwise fails silently. This PR handles the upload error by showing a toast message with the filename and error message. 

Additionally, and perhaps more excitingly, the implementation fixes a bug where uploading is stopped even if other chosen files do contain valid homebrew. With this change, valid JSON will continue to process, and multiple failures will show multiple toasts.

**Note** This does not show a toast when the uploaded file is valid JSON but invalid homebrew schema, and does not show toasts for failures in other types of file uploads (e.g., encounter builder).

<img width="1236" alt="Screen Shot 2021-09-18 at 9 16 38 PM" src="https://user-images.githubusercontent.com/5326769/133915551-693fc33b-2e4f-4661-a405-39ec2bdf383a.png">
<img width="1289" alt="Screen Shot 2021-09-18 at 9 17 58 PM" src="https://user-images.githubusercontent.com/5326769/133915554-79ab6a96-5e0e-46d2-b11d-057a616dd2ce.png">

This also works in the homebrew mini-view on pages that include it.

<img width="1279" alt="Screen Shot 2021-09-18 at 9 23 24 PM" src="https://user-images.githubusercontent.com/5326769/133915555-2f718b0b-ebe7-4fc7-be5e-b36a9ce6e02b.png">