### PR TITLE
easy switching for translated content

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -118,6 +118,18 @@ class NavBar {
 		this._addElement_li(NavBar._CAT_UTILITIES, "privacy-policy.html", "Privacy Policy");
 
 		this._addElement_dropdown(null, NavBar._CAT_SETTINGS);
+		if (Object.keys(DataUtil.contentLanguages).length > 1) {
+			this._addElement_dropdown(NavBar._CAT_SETTINGS, NavBar._CAT_LANGUAGE, { isSide: true });
+			Object.entries(DataUtil.contentLanguages).forEach(([k, v]) => {
+				this._addElement_button(
+					NavBar._CAT_LANGUAGE,
+					{
+						html: v.name,
+						click: () => { DataUtil.setLanguage(k); },
+					},
+				);
+			});
+		};
 		this._addElement_button(
 			NavBar._CAT_SETTINGS,
 			{
@@ -664,6 +676,7 @@ NavBar._CAT_ADVENTURES = "Adventures";
 NavBar._CAT_REFERENCES = "References";
 NavBar._CAT_UTILITIES = "Utilities";
 NavBar._CAT_SETTINGS = "Settings";
+NavBar._CAT_LANGUAGE = "Content Language";
 
 NavBar._navbar = null;
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -2601,11 +2601,26 @@ DataUtil = {
 	_merging: {},
 	_merged: {},
 
+	defaultContentLanguage: 'en',
+	contentLanguages: {
+		'en': { name: 'English', baseDir: 'data/' },
+		//'de': { name: 'Deutsch', baseDir: 'data.de/' },
+	},
+
 	async _pLoad (url) {
+		language = StorageUtil.syncGet("contentLanguage")
+		if (!language) {
+			language = this.defaultContentLanguage;
+		}
+		if (language in DataUtil.contentLanguages) {
+			url = url.replace("data/", DataUtil.contentLanguages[language].baseDir);
+		}
+
 		if (DataUtil._loading[url]) {
 			await DataUtil._loading[url];
 			return DataUtil._loaded[url];
 		}
+		console.log("loading " + url);
 
 		DataUtil._loading[url] = new Promise((resolve, reject) => {
 			const request = new XMLHttpRequest();
@@ -2625,6 +2640,16 @@ DataUtil = {
 
 		await DataUtil._loading[url];
 		return DataUtil._loaded[url];
+	},
+
+	setLanguage(language) {
+		StorageUtil.syncSet("contentLanguage", language);
+		if (typeof location != "undefined") {
+			// Without the setTimeout chrome will not reload books/quickref
+			setTimeout(function () {
+				window.location.reload();
+			},100);
+		}
 	},
 
 	_mutAddProps (data) {

--- a/node/generate-dmscreen-reference.js
+++ b/node/generate-dmscreen-reference.js
@@ -2,21 +2,6 @@ const fs = require("fs");
 const utB = require("./util-book-reference");
 require("../js/utils");
 
-const index = utB.UtilBookReference.getIndex(
-	{
-		name: "Quick Reference",
-		id: "bookref-quick",
-		tag: "quickref",
-	},
-	{
-		name: "DM Reference",
-		id: "bookref-dmscreen",
-		tag: "dmref",
-	},
-);
-
-fs.writeFileSync("data/generated/bookref-dmscreen.json", CleanUtil.getCleanJson(index, {isMinify: true}), "utf8");
-
 function flattenReferenceIndex (ref, skipHeaders) {
 	const outMeta = {
 		name: {},
@@ -74,5 +59,22 @@ function flattenReferenceIndex (ref, skipHeaders) {
 	};
 }
 
-fs.writeFileSync("data/generated/bookref-dmscreen-index.json", JSON.stringify(flattenReferenceIndex(index.reference)), "utf8");
+Object.entries(DataUtil.contentLanguages).forEach(([k, v]) => {
+	const index = utB.UtilBookReference.getIndex("../"+v.baseDir,
+		{
+			name: "Quick Reference",
+			id: "bookref-quick",
+			tag: "quickref",
+		},
+		{
+			name: "DM Reference",
+			id: "bookref-dmscreen",
+			tag: "dmref",
+		},
+	);
+
+	fs.writeFileSync(`${v.baseDir}/generated/bookref-dmscreen.json`, CleanUtil.getCleanJson(index, { isMinify: true }), "utf8");
+	fs.writeFileSync(`${v.baseDir}/generated/bookref-dmscreen-index.json`, JSON.stringify(flattenReferenceIndex(index.reference)), "utf8");
+});
+
 console.log("Updated DM Screen references.");

--- a/node/generate-nav-adventure-book-index.js
+++ b/node/generate-nav-adventure-book-index.js
@@ -38,5 +38,7 @@ const out = _METAS.mergeMap(({file, prop}) => {
 	};
 });
 
-fs.writeFileSync("data/generated/gendata-nav-adventure-book-index.json", JSON.stringify(out), "utf8");
+Object.entries(DataUtil.contentLanguages).forEach(([k, v]) => {
+	fs.writeFileSync(v.baseDir + "/generated/gendata-nav-adventure-book-index.json", JSON.stringify(out), "utf8");
+});
 console.log("Generated navbar adventure/book index.");

--- a/node/generate-quick-reference.js
+++ b/node/generate-quick-reference.js
@@ -1,5 +1,7 @@
 const fs = require("fs");
 const utB = require("./util-book-reference");
 
-fs.writeFileSync("data/generated/bookref-quick.json", JSON.stringify(utB.UtilBookReference.getIndex({name: "Quick Reference", id: "bookref-quick", tag: "quickref"})).replace(/\s*\u2014\s*?/g, "\\u2014"), "utf8");
+Object.entries(DataUtil.contentLanguages).forEach(([k, v]) => {
+	fs.writeFileSync(`${v.baseDir}/generated/bookref-quick.json`, JSON.stringify(utB.UtilBookReference.getIndex(`../${v.baseDir}`, {name: "Quick Reference", id: "bookref-quick", tag: "quickref"})).replace(/\s*\u2014\s*?/g, "\\u2014"), "utf8");
+})
 console.log("Updated quick references.");

--- a/node/generate-subclass-lookup.js
+++ b/node/generate-subclass-lookup.js
@@ -2,14 +2,16 @@ const fs = require("fs");
 require("./util.js");
 require("../js/utils");
 
-const out = {};
-const classIndex = JSON.parse(fs.readFileSync("./data/class/index.json", "utf-8"));
-Object.values(classIndex).forEach(f => {
-	const data = JSON.parse(fs.readFileSync(`./data/class/${f}`, "utf-8"));
+Object.entries(DataUtil.contentLanguages).forEach(([k, v]) => {
+	const out = {};
+	const classIndex = JSON.parse(fs.readFileSync(`${v.baseDir}/class/index.json`, "utf-8"));
+	Object.values(classIndex).forEach(f => {
+		const data = JSON.parse(fs.readFileSync(`${v.baseDir}/class/${f}`, "utf-8"));
 
-	(data.subclass || []).forEach(sc => {
-		MiscUtil.set(out, sc.classSource, sc.className, sc.source, sc.shortName, {name: sc.name, isReprinted: sc.isReprinted});
+		(data.subclass || []).forEach(sc => {
+			MiscUtil.set(out, sc.classSource, sc.className, sc.source, sc.shortName, { name: sc.name, isReprinted: sc.isReprinted });
+		});
 	});
+	fs.writeFileSync(`${v.baseDir}/generated/gendata-subclass-lookup.json`, CleanUtil.getCleanJson(out, { isMinify: true }));
 });
-fs.writeFileSync(`./data/generated/gendata-subclass-lookup.json`, CleanUtil.getCleanJson(out, {isMinify: true}));
 console.log("Regenerated subclass lookup.");

--- a/node/generate-tables-data.js
+++ b/node/generate-tables-data.js
@@ -7,12 +7,12 @@ Object.assign(global, require("../js/hist.js"));
 
 class GenTables {
 	_doLoadAdventureData () {
-		return ut.readJson(`./data/adventures.json`).adventure
+		return ut.readJson(`${this._baseDir}/adventures.json`).adventure
 			.map(idx => {
 				if (GenTables.ADVENTURE_WHITELIST[idx.id]) {
 					return {
 						adventure: idx,
-						adventureData: JSON.parse(fs.readFileSync(`./data/adventure/adventure-${idx.id.toLowerCase()}.json`, "utf-8")),
+						adventureData: JSON.parse(fs.readFileSync(`${this._baseDir}/adventure/adventure-${idx.id.toLowerCase()}.json`, "utf-8")),
 					};
 				}
 			})
@@ -20,19 +20,20 @@ class GenTables {
 	}
 
 	_doLoadBookData () {
-		return ut.readJson(`./data/books.json`).book
+		return ut.readJson(`${this._baseDir}/books.json`).book
 			.map(idx => {
 				if (!GenTables.BOOK_BLACKLIST[idx.id]) {
 					return {
 						book: idx,
-						bookData: JSON.parse(fs.readFileSync(`./data/book/book-${idx.id.toLowerCase()}.json`, "utf-8")),
+						bookData: JSON.parse(fs.readFileSync(`${this._baseDir}/book/book-${idx.id.toLowerCase()}.json`, "utf-8")),
 					};
 				}
 			})
 			.filter(it => it);
 	}
 
-	async pRun () {
+	async pRun (baseDir) {
+		this._baseDir = baseDir;
 		const output = {tables: [], tableGroups: []};
 
 		this._addBookAndAdventureData(output);
@@ -40,7 +41,7 @@ class GenTables {
 		await this._pAddVariantRuleData(output);
 
 		const toSave = JSON.stringify({table: output.tables, tableGroup: output.tableGroups});
-		fs.writeFileSync(`./data/generated/gendata-tables.json`, toSave, "utf-8");
+		fs.writeFileSync(`${this._baseDir}/generated/gendata-tables.json`, toSave, "utf-8");
 		console.log("Regenerated table data.");
 	}
 
@@ -100,7 +101,7 @@ class GenTables {
 
 	async _pAddVariantRuleData (output) {
 		ut.patchLoadJson();
-		const variantRuleData = await DataUtil.loadJSON(`./data/variantrules.json`);
+		const variantRuleData = await DataUtil.loadJSON(`${this._baseDir}/variantrules.json`);
 		ut.unpatchLoadJson();
 
 		variantRuleData.variantrule.forEach(it => {
@@ -116,4 +117,6 @@ GenTables.ADVENTURE_WHITELIST = {
 };
 
 const generator = new GenTables();
-module.exports = generator.pRun();
+Object.entries(DataUtil.contentLanguages).forEach(([k, v]) => {
+	module.exports = generator.pRun(v.baseDir);
+});

--- a/node/util-book-reference.js
+++ b/node/util-book-reference.js
@@ -23,11 +23,11 @@ UtilBookReference = {
 		}
 	},
 
-	getIndex (...refTypes) {
-		const index = require(`../data/books.json`);
+	getIndex (baseDir, ...refTypes) {
+		const index = require(`${baseDir}/books.json`);
 		const books = {};
 		index.book.forEach(b => {
-			books[b.id.toLowerCase()] = require(`../data/book/book-${b.id.toLowerCase()}.json`);
+			books[b.id.toLowerCase()] = require(`${baseDir}/book/book-${b.id.toLowerCase()}.json`);
 		});
 
 		const outJson = {


### PR DESCRIPTION
This change would allow for easy upstream tracking since all translated jsons can be kept in a separate data directory.
Basically you keep all translations in data.$LANG/ and only adjust utils.js:contentLanguages/defaultContentLanguage

This is not perfect but works pretty well.

JS is not my forte but if you're interested in improving this to merge quality let me know