### PR TITLE
Ability to embed initiative tracker server token in URL

### DIFF
--- a/inittrackerplayerview.html
+++ b/inittrackerplayerview.html
@@ -93,7 +93,7 @@
 
 		<hr class="initp__initial">
 
-		<div class="initp__initial row w-100">
+		<div class="initp__initial row w-100 flex">
 			<div class="col-5 bold">Player Name</div>
 			<div class="col-5 bold">Server Token</div>
 			<div class="col-2 text-center"></div>

--- a/inittrackerplayerview.html
+++ b/inittrackerplayerview.html
@@ -94,12 +94,12 @@
 		<hr class="initp__initial">
 
 		<div class="initp__initial row w-100 flex">
-			<div class="col-5 bold">Player Name</div>
+			<div class="col-5 bold mr-4">Player Name</div>
 			<div class="col-5 bold">Server Token</div>
 			<div class="col-2 text-center"></div>
 		</div>
 		<div class="initp__initial row w-100 flex mb-4">
-			<div class="col-5 bold"><input class="form-control code" id="initp__ipt_player_name"></div>
+			<div class="col-5 bold mr-4"><input class="form-control code" id="initp__ipt_player_name"></div>
 			<div class="col-5 bold"><input class="form-control code" id="initp__ipt_server_token"></div>
 			<div class="col-2 flex-vh-center"><button class="btn btn-xs btn-primary" id="initp__btn_connect">Connect</button></div>
 		</div>

