### PR TITLE
Text Converter (Mainly items) Tweaks

### DIFF
--- a/js/converter-item.js
+++ b/js/converter-item.js
@@ -174,6 +174,7 @@ class ItemParser extends BaseParser {
 		let baseItem = null;
 		let genericType = null;
 		let genericVariantBases = []; // in case it's a variant of a specific list of items
+		let genericVariantExceptions = [];
 
 		for (let i = 0; i < parts.length; ++i) {
 			let part = parts[i];
@@ -258,6 +259,19 @@ class ItemParser extends BaseParser {
 			// armor (plate, half plate, or splint)
 			const variantListPattern = /(?:\s+or|\s*,(?! but)|\s+and)(?: or)?\s+/i;
 
+			const checkExceptions = subcategory => {
+				const exceptionsSplit = subcategory.split(/,?\s*(?:except|but(?:\s*not)?)\s*/);
+				if (exceptionsSplit.length > 1) {
+					const exceptions = exceptionsSplit[1].split(variantListPattern).map(s => s.trim());
+					exceptions.forEach(exceptionName => {
+						let item = ItemParser.getItem(exceptionName);
+						if (!item) item = ItemParser.getItem(`${exceptionName} armor`); // "armor (plate)" -> "plate armor"
+						if (!item) throw new Error(`Could not find exception item "${exceptionName}"`);
+						genericVariantExceptions.push(item.name); // correct capitalization
+					});
+				}
+			};
+
 			if (mBaseWeapon) {
 				if (mBaseWeapon[1].toLowerCase() === "staff") stats.staff = true;
 				baseItem = ItemParser.getItem(mBaseWeapon[2]);
@@ -278,6 +292,8 @@ class ItemParser extends BaseParser {
 						if (!baseItem) throw new Error(`Could not find base item "${mBaseWeapon[2]}"`);
 					}
 				}
+				if (genericType || genericVariantBases.length > 0) 
+					checkExceptions(mBaseWeapon[2]);
 				continue;
 			} else if (mBaseArmor) {
 				baseItem = ItemParser.getItem(mBaseArmor[1]);
@@ -317,6 +333,8 @@ class ItemParser extends BaseParser {
 						if (!baseItem) throw new Error(`Could not find base item "${mBaseArmor[1]}"`);
 					}
 				}
+				if (genericType || genericVariantBases.length > 0) 
+					checkExceptions(mBaseArmor[1]);
 
 				continue;
 			}
@@ -330,6 +348,7 @@ class ItemParser extends BaseParser {
 		// Stash the genericType for later processing/removal
 		if (genericType) stats.__genericType = genericType;
 		if (genericVariantBases.length != 0) stats.__genericVariantBases = genericVariantBases;
+		if (genericVariantExceptions.length != 0) stats.__genericVariantExceptions = genericVariantExceptions;
 	}
 
 	static _setCleanTaglineInfo_getArmorBaseItem (name) {
@@ -404,8 +423,10 @@ class ItemParser extends BaseParser {
 
 		const genericType = stats.__genericType;
 		const genericVariantBases = stats.__genericVariantBases;
+		const genericVariantExceptions = stats.__genericVariantExceptions;
 		delete stats.__genericType;
 		delete stats.__genericVariantBases;
+		delete stats.__genericVariantExceptions;
 
 		let prefixSuffixName = stats.name;
 		prefixSuffixName = prefixSuffixName.replace(/^weapon /i, "");
@@ -438,6 +459,12 @@ class ItemParser extends BaseParser {
 					"name": item.name
 				});
 			});
+		}
+
+		if (genericVariantExceptions) {
+			stats.excludes = {
+				"name": genericVariantExceptions
+			};
 		}
 	}
 

--- a/js/converter-item.js
+++ b/js/converter-item.js
@@ -91,7 +91,11 @@ class ItemParser extends BaseParser {
 		this._doItemPostProcess(item, options);
 		this._setCleanTaglineInfo_handleGenericType(item, options);
 		this._doVariantPostProcess(item, options);
-		return PropOrder.getOrdered(item, item.__prop || "item");
+
+		const prop = item.__prop
+		delete item.__prop
+
+		return PropOrder.getOrdered(item, prop || "item");
 	}
 
 	// SHARED UTILITY FUNCTIONS ////////////////////////////////////////////////////////////////////////////////////////

