### PR TITLE
bug in function checkSetFirstActive ()

### DIFF
--- a/js/dmscreen-initiativetracker.js
+++ b/js/dmscreen-initiativetracker.js
@@ -1165,10 +1165,8 @@ class InitiativeTracker {
 							handleTurnStart($nxt);
 						} else break;
 					}
+					$iptRound.val(Number($iptRound.val() || 0) + 1);
 				}
-
-				$iptRound.val(Number($iptRound.val() || 0) + 1);
-
 				doUpdateExternalStates();
 			}
 		}


### PR DESCRIPTION
$iptRound.val(Number($iptRound.val() || 0) + 1); gets triggered on the 'btnAdd' and 'btnAddMonster' on the first row due to it being in the wrong statement. Shouldn't be triggered if $rows.length is less than 1.

Simple fix.