### PR TITLE
books.html - add a Type column sorted by default, to match Nav menu list

### DIFF
--- a/books.html
+++ b/books.html
@@ -78,7 +78,8 @@
 		</div>
 
 		<div id="filtertools" class="input-group input-group--bottom ve-flex no-shrink">
-			<button class="col-9-7 sort btn btn-default btn-xs" data-sort="name">Name</button>
+			<button class="col-8-5 sort btn btn-default btn-xs" data-sort="name">Name</button>
+			<button class="col-1-3 sort btn btn-default btn-xs" data-sort="group">Type</button>
 			<button class="ve-grow sort btn btn-default btn-xs" data-sort="published">Published</button>
 		</div>
 

--- a/js/adventures.js
+++ b/js/adventures.js
@@ -8,7 +8,7 @@ class Adventures {
 		if (o.sortBy === "name") return byName();
 		if (o.sortBy === "storyline") return orFallback(SortUtil.ascSort, "storyline");
 		if (o.sortBy === "level") return orFallback(SortUtil.ascSort, "_startLevel");
-		if (o.sortBy === "published") return SortUtil.ascSortDate(a._pubDate, b._pubDate) || SortUtil.ascSort(b.publishedOrder || 0, a.publishedOrder || 0) || byName();
+		if (o.sortBy === "published") return SortUtil.ascSortDate(b._pubDate, a._pubDate) || SortUtil.ascSort(a.publishedOrder || 0, b.publishedOrder || 0) || byName();
 
 		function byName () {
 			return SortUtil.ascSort(a.name, b.name);
@@ -29,7 +29,7 @@ const adventuresList = new BooksList({
 	contentsUrl: "data/adventures.json",
 	fnSort: Adventures.sortAdventures,
 	sortByInitial: "published",
-	sortDirInitial: "desc",
+	sortDirInitial: "asc",
 	dataProp: "adventure",
 	enhanceRowDataFn: (adv) => {
 		adv._startLevel = adv.level.start || 20;

--- a/js/books.js
+++ b/js/books.js
@@ -4,7 +4,8 @@ class Books {
 	static sortBooks (dataList, a, b, o) {
 		a = dataList[a.ix];
 		b = dataList[b.ix];
-		if (o.sortBy === "published") return SortUtil.ascSortDate(a._pubDate, b._pubDate) || SortUtil.ascSort(a.name, b.name);
+		if (o.sortBy === "group") return SortUtil.ascSortSourceGroup(a, b) || SortUtil.ascSortDate(b._pubDate, a._pubDate) || SortUtil.ascSort(a.name, b.name)
+		if (o.sortBy === "published") return SortUtil.ascSortDate(b._pubDate, a._pubDate) || SortUtil.ascSort(a.name, b.name);
 		return SortUtil.ascSort(a.name, b.name);
 	}
 }
@@ -12,15 +13,16 @@ class Books {
 const booksList = new BooksList({
 	contentsUrl: "data/books.json",
 	fnSort: Books.sortBooks,
-	sortByInitial: "published",
-	sortDirInitial: "desc",
+	sortByInitial: "group",
+	sortDirInitial: "asc",
 	dataProp: "book",
 	rootPage: "book.html",
 	enhanceRowDataFn: (bk) => {
 		bk._pubDate = new Date(bk.published || "1970-01-01");
 	},
 	rowBuilderFn: (bk) => {
-		return `<span class="col-10 bold">${bk.name}</span>
+		return `<span class="col-9 bold">${bk.name}</span>
+		<span class="col-1-3">${BooksList.getGroupStr(bk)}</span>
 		<span class="col-2">${BooksList.getDateStr(bk)}</span>`;
 	},
 });

--- a/js/bookslist.js
+++ b/js/bookslist.js
@@ -1,10 +1,16 @@
 "use strict";
 
 class BooksList {
-	static getDateStr (it) {
-		if (!it.published) return "\u2014";
-		const date = new Date(it.published);
+	static getDateStr (book) {
+		if (!book.published) return "\u2014";
+		const date = new Date(book.published);
 		return DatetimeUtil.getDateStr(date);
+	}
+
+	static getGroupStr (book) {
+		const group = book.group || "other";
+		const entry = SourceUtil.ADV_BOOK_GROUPS.find(it => it.group === group);
+		return entry.displayName;
 	}
 
 	constructor (options) {

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -223,7 +223,7 @@ class NavBar {
 
 			if (!metas.length) return;
 
-			NavBar._ADV_BOOK_GROUPS[prop]
+			SourceUtil.ADV_BOOK_GROUPS
 				.forEach(({group, displayName}) => {
 					const inGroup = metas.filter(it => (it.group || "other") === group);
 					if (!inGroup.length) return;
@@ -655,23 +655,6 @@ NavBar._MIN_MOVE_PX = 3;
 NavBar._ALT_CHILD_PAGES = {
 	"book.html": "books.html",
 	"adventure.html": "adventures.html",
-};
-NavBar._ADV_BOOK_GROUPS = {
-	"book": [
-		{group: "core", displayName: "Core"},
-		{group: "supplement", displayName: "Supplements"},
-		{group: "setting", displayName: "Settings"},
-		{group: "supplement-alt", displayName: "Extras"},
-		{group: "homebrew", displayName: "Homebrew"},
-		{group: "screen", displayName: "Screens"},
-		{group: "other", displayName: "Miscellaneous"},
-	],
-	"adventure": [
-		{group: "supplement", displayName: "Supplements"},
-		{group: "supplement-alt", displayName: "Extras"},
-		{group: "homebrew", displayName: "Homebrew"},
-		{group: "other", displayName: "Miscellaneous"},
-	],
 };
 NavBar._CAT_RULES = "Rules";
 NavBar._CAT_BOOKS = "Books";

--- a/js/utils.js
+++ b/js/utils.js
@@ -364,6 +364,16 @@ CleanUtil._TAG_DASH_EXPAND_REGEX = /({@[a-zA-Z])([\u2014\u2013])/g;
 
 // SOURCES =============================================================================================================
 SourceUtil = {
+	ADV_BOOK_GROUPS: [
+		{group: "core", displayName: "Core"},
+		{group: "supplement", displayName: "Supplements"},
+		{group: "setting", displayName: "Settings"},
+		{group: "supplement-alt", displayName: "Extras"},
+		{group: "homebrew", displayName: "Homebrew"},
+		{group: "screen", displayName: "Screens"},
+		{group: "other", displayName: "Miscellaneous"},
+	],
+
 	_subclassReprintLookup: {},
 	async pInitSubclassReprintLookup () {
 		SourceUtil._subclassReprintLookup = await DataUtil.loadJSON(`${Renderer.get().baseUrl}data/generated/gendata-subclass-lookup.json`);
@@ -2523,6 +2533,14 @@ SortUtil = {
 					},
 				});
 			});
+	},
+
+	ascSortSourceGroup (a, b) {
+		const agrp = a.group || "other";
+		const bgrp = b.group || "other";
+		const aidx = SourceUtil.ADV_BOOK_GROUPS.findIndex(it => it.group === agrp);
+		const bidx = SourceUtil.ADV_BOOK_GROUPS.findIndex(it => it.group === bgrp);
+		return aidx - bidx;
 	},
 
 	ascSortAdventure (a, b) {


### PR DESCRIPTION
This PR adds a new Type column to the books.html page using the existing groups and display names from the Nav menu. It is also set as the default sort so that this table and the book covers below now match the Nav menu by default.

It also fixes a bug where in books.html and adventures.html the Published column was sorting in reverse.