### PR TITLE
Fixed Champion Perception

### DIFF
--- a/data/bestiary/bestiary-mpmm.json
+++ b/data/bestiary/bestiary-mpmm.json
@@ -5614,7 +5614,7 @@
 			"skill": {
 				"athletics": "+9",
 				"intimidation": "+5",
-				"perception": "-t-6"
+				"perception": "+6"
 			},
 			"passive": 16,
 			"languages": [


### PR DESCRIPTION
Fixed a typo causing perception bonus to appear wrong in the Champions MPMM entry