### PR TITLE
Tags and typos in class-mystic.json

### DIFF
--- a/data/class/class-mystic.json
+++ b/data/class/class-mystic.json
@@ -518,7 +518,7 @@
 			"classSource": "UATheMysticClass",
 			"level": 1,
 			"entries": [
-				"Psionic talents and disciplines are the heart of a mystic's craft. They are the mental exercises and psionic formulae used to forge will into tangible, magical effects.",
+				"{@filter Psionic talents|psionics|type=T} and {@filter disciplines|psionics|type=D} are the heart of a mystic's craft. They are the mental exercises and psionic formulae used to forge will into tangible, magical effects.",
 				"Psionic disciplines were each discovered by different orders and tend to reflect their creators' specialties. However, a mystic can learn any discipline regardless of its associated order."
 			]
 		},
@@ -535,14 +535,14 @@
 					"type": "entries",
 					"name": "Psionic Talents",
 					"entries": [
-						"A psionic talent is a minor psionic effect you have mastered. At 1st level, you know one psionic talent of your choice. You learn additional talents of your choice at higher levels. The Talents Known column of the Mystic table shows the total number of talents you know at each level; when that number goes up for you, choose a new talent."
+						"A {@filter psionic talent|psionics|type=T} is a minor psionic effect you have mastered. At 1st level, you know one psionic talent of your choice. You learn additional talents of your choice at higher levels. The Talents Known column of the Mystic table shows the total number of talents you know at each level; when that number goes up for you, choose a new talent."
 					]
 				},
 				{
 					"type": "entries",
 					"name": "Psionic Disciplines",
 					"entries": [
-						"A psionic discipline is a rigid set of mental exercises that allows a mystic to manifest psionic power. A mystic masters only a few disciplines at a time.",
+						"A {@filter psionic discipline|psionics|type=D} is a rigid set of mental exercises that allows a mystic to manifest psionic power. A mystic masters only a few disciplines at a time.",
 						"At 1st level, you know one psionic discipline of your choice. The Disciplines Known column of the Mystic table shows the total number of disciplines you know at each level; when that number goes up for you, choose a new discipline.",
 						"In addition, whenever you gain a level in this class, you can replace one discipline you know with a different one of your choice."
 					]
@@ -775,7 +775,7 @@
 			"level": 8,
 			"entries": [
 				"At 8th level, you gain the ability to infuse your weapon attacks with psychic energy. Once on each of your turns when you hit a creature with a weapon, you can deal an extra {@damage 1d8} psychic damage to that target. When you reach 14th level, this extra damage increases to {@dice 2d8}.",
-				"In addition, you add your Intelligence modifier to any damage roll you make for a psionic talent."
+				"In addition, you add your Intelligence modifier to any damage roll you make for a {@filter psionic talent|psionics|type=T}."
 			]
 		},
 		{
@@ -873,7 +873,7 @@
 			"classSource": "UATheMysticClass",
 			"level": 14,
 			"entries": [
-				"At 14th level, your potent psionics damage increased to {@dice 2d8}."
+				"At 14th level, your Potent Psionics damage increased to {@dice 2d8}."
 			]
 		},
 		{
@@ -1017,7 +1017,7 @@
 			"level": 1,
 			"header": 1,
 			"entries": [
-				"At 1st level, you learn two additional psionic disciplines of your choice. They must be chosen from among the Avatar disciplines."
+				"At 1st level, you learn two additional psionic disciplines of your choice. They must be chosen from among the {@filter Avatar disciplines|psionics|type=D|order=Avatar}."
 			]
 		},
 		{
@@ -1109,7 +1109,7 @@
 			"level": 1,
 			"header": 1,
 			"entries": [
-				"At 1st level, you learn two additional psionic disciplines of your choice. They must be chosen from among the Awakened disciplines."
+				"At 1st level, you learn two additional psionic disciplines of your choice. They must be chosen from among the {@filter Awakened disciplines|psionics|type=D|order=Awakened}."
 			]
 		},
 		{
@@ -1192,7 +1192,7 @@
 			"level": 1,
 			"header": 1,
 			"entries": [
-				"At 1st level, you learn two additional psionic disciplines of your choice. They must be chosen from among the Immortal disciplines."
+				"At 1st level, you learn two additional psionic disciplines of your choice. They must be chosen from among the {@filter Immortal disciplines|psionics|type=D|order=Immortal}."
 			]
 		},
 		{
@@ -1286,7 +1286,7 @@
 			"level": 1,
 			"header": 1,
 			"entries": [
-				"At 1st level, you learn two additional psionic disciplines of your choice. They must be chosen from among the Nomad disciplines."
+				"At 1st level, you learn two additional psionic disciplines of your choice. They must be chosen from among the {@filter Nomad disciplines|psionics|type=D|order=Nomad}."
 			]
 		},
 		{
@@ -1497,7 +1497,7 @@
 			"level": 1,
 			"header": 1,
 			"entries": [
-				"At 1st level, you learn two additional psionic disciplines of your choice. They must be chosen from among the Wu Jen disciplines."
+				"At 1st level, you learn two additional psionic disciplines of your choice. They must be chosen from among the {@filter Wu Jen disciplines|psionics|type=D|order=Wu Jen}."
 			]
 		},
 		{
@@ -1539,7 +1539,7 @@
 			"level": 6,
 			"header": 2,
 			"entries": [
-				"At 6th level, you learn three wizard spells of your choice and always have them prepared. The spells must be of 1st through 3rd level.",
+				"At 6th level, you learn three wizard spells of your choice and always have them prepared. The spells must be of {@filter 1st through 3rd level|spells|level=1;2;3|class=wizard}.",
 				"As a bonus action, you can spend psi points to create spell slots that you can use to cast these spells, as well as other spells you are capable of casting. The psi-point cost of each spell slot is detailed on the table below.",
 				{
 					"type": "table",
@@ -1575,7 +1575,7 @@
 					]
 				},
 				"The spell slot remains until you use it or finish a long rest. You must observe your psi limit when spending psi points to create a spell slot.",
-				"Whenever you gain a level in this class, you can replace on of the chosen wizard spells with a different wizard spell of 1st through 3rh level."
+				"Whenever you gain a level in this class, you can replace on of the chosen wizard spells with a different {@filter wizard spell of 1st through 3rd level|spells|level=1;2;3|class=wizard}."
 			]
 		},
 		{


### PR DESCRIPTION
Added various talent/discipline filter tags; wizard spell filter for Wu Jen (Arcane Dabbler); Order discipline filters for Bonus Disciplines features; couple of typos covered by the aforementioned.