--- a/js/converter-item.js
+++ b/js/converter-item.js
@@ -26,6 +26,8 @@ class ItemParser extends BaseParser {
 
 	static _getBaseItem (itemName, category) {
 		let baseItem = ItemParser.getItem(itemName);
+		if (!baseItem) baseItem = ItemParser.getItem(itemName.replace(/s$/i, ""))
+		if (!baseItem) baseItem = ItemParser.getItem(itemName.replace(/es$/i, ""))
 		if (!baseItem && category.toLowerCase() === "armor") {
 			baseItem = ItemParser.getItem(`${itemName} armor`); // "armor (plate)" -> "plate armor"
 		}
@@ -407,8 +409,7 @@ class ItemParser extends BaseParser {
 					if (exceptSep.toLowerCase() !== "without") {
 						const exceptions = except.split(variantListPattern).map(s => s.trim());
 						exceptions.forEach(exceptionName => {
-							let item = ItemParser.getItem(exceptionName);
-							if (!item) item = ItemParser.getItem(`${exceptionName} armor`); // "armor (plate)" -> "plate armor"
+							let item = this._getBaseItem(exceptionName, category);
 							if (!item) throw new Error(`Could not find exception item "${exceptionName}"`);
 							genericVariantExceptions.push(item.name); // correct capitalization
 						});

--- a/js/converter-item.js
+++ b/js/converter-item.js
@@ -267,22 +267,57 @@ class ItemParser extends BaseParser {
 						.replace(/(a|an|any)\s+/, "")
 						.split(variantListPattern)
 						;
-					let genericsNumBefore = genericVariantBases.length;
+					let handled = false;
 					baseItems.forEach((itemName) => {
 						let item = ItemParser.getItem(itemName);
 						if (!item) throw new Error(`Could not find base item "${itemName}"`);
 						genericVariantBases.push(item);
+						handled = true;
 					});
-					if (genericVariantBases.length == genericsNumBefore) {
-						if (!item) throw new Error(`Could not find base item "${baseItem}"`);
+					if (!handled) {
+						if (!baseItem) throw new Error(`Could not find base item "${mBaseWeapon[2]}"`);
 					}
 				}
 				continue;
 			} else if (mBaseArmor) {
-				if (this._setCleanTaglineInfo_isMutAnyArmor(stats, mBaseArmor)) continue;
+				baseItem = ItemParser.getItem(mBaseArmor[1]);
+				if (!baseItem) baseItem = ItemParser.getItem(`${mBaseArmor[1]} armor`); // "armor (plate)" -> "plate armor"
 
-				baseItem = this._setCleanTaglineInfo_getArmorBaseItem(mBaseArmor.groups.type);
-				if (!baseItem) throw new Error(`Could not find base item "${mBaseArmor.groups.type}"`);
+				if (!baseItem) {
+					let trimmed = mBaseArmor[1]
+						.replace(/(a|an|any)\s+/, "")
+						.trim()
+						;
+
+					let handled = false;
+					// check armor types
+					if (/^heavy/.test(trimmed)) {
+						genericType = "heavy armor";
+						handled = true;
+					} else if (/^medium/.test(trimmed)) {
+						genericType = "medium armor";
+						handled = true;
+					} else if (/^light/.test(trimmed)) {
+						genericType = "light armor";
+						handled = true;
+					}
+
+					if (!handled) {
+						let baseItems = trimmed
+							.split(variantListPattern)
+							;
+						baseItems.forEach((itemName) => {
+							let item = ItemParser.getItem(itemName);
+							if (!item) throw new Error(`Could not find base item "${itemName}"`);
+							genericVariantBases.push(item);
+							handled = true;
+						});
+					}
+					if (!handled) {
+						if (!baseItem) throw new Error(`Could not find base item "${mBaseArmor[1]}"`);
+					}
+				}
+
 				continue;
 			}
 			// endregion
@@ -391,6 +426,9 @@ class ItemParser extends BaseParser {
 				case "weapon": stats.requires = [{"weapon": true}]; break;
 				case "sword": stats.requires = [{"sword": true}]; break;
 				case "armor": stats.requires = [{"armor": true}]; break;
+				case "heavy armor": stats.requires = [{"type": "HA"}]; break;
+				case "medium armor": stats.requires = [{"type": "MA"}]; break;
+				case "light armor": stats.requires = [{"type": "LA"}]; break;
 				default: throw new Error(`Unhandled generic type "${genericType}"`);
 			}
 		} else if (genericVariantBases) {

--- a/js/converter-item.js
+++ b/js/converter-item.js
@@ -280,13 +280,15 @@ class ItemParser extends BaseParser {
 				}
 			}
 
-			const baseCats = ["weapon", "staff", "armor"];
-			const exceptionSeps = ["except", "but\\s*(?:not)?", "without"];
-
 			// example: weapon (dagger, shortsword), weapon (maul or warhammer), 
 			// armor (plate, half plate, or splint)
 			// list separated by commas and/or "or"s
-			const variantListPattern = /(?:\s+or|\s*,|\s+and)(?: or)?\s+/i;
+			const variantListPattern = /(?:\s+or\s|\s*,|\s+and\s)(?:\sor\s)?\s*/i;
+
+			const baseCats = ["weapon", "staff", "armor"];
+			const exceptionSeps = ["except", "but\\s*(?:not)?", "without"];
+			const stackableTerms = ["melee", "ranged", "piercing", "slashing", "edged", "bladed", "bludgeoning", "blunt"];
+
 			// separates part before exceptions and after exceptions inside the category, in case
 			// of generic variant with things like "armor (heavy but not plate)"
 			const mBaseItem = new RegExp(
@@ -324,27 +326,48 @@ class ItemParser extends BaseParser {
 					baseItems.forEach((itemName) => {
 						let found = false;
 						if (categoryL === "weapon" || categoryL === "staff") {
-							found = true;
-							switch (itemName) {
-								case "melee": case "melee weapon":
-									genericTypes.push("melee"); break;
-								case "ranged": case "ranged weapon":
-									genericTypes.push("ranged"); break;
-								case "piercing": case "piercing weapon":
-									genericTypes.push("piercing"); break;
-								case "slashing": case "slashing weapon":
-								case "edged": case "edged weapon":
-								case "bladed": case "bladed weapon":
-									genericTypes.push("slashing"); break;
-								case "bludgeoning": case "bludgeoning weapon":
-								case "blunt": case "blunt weapon":
-									genericTypes.push("bludgeoning"); break;
-								case "sword": genericTypes.push("sword"); break;
-								case "axe": genericTypes.push("axe"); break;
-								case "bow": genericTypes.push("bow"); break;
-								case "crossbow": genericTypes.push("crossbow"); break;
-								default: found = false;
-							}
+							// List containing terms to check against 
+							// for generic item terms
+							const genericTerms = [];
+
+							itemName = itemName
+								.split(/\s+/)
+								.map(word => {
+									if (stackableTerms.includes(word)) {
+										genericTerms.push(word);
+										return "";
+									}
+									return word;
+								})
+								.join(" ");
+
+							genericTerms.push(itemName);
+
+							found = false;
+							genericTerms.forEach(term => {
+								let foundHere = true;
+								switch (term) {
+									case "melee": case "melee weapon":
+										genericTypes.push("melee"); break;
+									case "ranged": case "ranged weapon":
+										genericTypes.push("ranged"); break;
+									case "piercing": case "piercing weapon":
+										genericTypes.push("piercing"); break;
+									case "slashing": case "slashing weapon":
+									case "edged": case "edged weapon":
+									case "bladed": case "bladed weapon":
+										genericTypes.push("slashing"); break;
+									case "bludgeoning": case "bludgeoning weapon":
+									case "blunt": case "blunt weapon":
+										genericTypes.push("bludgeoning"); break;
+									case "sword": genericTypes.push("sword"); break;
+									case "axe": genericTypes.push("axe"); break;
+									case "bow": genericTypes.push("bow"); break;
+									case "crossbow": genericTypes.push("crossbow"); break;
+									default: foundHere = false;
+								}
+								found = found || foundHere;
+							});
 						} else if (categoryL === "armor") {
 							found = true;
 							if (/^heavy/i.test(itemName)) {

--- a/js/converter-item.js
+++ b/js/converter-item.js
@@ -138,7 +138,10 @@ class ItemParser extends BaseParser {
 
 	// SHARED PARSING FUNCTIONS ////////////////////////////////////////////////////////////////////////////////////////
 	static _setCleanTaglineInfo (stats, curLine, options) {
-		const parts = curLine.split(",").map(it => it.trim()).filter(Boolean);
+		// split on first comma not inside parentheses
+		// \s*(?![^()]*\)) : not inside parentheses
+		// (.*) : only first
+		const parts = curLine.split(/,\s*(?![^()]*\))(.*)/s).map(it => it.trim()).filter(Boolean);
 
 		const handlePartRarity = (rarity) => {
 			rarity = rarity.trim().toLowerCase();

--- a/js/converter-item.js
+++ b/js/converter-item.js
@@ -318,6 +318,15 @@ class ItemParser extends BaseParser {
 									genericTypes.push("melee"); break;
 								case "ranged": case "ranged weapon":
 									genericTypes.push("ranged"); break;
+								case "piercing": case "piercing weapon":
+									genericTypes.push("piercing"); break;
+								case "slashing": case "slashing weapon":
+								case "edged": case "edged weapon":
+								case "bladed": case "bladed weapon":
+									genericTypes.push("slashing"); break;
+								case "bludgeoning": case "bludgeoning weapon":
+								case "blunt": case "blunt weapon":
+									genericTypes.push("bludgeoning"); break;
 								case "sword": genericTypes.push("sword"); break;
 								case "axe": genericTypes.push("axe"); break;
 								case "bow": genericTypes.push("bow"); break;
@@ -519,6 +528,9 @@ class ItemParser extends BaseParser {
 				switch (genericType) {
 					case "weapon": stats.requires.push({"weapon": true}); break;
 					case "melee": stats.requires.push({"type": "M"}); break;
+					case "piercing": stats.requires.push({"dmgType": "P"}); break;
+					case "slashing": stats.requires.push({"dmgType": "S"}); break;
+					case "bludgeoning": stats.requires.push({"dmgType": "B"}); break;
 					case "ranged": rstats.equires.push({"type": "R"}); break;
 					case "sword": stats.requires.push({"sword": true}); break;
 					case "axe": stats.requires.push({"axe": true}); break;

--- a/js/converter-item.js
+++ b/js/converter-item.js
@@ -389,6 +389,9 @@ class ItemParser extends BaseParser {
 								genericVariantBases.push(item);
 							} 
 						}
+						if (!found && (/\s*/.test(itemName) || itemName === categoryL) )
+							// any item of the category, will use property matches too
+							found = true;
 						if (!found)
 							throw new Error(`Could not find generic base item "${itemName}"`);
 						handled = true;
@@ -399,7 +402,7 @@ class ItemParser extends BaseParser {
 				}
 
 				// handle exceptions (but not <item>, except <item>, etc.)
-				if (exceptSep && (genericTypes.length > 0 || genericVariantBases.length > 0)) {
+				if (exceptSep) {
 					// item exceptions
 					if (exceptSep.toLowerCase() !== "without") {
 						const exceptions = except.split(variantListPattern).map(s => s.trim());
@@ -511,7 +514,14 @@ class ItemParser extends BaseParser {
 	}
 
 	static _setCleanTaglineInfo_handleGenericType (stats, options) {
-		if (!(stats.__genericTypes || stats.__genericVariantBases)) return;
+		if (!(
+			stats.__genericTypes 
+			|| stats.__genericVariantBases 
+			|| stats.__genericVariantExceptions 
+			|| stats.__genericVariantRequiresProperties 
+			|| stats.__genericVariantExceptProperties 
+		))
+			return;
 
 		const genericTypes = stats.__genericTypes;
 		const genericVariantBases = stats.__genericVariantBases;

--- a/js/converter-item.js
+++ b/js/converter-item.js
@@ -169,6 +169,7 @@ class ItemParser extends BaseParser {
 
 		let baseItem = null;
 		let genericType = null;
+		let genericVariantBases = []; // in case it's a variant of a specific list of items
 
 		for (let i = 0; i < parts.length; ++i) {
 			let part = parts[i];
@@ -246,11 +247,34 @@ class ItemParser extends BaseParser {
 			}
 
 			const mBaseWeapon = /^(weapon|staff) \(([^)]+)\)$/i.exec(part);
-			const mBaseArmor = /^armor \((?<type>[^)]+)\)$/i.exec(part);
+			const mBaseArmor = /^armor \(([^)]+)\)$/i.exec(part);
+
+			// list separated by commas and/or "or"s
+			// example: weapon (dagger, shortsword), weapon (maul or warhammer), 
+			// armor (plate, half plate, or splint)
+			const variantListPattern = /(?:\s+or|\s*,(?! but)|\s+and)(?: or)?\s+/i;
+
 			if (mBaseWeapon) {
 				if (mBaseWeapon[1].toLowerCase() === "staff") stats.staff = true;
 				baseItem = ItemParser.getItem(mBaseWeapon[2]);
-				if (!baseItem) throw new Error(`Could not find base item "${mBaseWeapon[2]}"`);
+				if (!baseItem) {
+					// check if the items are a list
+					let baseItems = mBaseWeapon[2]
+						.replace(/(a|an|any)\s+/, "")
+						.split(variantListPattern)
+						;
+					options.cbWarning("Subparts: " + baseItems);
+					let genericsNumBefore = genericVariantBases.length;
+					baseItems.forEach((itemName) => {
+						let item = ItemParser.getItem(itemName);
+						if (!item) throw new Error(`Could not find base item "${itemName}"`);
+						genericVariantBases.push(item);
+						options.cbWarning(`item: ${item.name}`);
+					});
+					if (genericVariantBases.length == genericsNumBefore) {
+						if (!item) throw new Error(`Could not find base item "${baseItem}"`);
+					}
+				}
 				continue;
 			} else if (mBaseArmor) {
 				if (this._setCleanTaglineInfo_isMutAnyArmor(stats, mBaseArmor)) continue;
@@ -268,6 +292,7 @@ class ItemParser extends BaseParser {
 		this._setCleanTaglineInfo_handleBaseItem(stats, baseItem, options);
 		// Stash the genericType for later processing/removal
 		if (genericType) stats.__genericType = genericType;
+		if (genericVariantBases.length != 0) stats.__genericVariantBases = genericVariantBases;
 	}
 
 	static _setCleanTaglineInfo_getArmorBaseItem (name) {

--- a/js/converter-item.js
+++ b/js/converter-item.js
@@ -385,8 +385,6 @@ class ItemParser extends BaseParser {
 						if (!found) {
 							let item = this._getBaseItem(itemName, category);
 							if (item) {
-								if (properties) throw new Error(`Properties not supported for specific base items (item: ${itemName})`)
-
 								found = true;
 								genericVariantBases.push(item);
 							} 

--- a/js/converter-item.js
+++ b/js/converter-item.js
@@ -126,18 +126,26 @@ class ItemParser extends BaseParser {
 	static _doItemPostProcess_addTags (stats, options) {
 		const manName = stats.name ? `(${stats.name}) ` : "";
 		try {
-			ChargeTag.tryRun(stats);
+			const defaultOptions = name => { return {
+				// For debugging if some options were needed
+				cbMan: str => {
+					if (options.verboseWarnings) {
+						options.cbWarning(`${manName}${name}: ${str}`);
+					}
+				}
+			} };
+
 			RechargeTypeTag.tryRun(stats, {cbMan: () => options.cbWarning(`${manName}Recharge type requires manual conversion`)});
-			BonusTag.tryRun(stats);
-			ItemMiscTag.tryRun(stats);
-			ItemSpellcastingFocusTag.tryRun(stats);
+			BonusTag.tryRun(stats, defaultOptions("BonusTag"));
+			ItemMiscTag.tryRun(stats, defaultOptions("ItemMiscTag"));
+			ItemSpellcastingFocusTag.tryRun(stats, defaultOptions("ItemSpellcastingFocusTag"));
 			DamageResistanceTag.tryRun(stats, {cbMan: () => options.cbWarning(`${manName}Damage resistance tagging requires manual conversion`)});
 			DamageImmunityTag.tryRun(stats, {cbMan: () => options.cbWarning(`${manName}Damage immunity tagging requires manual conversion`)});
 			DamageVulnerabilityTag.tryRun(stats, {cbMan: () => options.cbWarning(`${manName}Damage vulnerability tagging requires manual conversion`)});
 			ConditionImmunityTag.tryRun(stats, {cbMan: () => options.cbWarning(`${manName}Condition immunity tagging requires manual conversion`)});
 			ReqAttuneTagTag.tryRun(stats, {cbMan: () => options.cbWarning(`${manName}Attunement requirement tagging requires manual conversion`)});
 			TagJsons.mutTagObject(stats, {keySet: new Set(["entries"]), isOptimistic: false});
-			AttachedSpellTag.tryRun(stats);
+			AttachedSpellTag.tryRun(stats, defaultOptions("AttachedSpellTag"));
 		} catch (e) {
 			JqueryUtil.doToast({
 				content: `Error in tags for ${manName}!`,

--- a/js/converter-item.js
+++ b/js/converter-item.js
@@ -191,6 +191,8 @@ class ItemParser extends BaseParser {
 		let genericTypes = [];
 		let genericVariantBases = []; // in case it's a variant of a specific list of items
 		let genericVariantExceptions = [];
+		// let genericVariantProperties = [];
+		let genericVariantExceptProperties = [];
 
 		for (let i = 0; i < parts.length; ++i) {
 			let part = parts[i];
@@ -274,6 +276,8 @@ class ItemParser extends BaseParser {
 			// armor (plate, half plate, or splint)
 			// list separated by commas and/or "or"s
 			const variantListPattern = /(?:\s+or|\s*,|\s+and)(?: or)?\s+/i;
+			// separates part before exceptions and after exceptions inside the category, in case
+			// of generic variant with things like "armor (heavy but not plate)"
 			const mBaseItem = new RegExp(
 				`(${baseCats.join("|")}) \\((.+?)(?:,?\\s*(${exceptionSeps.join("|")})\\s(.*))?\\)`, "i"
 			).exec(part);
@@ -281,7 +285,6 @@ class ItemParser extends BaseParser {
 			if (mBaseItem) {
 				const [_, category, subcategory, exceptSep, except] = mBaseItem;
 				const categoryL = category.toLowerCase();
-				options.cbWarning(`${category} | ${subcategory} | ${exceptSep} | ${except}`);
 				
 				if (categoryL === "staff") stats.staff = true;
 				baseItem = this._getBaseItem(subcategory, category);
@@ -321,8 +324,8 @@ class ItemParser extends BaseParser {
 						}
 
 						if (!found) {
-							let item = this._getItem(itemName, category);
-							if (!item) throw new Error(`Could not find base item "${itemName}"`);
+							let item = this._getBaseItem(itemName, category);
+							if (!item) throw new Error(`Could not find generic base item "${itemName}"`);
 							genericVariantBases.push(item);
 						}
 						handled = true;
@@ -334,13 +337,31 @@ class ItemParser extends BaseParser {
 
 				// handle exceptions (but not <item>, except <item>, etc.)
 				if (exceptSep && (genericTypes.length > 0 || genericVariantBases.length > 0)) {
-					const exceptions = except.split(variantListPattern).map(s => s.trim());
-					exceptions.forEach(exceptionName => {
-						let item = ItemParser.getItem(exceptionName);
-						if (!item) item = ItemParser.getItem(`${exceptionName} armor`); // "armor (plate)" -> "plate armor"
-						if (!item) throw new Error(`Could not find exception item "${exceptionName}"`);
-						genericVariantExceptions.push(item.name); // correct capitalization
-					});
+					// item exceptions
+					if (exceptSep.toLowerCase() !== "without") {
+						const exceptions = except.split(variantListPattern).map(s => s.trim());
+						exceptions.forEach(exceptionName => {
+							let item = ItemParser.getItem(exceptionName);
+							if (!item) item = ItemParser.getItem(`${exceptionName} armor`); // "armor (plate)" -> "plate armor"
+							if (!item) throw new Error(`Could not find exception item "${exceptionName}"`);
+							genericVariantExceptions.push(item.name); // correct capitalization
+						});
+					}
+					// property exceptions
+					// example: any melee weapon without the light or two-handed property
+					else {
+						const propertiesMatch = /^(?:the\s*)?(.*?)\s+property/i.exec(except);
+						if (!propertiesMatch) throw new Error(`Unknown exceptions string "without ${except}"`);
+
+						const exceptProperties = propertiesMatch[1].split(variantListPattern).map(s => s.trim());
+						exceptProperties.forEach(property => {
+							let tag = ItemParser._PROPERTY_TO_TAG[property];
+							if (!tag) throw new Error(`Unknown exception property "${property}"`);
+							if (!genericVariantExceptProperties.includes(tag)) {
+								genericVariantExceptProperties.push(tag);
+							}
+						});
+					}
 				}
 				continue;
 			}
@@ -355,6 +376,8 @@ class ItemParser extends BaseParser {
 		if (genericTypes.length != 0) stats.__genericTypes = genericTypes;
 		if (genericVariantBases.length != 0) stats.__genericVariantBases = genericVariantBases;
 		if (genericVariantExceptions.length != 0) stats.__genericVariantExceptions = genericVariantExceptions;
+		// if (genericVariantProperties.length != 0) stats.__genericVariantProperties = genericVariantProperties;
+		if (genericVariantExceptProperties.length != 0) stats.__genericVariantExceptProperties = genericVariantExceptProperties;
 	}
 
 	static _setCleanTaglineInfo_getArmorBaseItem (name) {
@@ -425,14 +448,18 @@ class ItemParser extends BaseParser {
 	}
 
 	static _setCleanTaglineInfo_handleGenericType (stats, options) {
-		if (!(stats.__genericTypes || stats.__genericVariantBases)) return;
+		if (!(stats.__genericTypes || stats.__genericVariantBases || stats.__genericVariantProperties)) return;
 
 		const genericTypes = stats.__genericTypes;
 		const genericVariantBases = stats.__genericVariantBases;
 		const genericVariantExceptions = stats.__genericVariantExceptions;
+		// const genericVariantProperties = stats.__genericVariantProperties;
+		const genericVariantExceptProperties = stats.__genericVariantExceptProperties;
 		delete stats.__genericTypes;
 		delete stats.__genericVariantBases;
 		delete stats.__genericVariantExceptions;
+		// delete stats.__genericVariantProperties;
+		delete stats.__genericVariantExceptProperties;
 
 		let prefixSuffixName = stats.name;
 		prefixSuffixName = prefixSuffixName.replace(/^weapon /i, "");
@@ -446,10 +473,13 @@ class ItemParser extends BaseParser {
 		if (isSuffix) stats.inherits.nameSuffix = ` ${prefixSuffixName.trim()}`;
 		else stats.inherits.namePrefix = `${prefixSuffixName.trim()} `;
 
+		// check _createSpecificVariants_hasRequiredProperty in render.js
+		// for how requires is used
+
 		stats.__prop = "variant";
 		stats.type = "GV";
+		stats.requires = [];
 		if (genericTypes) {
-			stats.requires = [];
 			genericTypes.forEach(genericType => {
 				switch (genericType) {
 					case "weapon": stats.requires.push({"weapon": true}); break;
@@ -466,8 +496,8 @@ class ItemParser extends BaseParser {
 					default: throw new Error(`Unhandled generic type "${genericType}"`);
 				}
 			});
-		} else if (genericVariantBases) {
-			stats.requires = [];
+		}
+		if (genericVariantBases) {
 			genericVariantBases.forEach(item => {
 				stats.requires.push({
 					"name": item.name
@@ -475,10 +505,14 @@ class ItemParser extends BaseParser {
 			});
 		}
 
+		if (genericVariantExceptions || genericVariantExceptProperties) {
+			stats.excludes = {};
+		}
 		if (genericVariantExceptions) {
-			stats.excludes = {
-				"name": genericVariantExceptions
-			};
+			stats.excludes["name"] = genericVariantExceptions;
+		}
+		if (genericVariantExceptProperties) {
+			stats.excludes["property"] = genericVariantExceptProperties;
 		}
 	}
 
@@ -523,6 +557,23 @@ ItemParser._MAPPED_ITEM_NAMES = {
 	"leather": "leather armor",
 	"scale": "scale mail",
 	"bolt": "crossbow bolt",
+};
+ItemParser._PROPERTY_TO_TAG = {
+	"thrown": "T",
+	"versatile": "V",
+	"heavy": "H",
+	"two-handed": "2H",
+	"two handed": "2H",
+	"twohanded": "2H",
+	"finesse": "F",
+	"light": "L",
+	"reach": "R",
+	"ammunition": "A",
+	"loading": "LD",
+	"special": "S",
+	"ammunition (futuristic)": "AF",
+	"reload": "RLD",
+	"burst fire": "BF",
 };
 
 if (typeof module !== "undefined") {

--- a/js/converter-item.js
+++ b/js/converter-item.js
@@ -24,6 +24,14 @@ class ItemParser extends BaseParser {
 		return null;
 	}
 
+	static _getBaseItem (itemName, category) {
+		let baseItem = ItemParser.getItem(itemName);
+		if (!baseItem && category.toLowerCase() === "armor") {
+			baseItem = ItemParser.getItem(`${itemName} armor`); // "armor (plate)" -> "plate armor"
+		}
+		return baseItem;
+	}
+
 	/**
 	 * Parses items from raw text pastes
 	 * @param inText Input text.
@@ -180,7 +188,7 @@ class ItemParser extends BaseParser {
 		};
 
 		let baseItem = null;
-		let genericType = null;
+		let genericTypes = [];
 		let genericVariantBases = []; // in case it's a variant of a specific list of items
 		let genericVariantExceptions = [];
 
@@ -246,10 +254,10 @@ class ItemParser extends BaseParser {
 
 			// region weapon/armor
 			if (partLower === "weapon" || partLower === "weapon (any)") {
-				genericType = "weapon";
+				genericTypes.push("weapon");
 				continue;
 			} else if (partLower === "armor" || partLower === "armor (any)") {
-				genericType = "armor";
+				genericTypes.push("armor");
 				continue;
 			} else {
 				const mWeaponAnyX = /^weapon \(any ([^)]+)\)$/i.exec(part);
@@ -259,18 +267,74 @@ class ItemParser extends BaseParser {
 				}
 			}
 
-			const mBaseWeapon = /^(weapon|staff) \(([^)]+)\)$/i.exec(part);
-			const mBaseArmor = /^armor \(([^)]+)\)$/i.exec(part);
+			const baseCats = ["weapon", "staff", "armor"];
+			const exceptionSeps = ["except", "but\\s*(?:not)?", "without"];
 
-			// list separated by commas and/or "or"s
 			// example: weapon (dagger, shortsword), weapon (maul or warhammer), 
 			// armor (plate, half plate, or splint)
-			const variantListPattern = /(?:\s+or|\s*,(?! but)|\s+and)(?: or)?\s+/i;
+			// list separated by commas and/or "or"s
+			const variantListPattern = /(?:\s+or|\s*,|\s+and)(?: or)?\s+/i;
+			const mBaseItem = new RegExp(
+				`(${baseCats.join("|")}) \\((.+?)(?:,?\\s*(${exceptionSeps.join("|")})\\s(.*))?\\)`, "i"
+			).exec(part);
 
-			const checkExceptions = subcategory => {
-				const exceptionsSplit = subcategory.split(/,?\s*(?:except|but(?:\s*not)?)\s*/);
-				if (exceptionsSplit.length > 1) {
-					const exceptions = exceptionsSplit[1].split(variantListPattern).map(s => s.trim());
+			if (mBaseItem) {
+				const [_, category, subcategory, exceptSep, except] = mBaseItem;
+				const categoryL = category.toLowerCase();
+				options.cbWarning(`${category} | ${subcategory} | ${exceptSep} | ${except}`);
+				
+				if (categoryL === "staff") stats.staff = true;
+				baseItem = this._getBaseItem(subcategory, category);
+
+				if (!baseItem) {
+					// check if the items are a list
+					let handled = false;
+					let baseItems = subcategory
+						.replace(/(a|an|any)\s+/, "")
+						.split(variantListPattern)
+						;
+					
+					baseItems.forEach((itemName) => {
+						let found = false;
+						if (categoryL === "weapon" || categoryL === "staff") {
+							found = true;
+							switch (itemName) {
+								case "melee": case "melee weapon":
+									genericTypes.push("melee"); break;
+								case "ranged": case "ranged weapon":
+									genericTypes.push("ranged"); break;
+								case "sword": genericTypes.push("sword"); break;
+								case "axe": genericTypes.push("axe"); break;
+								case "bow": genericTypes.push("bow"); break;
+								case "crossbow": genericTypes.push("crossbow"); break;
+								default: found = false;
+							}
+						} else if (categoryL === "armor") {
+							found = true;
+							if (/^heavy/i.test(itemName)) {
+								genericTypes.push("heavy armor");
+							} else if (/^medium/i.test(itemName)) {
+								genericTypes.push("medium armor");
+							} else if (/^light/i.test(itemName)) {
+								genericTypes.push("light armor");
+							}		
+						}
+
+						if (!found) {
+							let item = this._getItem(itemName, category);
+							if (!item) throw new Error(`Could not find base item "${itemName}"`);
+							genericVariantBases.push(item);
+						}
+						handled = true;
+					});
+					if (!handled) {
+						if (!baseItem) throw new Error(`Could not find base item "${subcategory}"`);
+					}
+				}
+
+				// handle exceptions (but not <item>, except <item>, etc.)
+				if (exceptSep && (genericTypes.length > 0 || genericVariantBases.length > 0)) {
+					const exceptions = except.split(variantListPattern).map(s => s.trim());
 					exceptions.forEach(exceptionName => {
 						let item = ItemParser.getItem(exceptionName);
 						if (!item) item = ItemParser.getItem(`${exceptionName} armor`); // "armor (plate)" -> "plate armor"
@@ -278,94 +342,6 @@ class ItemParser extends BaseParser {
 						genericVariantExceptions.push(item.name); // correct capitalization
 					});
 				}
-			};
-
-			if (mBaseWeapon) {
-				if (mBaseWeapon[1].toLowerCase() === "staff") stats.staff = true;
-				baseItem = ItemParser.getItem(mBaseWeapon[2]);
-				if (!baseItem) {
-					// check if the items are a list
-					let handled = false;
-					let baseItems = mBaseWeapon[2]
-						.replace(/(a|an|any)\s+/, "")
-						.split(variantListPattern)
-						;
-					baseItems.forEach((itemName) => {
-						let found = true;
-						switch (itemName) {
-							case "melee": case "melee weapon":
-								genericType = "melee"; break;
-							case "ranged": case "ranged weapon":
-								genericType = "ranged"; break;
-							case "sword": genericType = "sword"; break;
-							case "axe": genericType = "axe"; break;
-							case "bow": genericType = "bow"; break;
-							case "crossbow":
-								if (genericType === "bow") {
-									genericType = "bow or crossbow";
-								} else {
-									genericType = "crossbow"
-								}
-								break;
-							default: found = false;
-						}
-
-						if (!found) {
-							let item = ItemParser.getItem(itemName);
-							if (!item) throw new Error(`Could not find base item "${itemName}"`);
-							genericVariantBases.push(item);
-						}
-						handled = true;
-					});
-					if (!handled) {
-						if (!baseItem) throw new Error(`Could not find base item "${mBaseWeapon[2]}"`);
-					}
-				}
-				if (genericType || genericVariantBases.length > 0) 
-					checkExceptions(mBaseWeapon[2]);
-				continue;
-			} else if (mBaseArmor) {
-				baseItem = ItemParser.getItem(mBaseArmor[1]);
-				if (!baseItem) baseItem = ItemParser.getItem(`${mBaseArmor[1]} armor`); // "armor (plate)" -> "plate armor"
-
-				if (!baseItem) {
-					let trimmed = mBaseArmor[1]
-						.replace(/(a|an|any)\s+/, "")
-						.trim()
-						;
-
-					let handled = false;
-					// check armor types
-					if (/^heavy/.test(trimmed)) {
-						genericType = "heavy armor";
-						handled = true;
-					} else if (/^medium/.test(trimmed)) {
-						genericType = "medium armor";
-						handled = true;
-					} else if (/^light/.test(trimmed)) {
-						genericType = "light armor";
-						handled = true;
-					}
-
-					if (!handled) {
-						let baseItems = trimmed
-							.split(variantListPattern)
-							;
-						baseItems.forEach((itemName) => {
-							let item = ItemParser.getItem(itemName);
-							if (!item) item = ItemParser.getItem(`${itemName} armor`); // "armor (plate)" -> "plate armor"
-							if (!item) throw new Error(`Could not find base item "${itemName}"`);
-							genericVariantBases.push(item);
-							handled = true;
-						});
-					}
-					if (!handled) {
-						if (!baseItem) throw new Error(`Could not find base item "${mBaseArmor[1]}"`);
-					}
-				}
-				if (genericType || genericVariantBases.length > 0) 
-					checkExceptions(mBaseArmor[1]);
-
 				continue;
 			}
 			// endregion
@@ -376,7 +352,7 @@ class ItemParser extends BaseParser {
 
 		this._setCleanTaglineInfo_handleBaseItem(stats, baseItem, options);
 		// Stash the genericType for later processing/removal
-		if (genericType) stats.__genericType = genericType;
+		if (genericTypes.length != 0) stats.__genericTypes = genericTypes;
 		if (genericVariantBases.length != 0) stats.__genericVariantBases = genericVariantBases;
 		if (genericVariantExceptions.length != 0) stats.__genericVariantExceptions = genericVariantExceptions;
 	}
@@ -449,12 +425,12 @@ class ItemParser extends BaseParser {
 	}
 
 	static _setCleanTaglineInfo_handleGenericType (stats, options) {
-		if (!(stats.__genericType || stats.__genericVariantBases)) return;
+		if (!(stats.__genericTypes || stats.__genericVariantBases)) return;
 
-		const genericType = stats.__genericType;
+		const genericTypes = stats.__genericTypes;
 		const genericVariantBases = stats.__genericVariantBases;
 		const genericVariantExceptions = stats.__genericVariantExceptions;
-		delete stats.__genericType;
+		delete stats.__genericTypes;
 		delete stats.__genericVariantBases;
 		delete stats.__genericVariantExceptions;
 
@@ -472,22 +448,24 @@ class ItemParser extends BaseParser {
 
 		stats.__prop = "variant";
 		stats.type = "GV";
-		if (genericType) {
-			switch (genericType) {
-				case "weapon": stats.requires = [{"weapon": true}]; break;
-				case "melee": throw new Error("Unimplemented!");
-				case "ranged": throw new Error("Unimplemented!");
-				case "sword": stats.requires = [{"sword": true}]; break;
-				case "axe": stats.requires = [{"axe": true}]; break;
-				case "bow": stats.requires = [{"bow": true}]; break;
-				case "crossbow": stats.requires = [{"crossbow": true}]; break;
-				case "bow or crossbow": stats.requires = [{"bow": true}, {"crossbow": true}]; break;
-				case "armor": stats.requires = [{"armor": true}]; break;
-				case "heavy armor": stats.requires = [{"type": "HA"}]; break;
-				case "medium armor": stats.requires = [{"type": "MA"}]; break;
-				case "light armor": stats.requires = [{"type": "LA"}]; break;
-				default: throw new Error(`Unhandled generic type "${genericType}"`);
-			}
+		if (genericTypes) {
+			stats.requires = [];
+			genericTypes.forEach(genericType => {
+				switch (genericType) {
+					case "weapon": stats.requires.push({"weapon": true}); break;
+					case "melee": stats.requires.push({"type": "M"}); break;
+					case "ranged": rstats.equires.push({"type": "R"}); break;
+					case "sword": stats.requires.push({"sword": true}); break;
+					case "axe": stats.requires.push({"axe": true}); break;
+					case "bow": stats.requires.push({"bow": true}); break;
+					case "crossbow": stats.requires.push({"crossbow": true}); break;
+					case "armor": stats.requires.push({"armor": true}); break;
+					case "heavy armor": stats.requires.push({"type": "HA"}); break;
+					case "medium armor": stats.requires.push({"type": "MA"}); break;
+					case "light armor": stats.requires.push({"type": "LA"}); break;
+					default: throw new Error(`Unhandled generic type "${genericType}"`);
+				}
+			});
 		} else if (genericVariantBases) {
 			stats.requires = [];
 			genericVariantBases.forEach(item => {

--- a/js/converter-item.js
+++ b/js/converter-item.js
@@ -191,7 +191,6 @@ class ItemParser extends BaseParser {
 		let genericTypes = [];
 		let genericVariantBases = []; // in case it's a variant of a specific list of items
 		let genericVariantExceptions = [];
-		// let genericVariantProperties = [];
 		let genericVariantExceptProperties = [];
 
 		for (let i = 0; i < parts.length; ++i) {
@@ -298,6 +297,19 @@ class ItemParser extends BaseParser {
 						;
 					
 					baseItems.forEach((itemName) => {
+						const propertyMatch = /(.+?)\s*with(?:\s+the)?\s*(.*?)\s+property/i.exec(itemName);
+						let properties = null;
+						if (propertyMatch) {
+							itemName = propertyMatch[1]; // remove the properties from the item name
+							properties = [];
+							// for each property
+							propertyMatch[2].split(variantListPattern).map(s => s.trim()).forEach(property => {
+								const tag = ItemParser._PROPERTY_TO_TAG[property];
+								if (!tag) throw new Error(`Unknown property "${property}"`);
+								properties.push(tag);
+							});
+						}
+
 						let found = false;
 						if (categoryL === "weapon" || categoryL === "staff") {
 							found = true;
@@ -323,11 +335,31 @@ class ItemParser extends BaseParser {
 							}		
 						}
 
+						// if added generic type, set properties
+						// currently every listed generic type has its own properties
+						// (like 'sword or bow with the light property' will only add the
+						// requirement to bows), might change it if it makes more sense
+						// for them to apply globally
+						if (found && properties) {
+							const addedGenericType = genericTypes.pop(genericTypes);
+							genericTypes.push({
+								"type": addedGenericType,
+								"properties": properties,
+							})
+						} 
+
+						// otherwise, check for specific base generic items
 						if (!found) {
 							let item = this._getBaseItem(itemName, category);
-							if (!item) throw new Error(`Could not find generic base item "${itemName}"`);
-							genericVariantBases.push(item);
+							if (item) {
+								if (properties) throw new Error(`Properties not supported for specific base items (item: ${itemName})`)
+
+								found = true;
+								genericVariantBases.push(item);
+							} 
 						}
+						if (!found)
+							throw new Error(`Could not find generic base item "${itemName}"`);
 						handled = true;
 					});
 					if (!handled) {
@@ -376,7 +408,6 @@ class ItemParser extends BaseParser {
 		if (genericTypes.length != 0) stats.__genericTypes = genericTypes;
 		if (genericVariantBases.length != 0) stats.__genericVariantBases = genericVariantBases;
 		if (genericVariantExceptions.length != 0) stats.__genericVariantExceptions = genericVariantExceptions;
-		// if (genericVariantProperties.length != 0) stats.__genericVariantProperties = genericVariantProperties;
 		if (genericVariantExceptProperties.length != 0) stats.__genericVariantExceptProperties = genericVariantExceptProperties;
 	}
 
@@ -448,17 +479,15 @@ class ItemParser extends BaseParser {
 	}
 
 	static _setCleanTaglineInfo_handleGenericType (stats, options) {
-		if (!(stats.__genericTypes || stats.__genericVariantBases || stats.__genericVariantProperties)) return;
+		if (!(stats.__genericTypes || stats.__genericVariantBases)) return;
 
 		const genericTypes = stats.__genericTypes;
 		const genericVariantBases = stats.__genericVariantBases;
 		const genericVariantExceptions = stats.__genericVariantExceptions;
-		// const genericVariantProperties = stats.__genericVariantProperties;
 		const genericVariantExceptProperties = stats.__genericVariantExceptProperties;
 		delete stats.__genericTypes;
 		delete stats.__genericVariantBases;
 		delete stats.__genericVariantExceptions;
-		// delete stats.__genericVariantProperties;
 		delete stats.__genericVariantExceptProperties;
 
 		let prefixSuffixName = stats.name;
@@ -481,6 +510,12 @@ class ItemParser extends BaseParser {
 		stats.requires = [];
 		if (genericTypes) {
 			genericTypes.forEach(genericType => {
+				let properties = null;
+				if (genericType.properties) {
+					properties = genericType.properties;
+					genericType = genericType.type;
+				}
+
 				switch (genericType) {
 					case "weapon": stats.requires.push({"weapon": true}); break;
 					case "melee": stats.requires.push({"type": "M"}); break;
@@ -495,6 +530,12 @@ class ItemParser extends BaseParser {
 					case "light armor": stats.requires.push({"type": "LA"}); break;
 					default: throw new Error(`Unhandled generic type "${genericType}"`);
 				}
+
+				if (properties) {
+					stats.requires[stats.requires.length-1].property = {
+						"includes": properties,
+					}
+				}
 			});
 		}
 		if (genericVariantBases) {
@@ -504,7 +545,6 @@ class ItemParser extends BaseParser {
 				});
 			});
 		}
-
 		if (genericVariantExceptions || genericVariantExceptProperties) {
 			stats.excludes = {};
 		}

--- a/js/converter-item.js
+++ b/js/converter-item.js
@@ -174,7 +174,10 @@ class ItemParser extends BaseParser {
 				case "artifact": stats.rarity = rarity; return true;
 				case "rarity varies": {
 					stats.rarity = "varies";
-					stats.__prop = "itemGroup";
+					// Do not set itemGroup for now, as it would need a way
+					// to set "items" to properly work and not make the item list
+					// error out
+					// stats.__prop = "itemGroup";
 					return true;
 				}
 				case "unknown rarity": {

--- a/js/converter-item.js
+++ b/js/converter-item.js
@@ -202,6 +202,7 @@ class ItemParser extends BaseParser {
 		let genericTypes = [];
 		let genericVariantBases = []; // in case it's a variant of a specific list of items
 		let genericVariantExceptions = [];
+		let genericVariantRequiresProperties = [];
 		let genericVariantExceptProperties = [];
 
 		for (let i = 0; i < parts.length; ++i) {
@@ -295,32 +296,32 @@ class ItemParser extends BaseParser {
 			if (mBaseItem) {
 				const [_, category, subcategory, exceptSep, except] = mBaseItem;
 				const categoryL = category.toLowerCase();
-				
+
 				if (categoryL === "staff") stats.staff = true;
 				baseItem = this._getBaseItem(subcategory, category);
 
 				if (!baseItem) {
+					let mainSubcategoryPart = subcategory;
+					// check for property specifications
+					const propertyMatch = /(.+?)\s*with(?:\s+the)?\s*(.*?)\s+property/i.exec(mainSubcategoryPart);
+					if (propertyMatch) {
+						mainSubcategoryPart = propertyMatch[1]; // remove the properties from the item name
+						// for each property
+						propertyMatch[2].split(variantListPattern).map(s => s.trim()).forEach(property => {
+							const tag = ItemParser._PROPERTY_TO_TAG[property];
+							if (!tag) throw new Error(`Unknown property "${property}"`);
+							genericVariantRequiresProperties.push(tag);
+						});
+					}
+
 					// check if the items are a list
 					let handled = false;
-					let baseItems = subcategory
+					let baseItems = mainSubcategoryPart
 						.replace(/(a|an|any)\s+/, "")
 						.split(variantListPattern)
 						;
 					
 					baseItems.forEach((itemName) => {
-						const propertyMatch = /(.+?)\s*with(?:\s+the)?\s*(.*?)\s+property/i.exec(itemName);
-						let properties = null;
-						if (propertyMatch) {
-							itemName = propertyMatch[1]; // remove the properties from the item name
-							properties = [];
-							// for each property
-							propertyMatch[2].split(variantListPattern).map(s => s.trim()).forEach(property => {
-								const tag = ItemParser._PROPERTY_TO_TAG[property];
-								if (!tag) throw new Error(`Unknown property "${property}"`);
-								properties.push(tag);
-							});
-						}
-
 						let found = false;
 						if (categoryL === "weapon" || categoryL === "staff") {
 							found = true;
@@ -355,20 +356,7 @@ class ItemParser extends BaseParser {
 							}		
 						}
 
-						// if added generic type, set properties
-						// currently every listed generic type has its own properties
-						// (like 'sword or bow with the light property' will only add the
-						// requirement to bows), might change it if it makes more sense
-						// for them to apply globally
-						if (found && properties) {
-							const addedGenericType = genericTypes.pop(genericTypes);
-							genericTypes.push({
-								"type": addedGenericType,
-								"properties": properties,
-							})
-						} 
-
-						// otherwise, check for specific base generic items
+						// check for specific base generic items
 						if (!found) {
 							let item = this._getBaseItem(itemName, category);
 							if (item) {
@@ -428,6 +416,7 @@ class ItemParser extends BaseParser {
 		if (genericTypes.length != 0) stats.__genericTypes = genericTypes;
 		if (genericVariantBases.length != 0) stats.__genericVariantBases = genericVariantBases;
 		if (genericVariantExceptions.length != 0) stats.__genericVariantExceptions = genericVariantExceptions;
+		if (genericVariantRequiresProperties.length != 0) stats.__genericVariantRequiresProperties = genericVariantRequiresProperties;
 		if (genericVariantExceptProperties.length != 0) stats.__genericVariantExceptProperties = genericVariantExceptProperties;
 	}
 
@@ -504,10 +493,12 @@ class ItemParser extends BaseParser {
 		const genericTypes = stats.__genericTypes;
 		const genericVariantBases = stats.__genericVariantBases;
 		const genericVariantExceptions = stats.__genericVariantExceptions;
+		const genericVariantRequiresProperties = stats.__genericVariantRequiresProperties;
 		const genericVariantExceptProperties = stats.__genericVariantExceptProperties;
 		delete stats.__genericTypes;
 		delete stats.__genericVariantBases;
 		delete stats.__genericVariantExceptions;
+		delete stats.__genericVariantRequiresProperties;
 		delete stats.__genericVariantExceptProperties;
 
 		let prefixSuffixName = stats.name;
@@ -530,12 +521,6 @@ class ItemParser extends BaseParser {
 		stats.requires = [];
 		if (genericTypes) {
 			genericTypes.forEach(genericType => {
-				let properties = null;
-				if (genericType.properties) {
-					properties = genericType.properties;
-					genericType = genericType.type;
-				}
-
 				switch (genericType) {
 					case "weapon": stats.requires.push({"weapon": true}); break;
 					case "melee": stats.requires.push({"type": "M"}); break;
@@ -553,12 +538,6 @@ class ItemParser extends BaseParser {
 					case "light armor": stats.requires.push({"type": "LA"}); break;
 					default: throw new Error(`Unhandled generic type "${genericType}"`);
 				}
-
-				if (properties) {
-					stats.requires[stats.requires.length-1].property = {
-						"includes": properties,
-					}
-				}
 			});
 		}
 		if (genericVariantBases) {
@@ -567,6 +546,17 @@ class ItemParser extends BaseParser {
 					"name": item.name
 				});
 			});
+		}
+		if (genericVariantRequiresProperties) {
+			if (stats.requires.length > 0) {
+				stats.requires.forEach(requireObj => {
+					requireObj["property"] = {"includes": genericVariantRequiresProperties};
+				});
+			} else {
+				stats.requires.push({
+					"property": {"includes": genericVariantRequiresProperties}
+				});
+			}
 		}
 		if (genericVariantExceptions || genericVariantExceptProperties) {
 			stats.excludes = {};

--- a/js/converter.js
+++ b/js/converter.js
@@ -521,7 +521,7 @@ Other options are "without the x [or y] property", "Armor (heavy but not x <plat
 | d4 | Spawned demon | Is cool? |
 | --- | ------- | --: |
 | 1 | barlgura | 1 |
-| 2 | shadow demon | 2 |
+| 2 | 1d4 shadow demon | 2 |
 | 3-4 | chasme | 3 |`;
 // endregion
 

--- a/js/converter.js
+++ b/js/converter.js
@@ -256,7 +256,7 @@ class CreatureConverter extends BaseConverter {
 	handleParse (input, cbOutput, cbWarning, isAppend) {
 		const opts = {
 			cbWarning,
-			cbOutput,
+			cbOutput: (obj, append, prop) => cbOutput(obj, append, prop || this.prop),
 			isAppend,
 			titleCaseFields: this._titleCaseFields,
 			isTitleCase: this._state.isTitleCase,
@@ -396,7 +396,7 @@ class SpellConverter extends BaseConverter {
 	handleParse (input, cbOutput, cbWarning, isAppend) {
 		const opts = {
 			cbWarning,
-			cbOutput,
+			cbOutput: (obj, append, prop) => cbOutput(obj, append, prop || this.prop),
 			isAppend,
 			titleCaseFields: this._titleCaseFields,
 			isTitleCase: this._state.isTitleCase,
@@ -451,7 +451,7 @@ class ItemConverter extends BaseConverter {
 	handleParse (input, cbOutput, cbWarning, isAppend) {
 		const opts = {
 			cbWarning,
-			cbOutput,
+			cbOutput: (obj, append, prop) => cbOutput(obj, append, prop || this.prop),
 			isAppend,
 			titleCaseFields: this._titleCaseFields,
 			isTitleCase: this._state.isTitleCase,
@@ -512,7 +512,7 @@ class FeatConverter extends BaseConverter {
 	handleParse (input, cbOutput, cbWarning, isAppend) {
 		const opts = {
 			cbWarning,
-			cbOutput,
+			cbOutput: (obj, append, prop) => cbOutput(obj, append, prop || this.prop),
 			isAppend,
 			titleCaseFields: this._titleCaseFields,
 			isTitleCase: this._state.isTitleCase,
@@ -630,7 +630,7 @@ class TableConverter extends BaseConverter {
 	handleParse (input, cbOutput, cbWarning, isAppend) {
 		const opts = {
 			cbWarning,
-			cbOutput,
+			cbOutput: (obj, append, prop) => cbOutput(obj, append, prop || this.prop),
 			isAppend,
 			titleCaseFields: this._titleCaseFields,
 			isTitleCase: this._state.isTitleCase,
@@ -766,74 +766,78 @@ class ConverterUi extends BaseComponent {
 			JqueryUtil.doToast({type: "warning", content: "Enabled editing. Note that edits will be overwritten as you parse new statblocks."});
 		});
 
+		const getSource = it => (it.source || (it.inherits ? it.inherits.source : null));
+
 		const $btnSaveLocal = $(`#save_local`).click(async () => {
 			const output = this._outText;
 			if (output && output.trim()) {
 				try {
-					const prop = this.activeConverter.prop;
-					const entries = JSON.parse(`[${output}]`);
+					const props = JSON.parse(output);
+					for (const prop in props) {
+						const entries = props[prop];
 
-					const invalidSources = entries.map(it => !it.source || !BrewUtil.hasSourceJson(it.source) ? (it.name || it.caption || "(Unnamed)").trim() : false).filter(Boolean);
-					if (invalidSources.length) {
-						JqueryUtil.doToast({
-							content: `One or more entries have missing or unknown sources: ${invalidSources.join(", ")}`,
-							type: "danger",
-						});
-						return;
-					}
-
-					// ignore duplicates
-					const _dupes = {};
-					const dupes = [];
-					const dedupedEntries = entries.map(it => {
-						const lSource = it.source.toLowerCase();
-						const lName = it.name.toLowerCase();
-						_dupes[lSource] = _dupes[lSource] || {};
-						if (_dupes[lSource][lName]) {
-							dupes.push(it.name);
-							return null;
-						} else {
-							_dupes[lSource][lName] = true;
-							return it;
+						const invalidSources = entries.map(it => !getSource(it) || !BrewUtil.hasSourceJson(getSource(it)) ? (it.name || it.caption || "(Unnamed)").trim() : false).filter(Boolean);
+						if (invalidSources.length) {
+							JqueryUtil.doToast({
+								content: `One or more entries have missing or unknown sources: ${invalidSources.join(", ")}`,
+								type: "danger",
+							});
+							return;
 						}
-					}).filter(Boolean);
-					if (dupes.length) {
-						JqueryUtil.doToast({
-							type: "warning",
-							content: `Ignored ${dupes.length} duplicate entr${dupes.length === 1 ? "y" : "ies"}`,
-						});
-					}
-
-					// handle overwrites
-					const overwriteMeta = dedupedEntries.map(it => {
-						const ix = (BrewUtil.homebrew[prop] || []).findIndex(bru => bru.name.toLowerCase() === it.name.toLowerCase() && bru.source.toLowerCase() === it.source.toLowerCase());
-						if (~ix) {
-							return {
-								isOverwrite: true,
-								ix,
-								entry: it,
-							};
-						} else return {entry: it, isOverwrite: false};
-					}).filter(Boolean);
-					const willOverwrite = overwriteMeta.map(it => it.isOverwrite).filter(Boolean);
-					if (willOverwrite.length && !confirm(`This will overwrite ${willOverwrite.length} entr${willOverwrite.length === 1 ? "y" : "ies"}. Are you sure?`)) {
-						return;
-					}
-
-					await Promise.all(overwriteMeta.map(meta => {
-						if (meta.isOverwrite) {
-							return BrewUtil.pUpdateEntryByIx(prop, meta.ix, MiscUtil.copy(meta.entry));
-						} else {
-							return BrewUtil.pAddEntry(prop, MiscUtil.copy(meta.entry));
+	
+						// ignore duplicates
+						const _dupes = {};
+						const dupes = [];
+						const dedupedEntries = entries.map(it => {
+							const lSource = getSource(it).toLowerCase();
+							const lName = it.name.toLowerCase();
+							_dupes[lSource] = _dupes[lSource] || {};
+							if (_dupes[lSource][lName]) {
+								dupes.push(it.name);
+								return null;
+							} else {
+								_dupes[lSource][lName] = true;
+								return it;
+							}
+						}).filter(Boolean);
+						if (dupes.length) {
+							JqueryUtil.doToast({
+								type: "warning",
+								content: `Ignored ${dupes.length} duplicate entr${dupes.length === 1 ? "y" : "ies"}`,
+							})
 						}
-					}));
-
-					JqueryUtil.doToast({
-						type: "success",
-						content: `Saved!`,
-					});
-
-					Omnisearch.pAddToIndex("monster", overwriteMeta.filter(meta => !meta.isOverwrite).map(meta => meta.entry));
+	
+						// handle overwrites
+						const overwriteMeta = dedupedEntries.map(it => {
+							const ix = (BrewUtil.homebrew[prop] || []).findIndex(bru => bru.name.toLowerCase() === it.name.toLowerCase() && getSource(bru).toLowerCase() === getSource(it).toLowerCase());
+							if (~ix) {
+								return {
+									isOverwrite: true,
+									ix,
+									entry: it,
+								}
+							} else return {entry: it, isOverwrite: false};
+						}).filter(Boolean);
+						const willOverwrite = overwriteMeta.map(it => it.isOverwrite).filter(Boolean);
+						if (willOverwrite.length && !confirm(`This will overwrite ${willOverwrite.length} entr${willOverwrite.length === 1 ? "y" : "ies"}. Are you sure?`)) {
+							return;
+						}
+	
+						await Promise.all(overwriteMeta.map(meta => {
+							if (meta.isOverwrite) {
+								return BrewUtil.pUpdateEntryByIx(prop, meta.ix, MiscUtil.copy(meta.entry));
+							} else {
+								return BrewUtil.pAddEntry(prop, MiscUtil.copy(meta.entry));
+							}
+						}));
+	
+						JqueryUtil.doToast({
+							type: "success",
+							content: `Saved!`,
+						});
+	
+						Omnisearch.pAddToIndex("monster", overwriteMeta.filter(meta => !meta.isOverwrite).map(meta => meta.entry));	
+					}
 				} catch (e) {
 					JqueryUtil.doToast({
 						content: `Current output was not valid JSON!`,
@@ -975,15 +979,38 @@ class ConverterUi extends BaseComponent {
 		this._editorOut.resize();
 	}
 
-	doCleanAndOutput (obj, append) {
+	doCleanAndOutput (obj, append, prop) {
+		prop = prop || "SET_PROP";
 		const asCleanString = CleanUtil.getCleanJson(obj, {isFast: false});
 		if (append) {
-			this._outText = `${asCleanString},\n${this._outText}`;
+			if (!this._outProps[prop]) {
+				this._outProps[prop] = []
+			}
+			this._outProps[prop].push(asCleanString)
 			this._state.hasAppended = true;
 		} else {
-			this._outText = asCleanString;
+			// to track the current rendered props and 
+			// add new items to teir lists more easily
+			this._outProps = {
+				[prop]: [asCleanString]
+			};
+
 			this._state.hasAppended = false;
 		}
+		const propToString = prop => `"${prop}": [\n\t`
+			+ this._outProps[prop]
+				.join(",\n")
+				.replace(/\n/g, "\n\t")
+			+ "\n]";
+
+		let outStrings = []
+		for (const prop in this._outProps) {
+			outStrings.push(propToString(prop))
+		}
+		this._outText = `{\n\t${
+			outStrings.join(",\n")
+					  .replace(/\n/g, "\n\t")
+		}\n}`;
 	}
 
 	set _outReadOnly (val) { this._editorOut.setOptions({readOnly: val}); }

--- a/js/converter.js
+++ b/js/converter.js
@@ -607,7 +607,7 @@ class RaceConverter extends BaseConverter {
 	handleParse (input, cbOutput, cbWarning, isAppend) {
 		const opts = {
 			cbWarning,
-			cbOutput,
+			cbOutput: (obj, append, prop) => cbOutput(obj, append, prop || this.prop),
 			isAppend,
 			titleCaseFields: this._titleCaseFields,
 			isTitleCase: this._state.isTitleCase,

--- a/js/converter.js
+++ b/js/converter.js
@@ -511,7 +511,18 @@ Once the Wreath of the Prism reaches an awakened state, it gains the following b
 Exalted
 Once the Wreath of the Prism reaches an exalted state, it gains the following benefits:
 • You can affect creatures of challenge rating 15 or lower with the wreath.
-• The save DC of the wreath’s spell increases to 17.`;
+• The save DC of the wreath’s spell increases to 17.
+===
+Weapon of Conjuring
+Weapon (any sword or piercing weapon with the light property), Very Rare (requires attunement)
+This weapon conjures a random demon on a critical hit. 
+It is also made up for the purpose of a variant example as there was no magic item I could find with both specific variant requirements (like this with the light property) and a table.
+Other options are "without the x [or y] property", "Armor (heavy but not x <plate, etc.>)", "Weapon (longsword or shortsword)", etc.
+| d4 | Spawned demon | Is cool? |
+| --- | ------- | --: |
+| 1 | barlgura | 1 |
+| 2 | shadow demon | 2 |
+| 3-4 | chasme | 3 |`;
 // endregion
 
 class FeatConverter extends BaseConverter {

--- a/js/converter.js
+++ b/js/converter.js
@@ -63,6 +63,7 @@ class BaseConverter extends BaseComponent {
 		this._renderSidebarConverterOptionsPart(parent, $wrpSidebar);
 		this._renderSidebarPagePart(parent, $wrpSidebar);
 		this._renderSidebarSourcePart(parent, $wrpSidebar);
+		this._renderSidebarDebugPart(parent, $wrpSidebar);
 	}
 
 	_renderSidebar () { throw new Error("Unimplemented!"); }
@@ -224,6 +225,29 @@ class BaseConverter extends BaseComponent {
 
 		ConverterUiUtil.renderSideMenuDivider($wrpSidebar);
 	}
+	
+	_renderSidebarDebugPart (parent, $wrpSidebar) {
+		const $cbRenderTextEachTime = ComponentUiUtil.$getCbBool(this._ui, "renderTextEachTime");
+		$$`<div class="sidemenu__row split-v-center">
+			<label class="sidemenu__row__label sidemenu__row__label--cb-label" title="Should the text in the output be rendered for every converted entry? Slower, but in case an error happens will show the output up to that point"><span>Render Text Every Entry</span>
+			${$cbRenderTextEachTime}
+		</label></div>`.appendTo($wrpSidebar);
+
+		const $cbPrintWarningsToConsole = ComponentUiUtil.$getCbBool(this._ui, "printWarningsToConsole");
+		$$`<div class="sidemenu__row split-v-center">
+			<label class="sidemenu__row__label sidemenu__row__label--cb-label" title="Should converter warnings be printed to console too, instead of only below the output box?"><span>Warnings To Console</span>
+			${$cbPrintWarningsToConsole}
+		</label></div>`.appendTo($wrpSidebar);
+
+		const $cbVerboseWarnings = ComponentUiUtil.$getCbBool(this._ui, "verboseWarnings");
+		$$`<div class="sidemenu__row split-v-center">
+			<label class="sidemenu__row__label sidemenu__row__label--cb-label" title="Should warnings be printed for every part of the text that is possibly a tag but isn't recognized? (For example, damage resistances)"><span>Verbose Warnings</span>
+			${$cbVerboseWarnings}
+		</label></div>`.appendTo($wrpSidebar);
+
+		ConverterUiUtil.renderSideMenuDivider($wrpSidebar);
+	}
+
 	// endregion
 }
 
@@ -894,7 +918,9 @@ class ConverterUi extends BaseComponent {
 				const splitStack = x.stack.split("\n");
 				const atPos = splitStack.length > 1 ? splitStack[1].trim() : "(Unknown location)";
 				const message = `[Error] ${x.message} ${atPos}`;
-				$(`#lastError`).show().html(message);
+				const rtetNotif = (this._state.renderTextEachTime) ? "" : 
+					" (Render Text Every Entry checkbox is off; you can try turning it on to see where the error happened)";
+				$(`#lastError`).show().html(message + rtetNotif);
 				this._editorOut.resize();
 				setTimeout(() => { throw x; });
 			}
@@ -1043,7 +1069,7 @@ ConverterUi._DEFAULT_STATE = {
 	converter: "Creature",
 	sourceJson: "",
 	inputSeparator: "===",
-	renderTextEachTime: true,
+	renderTextEachTime: false,
 	printWarningsToConsole: true,
 	verboseWarnings: false,
 };

--- a/js/converter.js
+++ b/js/converter.js
@@ -924,6 +924,10 @@ class ConverterUi extends BaseComponent {
 							isAppend || i !== 0, // always clear the output for the first non-append chunk, then append
 						);
 					});
+
+				if (!this._state.renderTextEachTime) {
+					this.doRenderOutput();
+				}
 			});
 		};
 
@@ -977,6 +981,8 @@ class ConverterUi extends BaseComponent {
 	showWarning (text) {
 		$(`#lastWarnings`).show().append(`<div>[Warning] ${text}</div>`);
 		this._editorOut.resize();
+
+		if (this._state.printWarningsToConsole) console.warn(text);
 	}
 
 	doCleanAndOutput (obj, append, prop) {
@@ -997,6 +1003,13 @@ class ConverterUi extends BaseComponent {
 
 			this._state.hasAppended = false;
 		}
+
+		if (this._state.renderTextEachTime) {
+			this.doRenderOutput();
+		}
+	}
+
+	doRenderOutput () {
 		const propToString = prop => `"${prop}": [\n\t`
 			+ this._outProps[prop]
 				.join(",\n")
@@ -1030,6 +1043,8 @@ ConverterUi._DEFAULT_STATE = {
 	converter: "Creature",
 	sourceJson: "",
 	inputSeparator: "===",
+	renderTextEachTime: true,
+	printWarningsToConsole: true,
 };
 
 async function doPageInit () {

--- a/js/converter.js
+++ b/js/converter.js
@@ -862,9 +862,7 @@ class ConverterUi extends BaseComponent {
 			const output = this._outText;
 			if (output && output.trim()) {
 				try {
-					const prop = this.activeConverter.prop;
-					const out = {[prop]: JSON.parse(`[${output}]`)};
-					DataUtil.userDownload(`converter-output`, out);
+					DataUtil.userDownload(`converter-output`, JSON.parse(output));
 				} catch (e) {
 					JqueryUtil.doToast({
 						content: `Current output was not valid JSON. Downloading as <span class="code">.txt</span> instead.`,

--- a/js/converter.js
+++ b/js/converter.js
@@ -513,16 +513,21 @@ Once the Wreath of the Prism reaches an exalted state, it gains the following be
 • You can affect creatures of challenge rating 15 or lower with the wreath.
 • The save DC of the wreath’s spell increases to 17.
 ===
-Weapon of Conjuring
-Weapon (any sword or piercing weapon with the light property), Very Rare (requires attunement)
+Weapon of Generic Variant Conjuring
+Weapon (any sword or piercing melee weapon with the light property), Very Rare (requires attunement)
 This weapon conjures a random demon on a critical hit. 
 It is also made up for the purpose of a variant example as there was no magic item I could find with both specific variant requirements (like this with the light property) and a table.
-Other options are "without the x [or y] property", "Armor (heavy but not x <plate, etc.>)", "Weapon (longsword or shortsword)", etc.
 | d4 | Spawned demon | Is cool? |
 | --- | ------- | --: |
 | 1 | barlgura | 1 |
 | 2 | 1d4 shadow demon | 2 |
-| 3-4 | chasme | 3 |`;
+| 3-4 | chasme | 3 |
+Other working examples:
+• Weapon (maul or warhammer)
+• Armor (light or medium)
+• Armor (heavy but not plate)
+• Weapon (any melee weapon without the special property)
+• Weapon (any weapon with the heavy property without the special property)`;
 // endregion
 
 class FeatConverter extends BaseConverter {

--- a/js/converter.js
+++ b/js/converter.js
@@ -253,7 +253,7 @@ class CreatureConverter extends BaseConverter {
 		ConverterUiUtil.renderSideMenuDivider($wrpSidebar);
 	}
 
-	handleParse (input, cbOutput, cbWarning, isAppend) {
+	handleParse (input, cbOutput, cbWarning, isAppend, verboseWarnings) {
 		const opts = {
 			cbWarning,
 			cbOutput: (obj, append, prop) => cbOutput(obj, append, prop || this.prop),
@@ -393,7 +393,7 @@ class SpellConverter extends BaseConverter {
 		$wrpSidebar.empty();
 	}
 
-	handleParse (input, cbOutput, cbWarning, isAppend) {
+	handleParse (input, cbOutput, cbWarning, isAppend, verboseWarnings) {
 		const opts = {
 			cbWarning,
 			cbOutput: (obj, append, prop) => cbOutput(obj, append, prop || this.prop),
@@ -448,7 +448,7 @@ class ItemConverter extends BaseConverter {
 		$wrpSidebar.empty();
 	}
 
-	handleParse (input, cbOutput, cbWarning, isAppend) {
+	handleParse (input, cbOutput, cbWarning, isAppend, verboseWarnings) {
 		const opts = {
 			cbWarning,
 			cbOutput: (obj, append, prop) => cbOutput(obj, append, prop || this.prop),
@@ -457,6 +457,7 @@ class ItemConverter extends BaseConverter {
 			isTitleCase: this._state.isTitleCase,
 			source: this._state.source,
 			page: this._state.page,
+			verboseWarnings,
 		};
 
 		switch (this._state.mode) {
@@ -509,7 +510,7 @@ class FeatConverter extends BaseConverter {
 		$wrpSidebar.empty();
 	}
 
-	handleParse (input, cbOutput, cbWarning, isAppend) {
+	handleParse (input, cbOutput, cbWarning, isAppend, verboseWarnings) {
 		const opts = {
 			cbWarning,
 			cbOutput: (obj, append, prop) => cbOutput(obj, append, prop || this.prop),
@@ -627,7 +628,7 @@ class TableConverter extends BaseConverter {
 		$wrpSidebar.empty();
 	}
 
-	handleParse (input, cbOutput, cbWarning, isAppend) {
+	handleParse (input, cbOutput, cbWarning, isAppend, verboseWarnings) {
 		const opts = {
 			cbWarning,
 			cbOutput: (obj, append, prop) => cbOutput(obj, append, prop || this.prop),
@@ -920,6 +921,7 @@ class ConverterUi extends BaseComponent {
 							this.doCleanAndOutput.bind(this),
 							this.showWarning.bind(this),
 							isAppend || i !== 0, // always clear the output for the first non-append chunk, then append
+							this._state.verboseWarnings,
 						);
 					});
 
@@ -1043,6 +1045,7 @@ ConverterUi._DEFAULT_STATE = {
 	inputSeparator: "===",
 	renderTextEachTime: true,
 	printWarningsToConsole: true,
+	verboseWarnings: false,
 };
 
 async function doPageInit () {

--- a/js/converterutils.js
+++ b/js/converterutils.js
@@ -706,8 +706,14 @@ class EntryConvert {
 			entries,
 		];
 
-		const popList = () => { while (stack.last().type === "list") stack.pop(); };
-		const popNestedEntries = () => { while (stack.length > 1) stack.pop(); };
+		const popList = () => { 
+			while (stack.last().type === "list" || stack.last().type === "table")
+				this.finalizeEntry(stack.pop());
+		}
+		const popNestedEntries = () => { 
+			while (stack.length > 1) 
+				this.finalizeEntry(stack.pop()); 
+		}
 
 		const addEntry = (entry, canCombine) => {
 			canCombine = canCombine && typeof entry === "string";
@@ -731,6 +737,13 @@ class EntryConvert {
 				} else {
 					target.entries.push(entry);
 				}
+			} else if (target.type === "table") {
+				if (canCombine && typeof target.rows.last() === "string") {
+					throw new Error("Cannot combine table entries") // for now?
+				} else {
+					target.rows.push(entry)
+				}
+				return;
 			}
 
 			if (typeof entry !== "string") stack.push(entry);
@@ -739,6 +752,7 @@ class EntryConvert {
 		const getCurrentEntryArray = () => {
 			if (stack.last().type === "list") return stack.last().items;
 			if (stack.last().type === "entries") return stack.last().entries;
+			if (stack.last().type === "table") return stack.last().rows;
 			return stack.last();
 		};
 
@@ -760,6 +774,72 @@ class EntryConvert {
 
 				curLine = curLine.replace(/^\s*•\s*/, "");
 				addEntry(curLine.trim());
+			} else if (ConvertUtil.isTableHeaderSeparator(curLine)) {
+				if (stack.last().type === "table") {
+					const tbl = stack.last()
+
+					let rowStyles = curLine.split(/\s*\|\s*/);
+					rowStyles.pop();
+					rowStyles.shift();
+
+					for (let i = 0; i < rowStyles.length; i++) {
+						let alignment = "";
+						if (/^:-*:$/.test(rowStyles[i])) {
+							alignment = "text-center";
+						} else if (/^-+:$/.test(rowStyles[i])) {
+							alignment = "text-right";
+						}
+						tbl.colStyles[i] = alignment;
+					}
+				} else {
+					throw new Error("Found table header without a related table")
+				}
+			} else if (ConvertUtil.isTableItemLine(curLine)) {
+				let thisRow = curLine.split(/\s*\|\s*/);
+				thisRow.pop();
+				thisRow.shift();
+
+				for (let i = 0; i < thisRow.length; i++) {
+					let cell = thisRow[i];
+					if (ConvertUtil.isNameLine(cell)) {
+						const {name, entry} = ConvertUtil.splitNameLine(cell);	
+						const entryObj = {
+							type: "entries",
+							name,
+							entries: [entry],
+						};
+						thisRow[i] = entryObj;
+					} else if (i == 0) {
+						// for rollable tables
+						const rollMatch = /^(\d+)(?:-(\d+))?$/.exec(cell);
+						if (rollMatch) {
+							const rollObj = {
+								type: "cell",
+								roll: {
+								}
+							};
+							if (!rollMatch[2]) {
+								rollObj.roll.exact = rollMatch[1];
+							} else {
+								rollObj.roll.min = rollMatch[1];
+								rollObj.roll.max = rollMatch[2];
+							}
+							thisRow[i] = rollObj;
+						}
+					}
+				}
+
+				if (stack.last().type !== "table") {
+					const table = {
+						type: "table",
+						colLabels: thisRow,
+						colStyles: [],
+						rows: [],
+					};
+					addEntry(table);
+				} else {
+					addEntry(thisRow);
+				}
 			} else if (ConvertUtil.isNameLine(curLine)) {
 				popNestedEntries(); // this implicitly pops nested lists
 
@@ -793,8 +873,30 @@ class EntryConvert {
 			ptrI._++;
 			curLine = toConvert[ptrI._];
 		}
-
+		// added for final table handling
+		popNestedEntries();
 		return entries;
+	}
+
+	static finalizeEntry (entry) {
+		if (entry.type === "table") {
+			let allNumbers = true;
+			// Center number only columns if it's the first column
+			for (let i = 0; i < entry.rows.length; i++) {
+				const row = entry.rows[i];
+				if (!(
+					(typeof row[0] === 'string' && /^\d+(-\d+)?$/.test(row[0]))
+					|| row[0].roll
+				)) {
+					allNumbers = false;
+					break;
+				}
+			}
+
+			if (allNumbers && entry.colStyles[0].trim() === "") {
+				entry.colStyles[0] = "text-center";
+			}
+		}
 	}
 }
 
@@ -844,6 +946,10 @@ class ConvertUtil {
 	}
 
 	static isListItemLine (line) { return line.trim().startsWith("•"); }
+
+	// Detect markdown tables
+	static isTableItemLine (line) { return /^\|(?:[^|]*\|)+$/.test(line) }
+	static isTableHeaderSeparator (line) { return /^\|(?:[\s\-:]*\|)+$/.test(line) }
 
 	static splitNameLine (line, isKeepPunctuation) {
 		const spl = this._getMergedSplitName({line});

--- a/js/converterutils.js
+++ b/js/converterutils.js
@@ -880,8 +880,12 @@ class EntryConvert {
 
 	static finalizeEntry (entry) {
 		if (entry.type === "table") {
+			// Convert dices
+			entry.colLabels[0] = DiceConvert.getTaggedEntry(entry.colLabels[0]);
+			entry.rows.map(row => row.map(cell => DiceConvert.getTaggedEntry(cell)));
+
 			let allNumbers = true;
-			// Center number only columns if it's the first column
+			// Center number/dice only columns if it's the first column
 			for (let i = 0; i < entry.rows.length; i++) {
 				const row = entry.rows[i];
 				if (!(

--- a/js/render.js
+++ b/js/render.js
@@ -6664,15 +6664,18 @@ Renderer.item = {
 		if (!toMatch) return false;
 
 		return Object.entries(toMatch)[method](([k, v]) => {
-			if (v instanceof Array) {
-				return baseItem[k] instanceof Array
-					? baseItem[k].some(it => v.includes(it))
-					: v.includes(baseItem[k]);
+			if (baseItem[k] === v) return true;
+			// for matching only some of an array value, like for item properties
+			if (v.includes) {
+				if (v.includes instanceof Array) {
+					return (baseItem[k] instanceof Array 
+						? baseItem[k].find(it => v.includes.includes(it)) 
+						: v.includes.includes(baseItem[k])
+					);
+				}
+				return baseItem[k] instanceof Array ? baseItem[k].find(it => v.includes === it) : v.includes === baseItem[k];
 			}
-
-			return baseItem[k] instanceof Array
-				? baseItem[k].some(it => v === it)
-				: v === baseItem[k];
+			return false;
 		});
 	},
 


### PR DESCRIPTION
Main changes:
- Text converters outputs proper JSON with elements put in the various prop categories, meaning generic variants for items now work
- The item text converter recognizes way more patterns in the subcategory, for example: `Weapon (any piercing weapon with the light property)` or `Armor (heavy but not plate)`. More examples in the sample text for the item converter. In general:
  - Support for generic exceptions (`except plate armor`, `except longswords`) (yes, it handles plurals too)
  - Support for lists of base items (`shortsword, longsword, or dagger`)
  - Support for property requirements, both positive and negative (and both) `with the light property`, `without the heavy property`
  - More support of base items being the main damage categories (`piercing weapon`, `blunt`, `bludgeoning`, `bladed`, etc.)
  - Support for `melee weapon` / `ranged weapon`, which can be combined with the other parameters
  - Disabled itemGroup output as there was no easy way to make it include an items list, and it didn't work for now
- Markdown tables are recognized in the entries now, and dice columns are recognized inside them.
- More options, mainly for debug. Also way faster when converting large amounts of elements by avoiding to rerender the text for every element converted, which can also be toggled as an option for debug purposes.

Also, the JSON schema was technically changed, as generic variant item requirements can now have an "includes" field, like this:
```JSON
"requires": [
  {
    "sword": true,
      "property": {
        "includes": [
        "L",
        "F"
        ]
    }
  }
]
```
I am not sure how to update the schema to account for that, though.