--- a/js/dmscreen-initiativetracker.js
+++ b/js/dmscreen-initiativetracker.js
@@ -166,6 +166,7 @@ class InitiativeTracker {
 		 * @param [opts]
 		 * @param [opts.$btnStartServer]
 		 * @param [opts.$btnGetToken]
+		 * @param [opts.$btnGetLink]
 		 * @param [opts.fnDispServerStoppedState]
 		 * @param [opts.fnDispServerRunningState]
 		 */
@@ -182,6 +183,7 @@ class InitiativeTracker {
 				srvPeer = new PeerVeServer();
 				await srvPeer.pInit();
 				if (opts.$btnGetToken) opts.$btnGetToken.prop("disabled", false);
+				if (opts.$btnGetLink) opts.$btnGetLink.prop("disabled", false);
 
 				srvPeer.on("connection", connection => {
 					const pConnected = new Promise(resolve => {
@@ -238,26 +240,36 @@ class InitiativeTracker {
 				const fnDispServerStoppedState = () => {
 					$btnStartServer.html(`<span class="glyphicon glyphicon-play"/> Start Server`).prop("disabled", false);
 					$btnGetToken.prop("disabled", true);
+					$btnGetLink.prop("disabled", true);
 				};
 
 				const fnDispServerRunningState = () => {
 					$btnStartServer.html(`<span class="glyphicon glyphicon-play"/> Server Running`).prop("disabled", true);
 					$btnGetToken.prop("disabled", false);
+					$btnGetLink.prop("disabled", false);
 				};
 
 				const $btnStartServer = $(`<button class="btn btn-default mr-2"></button>`)
 					.click(async () => {
-						const isRunning = await startServer({$btnStartServer, $btnGetToken, fnDispServerStoppedState, fnDispServerRunningState});
+						const isRunning = await startServer({$btnStartServer, $btnGetToken, $btnGetLink, fnDispServerStoppedState, fnDispServerRunningState});
 						if (isRunning) {
 							srvPeer.onTemp("connection", showConnected);
 							showConnected();
 						}
 					});
 
-				const $btnGetToken = $(`<button class="btn btn-default" disabled><span class="glyphicon glyphicon-copy"/> Copy Token</button>`).appendTo($wrpHelp)
+				const $btnGetToken = $(`<button class="btn btn-default mr-2" disabled><span class="glyphicon glyphicon-copy"/> Copy Token</button>`).appendTo($wrpHelp)
 					.click(() => {
 						MiscUtil.pCopyTextToClipboard(srvPeer.token);
 						JqueryUtil.showCopiedEffect($btnGetToken);
+					});
+
+				const $btnGetLink = $(`<button class="btn btn-default" disabled><span class="glyphicon glyphicon-link"/> Copy Link</button>`).appendTo($wrpHelp)
+					.click(() => {
+						const cleanOrigin = window.location.origin.replace(/\/+$/, "");
+						const url = `${cleanOrigin}/inittrackerplayerview.html#${srvPeer.token}`;
+						MiscUtil.pCopyTextToClipboard(url);
+						JqueryUtil.showCopiedEffect($btnGetLink);
 					});
 
 				if (srvPeer) fnDispServerRunningState();
@@ -273,7 +285,7 @@ class InitiativeTracker {
 							<li>Wait for them to connect!</li>
 						</ol>
 						</p>
-						<p>${$btnStartServer}${$btnGetToken}</p>
+						<p>${$btnStartServer}${$btnGetToken}${$btnGetLink}</p>
 						<p><i>Please note that this system is highly experimental. Your experience may vary.</i></p>
 					</div>
 				</div>`.appendTo($wrpHelp);

--- a/js/inittrackerplayerview.js
+++ b/js/inittrackerplayerview.js
@@ -13,6 +13,8 @@ window.addEventListener("load", () => {
 		.change(() => $iptPlayerName.removeClass("form-control--error"))
 		.disableSpellcheck();
 
+	$iptServerToken.val(window.location.hash.slice(1));
+
 	const $btnConnect = $(`#initp__btn_connect`)
 		.click(async () => {
 			if (!$iptPlayerName.val().trim()) return $iptPlayerName.addClass("form-control--error");

--- a/js/utils.js
+++ b/js/utils.js
@@ -7,7 +7,7 @@ if (IS_NODE) require("./parser.js");
 
 // in deployment, `IS_DEPLOYED = "<version number>";` should be set below.
 IS_DEPLOYED = undefined;
-VERSION_NUMBER = /* 5ETOOLS_VERSION__OPEN */"1.141.2"/* 5ETOOLS_VERSION__CLOSE */;
+VERSION_NUMBER = /* 5ETOOLS_VERSION__OPEN */"1.142.0"/* 5ETOOLS_VERSION__CLOSE */;
 DEPLOYED_STATIC_ROOT = ""; // "https://static.5etools.com/"; // FIXME re-enable this when we have a CDN again
 // for the roll20 script to set
 IS_VTT = false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "5etools",
-	"version": "1.141.2",
+	"version": "1.142.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "5etools",
-			"version": "1.141.2",
+			"version": "1.142.0",
 			"license": "MIT",
 			"devDependencies": {
 				"ajv": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "5etools",
 	"author": "TheGiddyLimit",
-	"version": "1.141.2",
+	"version": "1.142.0",
 	"license": "MIT",
 	"description": "A site dedicated to making playing games with your friends as easy as possible.",
 	"scripts": {

--- a/sw.js
+++ b/sw.js
@@ -10,7 +10,7 @@
 
 importScripts("./js/sw-files.js");
 
-const cacheName = /* 5ETOOLS_VERSION__OPEN */"1.141.2"/* 5ETOOLS_VERSION__CLOSE */;
+const cacheName = /* 5ETOOLS_VERSION__OPEN */"1.142.0"/* 5ETOOLS_VERSION__CLOSE */;
 const cacheableFilenames = new Set(filesToCache);
 
 let isCacheRunning;


### PR DESCRIPTION
Implements the feature requested in [5ET-748](https://github.com/5etools/tracker/issues/938).

It's just a simple "Copy Link" button, that appends the server token as the URL hash. When the player initiative page is loaded, it then simply inputs the hash in the "Token" field. Seems to be working nicely! If you think we should do something like `#token:TOKEN_HERE` for the hash instead, I could probably make that change. It just didn't seem necessary, since the initiative tracker page doesn't have anything else in the hash.

I have tried to keep the changes minimal and to follow the conventions of the existing code, though I may have missed some utility function or layer of abstraction that I should use. If so let me know.

I also took the liberty of fixing a few minor style issues on the initiative page.