### PR TITLE
Add 5eTools `{@tag }` Syntax Highlighting to Ace

### DIFF
--- a/lib/mode-json.js
+++ b/lib/mode-json.js
@@ -1,6 +1,9 @@
 define("ace/mode/json_highlight_rules",["require","exports","module","ace/lib/oop","ace/mode/text_highlight_rules"], function(require, exports, module){"use strict";
 var oop = require("../lib/oop");
 var TextHighlightRules = require("./text_highlight_rules").TextHighlightRules;
+var keywords = [...Renderer._stripTagLayer.toString().matchAll(/case "@(\w+?)"/g)].map(item => item[1]).join("|");
+var sources = Object.keys(Parser.SOURCE_JSON_TO_FULL).join("|");
+var brewSources = BrewUtil2.getSources().map(item => item.json).join("|");
 var JsonHighlightRules = function () {
     this.$rules = {
         "start": [
@@ -21,7 +24,7 @@ var JsonHighlightRules = function () {
                 token: "constant.language.boolean",
                 regex: "(?:true|false)\\b"
             }, {
-                token: "text",
+                token: "invalid",
                 regex: "['](?:(?:\\\\.)|(?:[^'\\\\]))*?[']"
             }, {
                 token: "comment",
@@ -49,6 +52,10 @@ var JsonHighlightRules = function () {
                 token: "constant.language.escape",
                 regex: /\\(?:x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|["\\\/bfnrt])/
             }, {
+                token: "meta.structure.tag.Open",
+                regex: "\\{(?=@)",
+                next: "tag5e"
+            }, {
                 token: "string",
                 regex: '"|$',
                 next: "start"
@@ -64,7 +71,35 @@ var JsonHighlightRules = function () {
             }, {
                 defaultToken: "comment"
             }
-        ]
+        ],
+			"tag5e": [
+				 {
+					  token: "keyword",
+					  regex: "@(" + keywords + ")\\b\\s"
+				 }, {
+					  token: "punctuation.separator",
+					  regex: /[|]/
+				 }, {
+					  token: "constant.language.source",
+					  regex: "\\b(" + sources + "|" + sources.toLowerCase() + "|" + brewSources + ")\\b"
+				 }, {
+					  token: "meta.structure.tag.Open",
+					  regex: "\\{(?=@)",
+					  push: "tag5e"
+				 }, {
+					  token: "string.5e",
+					  regex: "(?<=\\|)[^|}]+(?=\\})"
+				 }, {
+					  token: "value.variable.rest.5e",
+					  regex: "(?<=\\|)[^|}]+(?=\\|)"
+				 }, {
+					  token: "meta.structure.tag.Close",
+					  regex: '\\}|(?=\\\")',
+					  next: "string"
+				 }, {
+					  defaultToken: "string"
+				 }
+			]
     };
 };
 oop.inherits(JsonHighlightRules, TextHighlightRules);

--- a/lib/mode-json.js
+++ b/lib/mode-json.js
@@ -81,7 +81,7 @@ var JsonHighlightRules = function () {
 					  regex: /[|]/
 				 }, {
 					  token: "constant.language.source",
-					  regex: "\\b(" + sources + "|" + sources.toLowerCase() + "|" + brewSources + ")\\b"
+					  regex: "\\b(" + sources + "|" + sources.toLowerCase() + "|" + brewSources + "|" + brewSources.toLowerCase() + ")\\b"
 				 }, {
 					  token: "meta.structure.tag.Open",
 					  regex: "\\{(?=@)",

--- a/lib/mode-json.js
+++ b/lib/mode-json.js
@@ -3,7 +3,7 @@ var oop = require("../lib/oop");
 var TextHighlightRules = require("./text_highlight_rules").TextHighlightRules;
 var keywords = [...Renderer._stripTagLayer.toString().matchAll(/case "@(\w+?)"/g)].map(item => item[1]).join("|");
 var sources = Object.keys(Parser.SOURCE_JSON_TO_FULL).join("|");
-var brewSources = BrewUtil2.getSources().map(item => item.json).join("|");
+var brewSources = (BrewUtil2.getSources().map(item => item.json).join("|")+"|Brew").replace(/^\|/, '');
 var JsonHighlightRules = function () {
     this.$rules = {
         "start": [
@@ -72,34 +72,34 @@ var JsonHighlightRules = function () {
                 defaultToken: "comment"
             }
         ],
-			"tag5e": [
-				 {
-					  token: "keyword",
-					  regex: "@(" + keywords + ")\\b\\s"
-				 }, {
-					  token: "punctuation.separator",
-					  regex: /[|]/
-				 }, {
-					  token: "constant.language.source",
-					  regex: "\\b(" + sources + "|" + sources.toLowerCase() + "|" + brewSources + "|" + brewSources.toLowerCase() + ")\\b"
-				 }, {
-					  token: "meta.structure.tag.Open",
-					  regex: "\\{(?=@)",
-					  push: "tag5e"
-				 }, {
-					  token: "string.5e",
-					  regex: "(?<=\\|)[^|}]+(?=\\})"
-				 }, {
-					  token: "value.variable.rest.5e",
-					  regex: "(?<=\\|)[^|}]+(?=\\|)"
-				 }, {
-					  token: "meta.structure.tag.Close",
-					  regex: '\\}|(?=\\\")',
-					  next: "string"
-				 }, {
-					  defaultToken: "string"
-				 }
-			]
+        "tag5e": [
+            {
+                token: "keyword",
+                regex: "@(" + keywords + ")\\b\\s"
+            }, {
+                token: "punctuation.separator",
+                regex: /[|]/
+            }, {
+                token: "keyword.operator",
+                regex: "\\b(" + sources + "|" + sources.toLowerCase() + "|" + brewSources + "|" + brewSources.toLowerCase() + ")\\b"
+            }, {
+                token: "meta.structure.tag.Open",
+                regex: "\\{(?=@)",
+                push: "tag5e"
+            }, {
+                token: "string.5e",
+                regex: "(?<=\\|)[^|}]+(?=\\})"
+            }, {
+                token: "support.type",
+                regex: "(?<=\\|)[^|}]+(?=\\|)"
+            }, {
+                token: "meta.structure.tag.Close",
+                regex: '\\}|(?=\\\")',
+                next: "string"
+            }, {
+                defaultToken: "string"
+            }
+        ]
     };
 };
 oop.inherits(JsonHighlightRules, TextHighlightRules);

--- a/lib/mode-json.js
+++ b/lib/mode-json.js
@@ -2,7 +2,7 @@ define("ace/mode/json_highlight_rules",["require","exports","module","ace/lib/oo
 var oop = require("../lib/oop");
 var TextHighlightRules = require("./text_highlight_rules").TextHighlightRules;
 var keywords = [...Renderer._stripTagLayer.toString().matchAll(/case "@(\w+?)"/g)].map(item => item[1]).join("|");
-var sources = Object.keys(Parser.SOURCE_JSON_TO_FULL).join("|");
+var coreSources = Object.keys(Parser.SOURCE_JSON_TO_FULL).join("|");
 var brewSources = (BrewUtil2.getSources().map(item => item.json).join("|")+"|Brew").replace(/^\|/, '');
 var JsonHighlightRules = function () {
     this.$rules = {
@@ -53,7 +53,7 @@ var JsonHighlightRules = function () {
                 regex: /\\(?:x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|["\\\/bfnrt])/
             }, {
                 token: "meta.structure.tag.Open",
-                regex: "\\{(?=@)",
+                regex: "\\{(?=@(?:" + keywords + ")\\s)",
                 next: "tag5e"
             }, {
                 token: "string",
@@ -81,10 +81,10 @@ var JsonHighlightRules = function () {
                 regex: /[|]/
             }, {
                 token: "keyword.operator",
-                regex: "\\b(" + sources + "|" + sources.toLowerCase() + "|" + brewSources + "|" + brewSources.toLowerCase() + ")\\b"
+                regex: "\\b(" + coreSources + "|" + coreSources.toLowerCase() + "|" + brewSources + "|" + brewSources.toLowerCase() + ")\\b"
             }, {
                 token: "meta.structure.tag.Open",
-                regex: "\\{(?=@)",
+                regex: "\\{(?=@(?:" + keywords + ")\\s)",
                 push: "tag5e"
             }, {
                 token: "string.5e",


### PR DESCRIPTION
- Recognizes valid tag keywords
- Recognizes valid sources, including both core and homebrew
- Tags not highlighting provides user feedback that their tag is in some way incorrect

![image](https://user-images.githubusercontent.com/52298102/191348700-7849d7b0-151f-4a00-a890-76f0c1657a97.png)
