### PR TITLE
Enforce Non-Empty Data Arrays

### DIFF
--- a/data/deities.json
+++ b/data/deities.json
@@ -2267,8 +2267,7 @@
 				"Arcana",
 				"Life",
 				"Light",
-				"War",
-				"Arcana"
+				"War"
 			],
 			"province": "Primary god of elves",
 			"symbol": "Quarter moon or starburst",
@@ -2338,8 +2337,7 @@
 			"title": "God of art and magic",
 			"domains": [
 				"Arcana",
-				"Light",
-				"Arcana"
+				"Light"
 			],
 			"symbol": "Crescent moon"
 		},

--- a/data/spells/spells-phb.json
+++ b/data/spells/spells-phb.json
@@ -7341,17 +7341,6 @@
 					},
 					{
 						"class": {
-							"name": "Warlock",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Genie (UA)",
-							"source": "UA2020SubclassesRevisited",
-							"subSubclass": "Marid"
-						}
-					},
-					{
-						"class": {
 							"name": "Monk",
 							"source": "PHB"
 						},
@@ -8796,17 +8785,6 @@
 						"subclass": {
 							"name": "Genie",
 							"source": "TCE",
-							"subSubclass": "Marid"
-						}
-					},
-					{
-						"class": {
-							"name": "Warlock",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Genie (UA)",
-							"source": "UA2020SubclassesRevisited",
 							"subSubclass": "Marid"
 						}
 					}
@@ -10256,12 +10234,6 @@
 				{
 					"name": "Tiefling (Asmodeus)",
 					"source": "MTF",
-					"baseName": "Tiefling",
-					"baseSource": "PHB"
-				},
-				{
-					"name": "Tiefling (Variant)",
-					"source": "SCAG",
 					"baseName": "Tiefling",
 					"baseSource": "PHB"
 				},
@@ -18778,17 +18750,6 @@
 							"source": "PHB"
 						},
 						"subclass": {
-							"name": "Genie (UA)",
-							"source": "UA2020SubclassesRevisited",
-							"subSubclass": "Djinni"
-						}
-					},
-					{
-						"class": {
-							"name": "Warlock",
-							"source": "PHB"
-						},
-						"subclass": {
 							"name": "Undead",
 							"source": "VRGR"
 						}
@@ -19573,17 +19534,6 @@
 						"subclass": {
 							"name": "Genie",
 							"source": "TCE",
-							"subSubclass": "Djinni"
-						}
-					},
-					{
-						"class": {
-							"name": "Warlock",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Genie (UA)",
-							"source": "UA2020SubclassesRevisited",
 							"subSubclass": "Djinni"
 						}
 					},
@@ -32290,17 +32240,6 @@
 					},
 					{
 						"class": {
-							"name": "Warlock",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Genie (UA)",
-							"source": "UA2020SubclassesRevisited",
-							"subSubclass": "Dao"
-						}
-					},
-					{
-						"class": {
 							"name": "Monk",
 							"source": "PHB"
 						},
@@ -34517,17 +34456,6 @@
 						"subclass": {
 							"name": "Genie",
 							"source": "TCE",
-							"subSubclass": "Marid"
-						}
-					},
-					{
-						"class": {
-							"name": "Warlock",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Genie (UA)",
-							"source": "UA2020SubclassesRevisited",
 							"subSubclass": "Marid"
 						}
 					}
@@ -37430,12 +37358,6 @@
 					"baseSource": "PHB"
 				},
 				{
-					"name": "Tiefling (Variant)",
-					"source": "SCAG",
-					"baseName": "Tiefling",
-					"baseSource": "PHB"
-				},
-				{
 					"name": "Tiefling (Asmodeus)",
 					"source": "UAFiendishOptions",
 					"baseName": "Tiefling",
@@ -37809,17 +37731,6 @@
 						"subclass": {
 							"name": "Genie",
 							"source": "TCE",
-							"subSubclass": "Djinni"
-						}
-					},
-					{
-						"class": {
-							"name": "Warlock",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Genie (UA)",
-							"source": "UA2020SubclassesRevisited",
 							"subSubclass": "Djinni"
 						}
 					},
@@ -39259,17 +39170,6 @@
 						"subclass": {
 							"name": "Genie",
 							"source": "TCE",
-							"subSubclass": "Dao"
-						}
-					},
-					{
-						"class": {
-							"name": "Warlock",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Genie (UA)",
-							"source": "UA2020SubclassesRevisited",
 							"subSubclass": "Dao"
 						}
 					},

--- a/test/schema-template/actions.json
+++ b/test/schema-template/actions.json
@@ -80,6 +80,7 @@
 	"properties": {
 		"action": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"$ref": "#/definitions/action"

--- a/test/schema-template/adventures.json
+++ b/test/schema-template/adventures.json
@@ -6,6 +6,7 @@
 	"properties": {
 		"adventure": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"type": "object",

--- a/test/schema-template/backgrounds.json
+++ b/test/schema-template/backgrounds.json
@@ -133,6 +133,7 @@
 	"properties": {
 		"background": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"$ref": "#/definitions/background"

--- a/test/schema-template/bestiary/bestiary.json
+++ b/test/schema-template/bestiary/bestiary.json
@@ -1087,10 +1087,11 @@
 	"properties": {
 		"monster": {
 			"type": "array",
-			"uniqueItems": true,
 			"items": {
 				"$ref": "#/definitions/creature"
-			}
+			},
+			"minItems": 1,
+			"uniqueItems": true
 		},
 		"_meta": {
 			"$ref": "../util.json#/definitions/metaBlock"

--- a/test/schema-template/bestiary/bestiary.json
+++ b/test/schema-template/bestiary/bestiary.json
@@ -1090,7 +1090,10 @@
 			"items": {
 				"$ref": "#/definitions/creature"
 			},
-			"minItems": 1,
+			"$$ifBrew": {
+				"minItems": 1
+			},
+			"$comment": "This is necessary as some site bestiary files assert only otherSources and do not contain any true data.",
 			"uniqueItems": true
 		},
 		"_meta": {

--- a/test/schema-template/bestiary/legendarygroups.json
+++ b/test/schema-template/bestiary/legendarygroups.json
@@ -74,6 +74,7 @@
 		"_meta": {"$ref": "../util.json#/definitions/metaBlock"},
 		"legendaryGroup": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {"$ref": "#/definitions/legendaryGroup"}
 		}

--- a/test/schema-template/bestiary/traits.json
+++ b/test/schema-template/bestiary/traits.json
@@ -59,6 +59,7 @@
 	"properties": {
 		"trait": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"$ref": "#/definitions/trait"

--- a/test/schema-template/books.json
+++ b/test/schema-template/books.json
@@ -6,6 +6,7 @@
 	"properties": {
 		"book": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"type": "object",

--- a/test/schema-template/charcreationoptions.json
+++ b/test/schema-template/charcreationoptions.json
@@ -74,6 +74,7 @@
 	"properties": {
 		"charoption": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {"$ref": "#/definitions/charoption"}
 		}

--- a/test/schema-template/class/class.json
+++ b/test/schema-template/class/class.json
@@ -850,22 +850,30 @@
 
 		"class": {
 			"type": "array",
-			"items": {"$ref": "#/definitions/class"}
+			"items": {"$ref": "#/definitions/class"},
+			"minItems": 1,
+			"uniqueItems": true
 		},
 
 		"subclass": {
 			"type": "array",
-			"items": {"$ref": "#/definitions/subclass"}
+			"items": {"$ref": "#/definitions/subclass"},
+			"minItems": 1,
+			"uniqueItems": true
 		},
 
 		"classFeature": {
 			"type": "array",
-			"items": {"$ref": "#/definitions/classFeature"}
+			"items": {"$ref": "#/definitions/classFeature"},
+			"minItems": 1,
+			"uniqueItems": true
 		},
 
 		"subclassFeature": {
 			"type": "array",
-			"items": {"$ref": "#/definitions/subclassFeature"}
+			"items": {"$ref": "#/definitions/subclassFeature"},
+			"minItems": 1,
+			"uniqueItems": true
 		}
 	},
 	"additionalProperties": false

--- a/test/schema-template/class/foundry.json
+++ b/test/schema-template/class/foundry.json
@@ -84,7 +84,9 @@
 					"source"
 				],
 				"additionalProperties": false
-			}
+			},
+			"minItems": 1,
+			"uniqueItems": true
 		},
 		"subclass": {
 			"type": "array",
@@ -119,7 +121,9 @@
 					"classSource"
 				],
 				"additionalProperties": false
-			}
+			},
+			"minItems": 1,
+			"uniqueItems": true
 		},
 		"classFeature": {
 			"type": "array",
@@ -155,7 +159,9 @@
 					"level"
 				],
 				"additionalProperties": false
-			}
+			},
+			"minItems": 1,
+			"uniqueItems": true
 		},
 		"subclassFeature": {
 			"type": "array",
@@ -196,7 +202,9 @@
 					"subclassSource"
 				],
 				"additionalProperties": false
-			}
+			},
+			"minItems": 1,
+			"uniqueItems": true
 		}
 	},
 

--- a/test/schema-template/conditionsdiseases.json
+++ b/test/schema-template/conditionsdiseases.json
@@ -59,6 +59,7 @@
 	"properties": {
 		"condition": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"$ref": "#/definitions/conditionDisease"
@@ -66,6 +67,7 @@
 		},
 		"disease": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"$ref": "#/definitions/conditionDisease"
@@ -73,6 +75,7 @@
 		},
 		"status": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"$ref": "#/definitions/conditionDisease"

--- a/test/schema-template/cultsboons.json
+++ b/test/schema-template/cultsboons.json
@@ -161,6 +161,7 @@
 	"properties": {
 		"cult": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"$ref": "#/definitions/cult"
@@ -168,6 +169,7 @@
 		},
 		"boon": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"$ref": "#/definitions/boon"

--- a/test/schema-template/deities.json
+++ b/test/schema-template/deities.json
@@ -16,6 +16,7 @@
 				},
 				"alignment": {
 					"type": "array",
+					"minItems": 1,
 					"items": {
 						"$ref": "util.json#/definitions/alignment"
 					}
@@ -59,6 +60,8 @@
 				},
 				"domains": {
 					"type": "array",
+					"minItems": 1,
+					"uniqueItems": true,
 					"items": {
 						"type": "string",
 						"$$ifSiteElse_key": {
@@ -101,6 +104,8 @@
 				},
 				"altNames": {
 					"type": "array",
+					"minItems": 1,
+					"uniqueItems": true,
 					"items": {
 						"type": "string"
 					}
@@ -158,6 +163,7 @@
 	"properties": {
 		"deity": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"$ref": "#/definitions/deity"

--- a/test/schema-template/encounters.json
+++ b/test/schema-template/encounters.json
@@ -67,6 +67,7 @@
 	"properties": {
 		"encounter": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"$ref": "#/definitions/encounter"

--- a/test/schema-template/feats.json
+++ b/test/schema-template/feats.json
@@ -29,6 +29,7 @@
 				},
 				"ability": {
 					"type": "array",
+					"minItems": 1,
 					"items": {
 						"type": "object",
 						"properties": {
@@ -148,6 +149,7 @@
 	"properties": {
 		"feat": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"$ref": "#/definitions/feat"

--- a/test/schema-template/fluff-charcreationoptions.json
+++ b/test/schema-template/fluff-charcreationoptions.json
@@ -6,6 +6,7 @@
 	"properties": {
 		"charoptionFluff": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"type": "object",
@@ -18,6 +19,7 @@
 					},
 					"images": {
 						"type": "array",
+						"minItems": 1,
 						"items": {
 							"$ref": "entry.json#/definitions/entryImage"
 						}

--- a/test/schema-template/fluff-conditionsdiseases.json
+++ b/test/schema-template/fluff-conditionsdiseases.json
@@ -6,6 +6,7 @@
 	"properties": {
 		"conditionFluff": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"type": "object",
@@ -18,6 +19,7 @@
 					},
 					"images": {
 						"type": "array",
+						"minItems": 1,
 						"items": {
 							"$ref": "entry.json#/definitions/entryImage"
 						}

--- a/test/schema-template/fluff-languages.json
+++ b/test/schema-template/fluff-languages.json
@@ -7,6 +7,7 @@
 		"languageFluff": {
 			"type": "array",
 			"uniqueItems": true,
+			"minItems": 1,
 			"items": {
 				"type": "object",
 				"properties": {

--- a/test/schema-template/fluff-races.json
+++ b/test/schema-template/fluff-races.json
@@ -76,6 +76,7 @@
 		"raceFluff": {
 			"type": "array",
 			"uniqueItems": true,
+			"minItems": 1,
 			"items": {
 				"$ref": "#/definitions/raceFluff"
 			}

--- a/test/schema-template/fluff-recipes.json
+++ b/test/schema-template/fluff-recipes.json
@@ -6,6 +6,7 @@
 	"properties": {
 		"recipeFluff": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"type": "object",

--- a/test/schema-template/fluff-vehicles.json
+++ b/test/schema-template/fluff-vehicles.json
@@ -6,6 +6,7 @@
 	"properties": {
 		"vehicleFluff": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"type": "object",

--- a/test/schema-template/foundry-backgrounds.json
+++ b/test/schema-template/foundry-backgrounds.json
@@ -8,6 +8,7 @@
 	"properties": {
 		"backgroundFeature": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"type": "object",

--- a/test/schema-template/foundry-items.json
+++ b/test/schema-template/foundry-items.json
@@ -9,6 +9,7 @@
 		"magicvariant": {"$ref": "util.json#/definitions/foundrySideDataGenericArray"},
 		"item": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"type": "object",

--- a/test/schema-template/foundry-psionics.json
+++ b/test/schema-template/foundry-psionics.json
@@ -10,6 +10,7 @@
 
 		"psionicDisciplineActive": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"type": "object",

--- a/test/schema-template/foundry-races.json
+++ b/test/schema-template/foundry-races.json
@@ -8,6 +8,7 @@
 	"properties": {
 		"raceFeature": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"type": "object",

--- a/test/schema-template/generated/bookref-quick.json
+++ b/test/schema-template/generated/bookref-quick.json
@@ -59,7 +59,8 @@
 					"type": "array",
 					"items": {
 						"$ref": "../entry.json"
-					}
+					},
+					"minItems": 1
 				}
 			},
 			"required": [

--- a/test/schema-template/homebrew.json
+++ b/test/schema-template/homebrew.json
@@ -20,7 +20,9 @@
 				},
 				"required": ["id", "source", "data"],
 				"additionalProperties": false
-			}
+			},
+			"minItems": 1,
+			"uniqueItems": true
 		}
 	},
 
@@ -93,7 +95,9 @@
 							"version"
 						],
 						"additionalProperties": false
-					}
+					},
+					"minItems": 1,
+					"uniqueItems": true
 				},
 				"spellSchools": {
 					"type": "object",
@@ -219,7 +223,9 @@
 									"coin",
 									"mult"
 								]
-							}
+							},
+							"minItems": 1,
+							"uniqueItems": true
 						}
 					}
 				},
@@ -243,7 +249,9 @@
 							"type": "array",
 							"items": {
 								"type": "string"
-							}
+							},
+							"minItems": 1,
+							"uniqueItems": true
 						}
 					}
 				},
@@ -252,7 +260,9 @@
 					"type": "array",
 					"items": {
 						"type": "string"
-					}
+					},
+					"minItems": 1,
+					"uniqueItems": true
 				},
 				"unlisted": {
 					"description": "If this homebrew file should be ignored/hidden by any indexer.",
@@ -303,7 +313,9 @@
 					"source"
 				],
 				"additionalProperties": false
-			}
+			},
+			"minItems": 1,
+			"uniqueItems": true
 		},
 		"adventure": {
 			"$ref": "adventures.json#/properties/adventure"

--- a/test/schema-template/items-base.json
+++ b/test/schema-template/items-base.json
@@ -312,7 +312,9 @@
 					"$ref": "#/definitions/itemLookupArray"
 				},
 				{
+					"type": "array",
 					"items": {
+						"type": "object",
 						"not": {
 							"required": ["template"]
 						}

--- a/test/schema-template/items-base.json
+++ b/test/schema-template/items-base.json
@@ -5,6 +5,7 @@
 	"definitions": {
 		"itemLookupArray": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {"$ref": "#/definitions/itemLookup"}
 		},
@@ -86,6 +87,7 @@
 	"properties": {
 		"baseitem": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"type": "object",
@@ -320,6 +322,7 @@
 		},
 		"itemEntry": {
 			"type": "array",
+			"minItems": 1,
 			"items": {
 				"type": "object",
 				"properties": {
@@ -334,6 +337,7 @@
 		},
 		"itemTypeAdditionalEntries": {
 			"type": "array",
+			"minItems": 1,
 			"items": {
 				"type": "object",
 				"properties": {

--- a/test/schema-template/items.json
+++ b/test/schema-template/items.json
@@ -232,6 +232,8 @@
 				"items": {
 					"description": "This is required for itemGroup entries.",
 					"type": "array",
+					"minItems": 1,
+					"uniqueItems": true,
 					"items": {
 						"type": "string"
 					}
@@ -539,7 +541,8 @@
 			"items": {
 				"$ref": "#/definitions/item"
 			},
-			"uniqueItems": true
+			"uniqueItems": true,
+			"minItems": 1
 		},
 		"itemGroup": {
 			"description": "Used to create fake item entries for groups of related items, often referred to as a single item (e.g. arcane foci)",
@@ -560,7 +563,8 @@
 					}
 				]
 			},
-			"uniqueItems": true
+			"uniqueItems": true,
+			"minItems": 1
 		},
 		"_meta": {
 			"$ref": "util.json#/definitions/metaBlock"

--- a/test/schema-template/languages.json
+++ b/test/schema-template/languages.json
@@ -81,6 +81,7 @@
 		"language": {
 			"type": "array",
 			"uniqueItems": true,
+			"minItems": 1,
 			"items": {
 				"$ref": "#/definitions/language"
 			}
@@ -88,6 +89,8 @@
 
 		"languageScript": {
 			"type": "array",
+			"uniqueItems": true,
+			"minItems": 1,
 			"items": {
 				"type": "object",
 				"properties": {

--- a/test/schema-template/magicvariants.json
+++ b/test/schema-template/magicvariants.json
@@ -6,6 +6,7 @@
 	"properties": {
 		"magicvariant": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"type": "object",

--- a/test/schema-template/makebrew-creature.json
+++ b/test/schema-template/makebrew-creature.json
@@ -10,6 +10,7 @@
 		"makebrewCreatureTrait": {
 			"description": "Additional trait templates which can be used in the homebrew builder.",
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"type": "object",

--- a/test/schema-template/makecards.json
+++ b/test/schema-template/makecards.json
@@ -5,6 +5,7 @@
 	"definitions": {
 		"itemLookupArray": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"type": "object",

--- a/test/schema-template/monsterfeatures.json
+++ b/test/schema-template/monsterfeatures.json
@@ -6,6 +6,7 @@
 	"properties": {
 		"monsterfeatures": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"type": "object",

--- a/test/schema-template/names.json
+++ b/test/schema-template/names.json
@@ -79,6 +79,7 @@
 	"properties": {
 		"name": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"$ref": "#/definitions/name"

--- a/test/schema-template/objects.json
+++ b/test/schema-template/objects.json
@@ -139,6 +139,7 @@
 		"object": {
 			"type": "array",
 			"uniqueItems": true,
+			"minItems": 1,
 			"items": {
 				"$ref": "#/definitions/object"
 			}

--- a/test/schema-template/optionalfeatures.json
+++ b/test/schema-template/optionalfeatures.json
@@ -101,6 +101,8 @@
 	"properties": {
 		"optionalfeature": {
 			"type": "array",
+			"uniqueItems": true,
+			"minItems": 1,
 			"items": {"$ref": "#/definitions/optionalfeature"}
 		}
 	},

--- a/test/schema-template/psionics.json
+++ b/test/schema-template/psionics.json
@@ -37,6 +37,7 @@
 				},
 				"modes": {
 					"type": "array",
+					"minItems": 1,
 					"uniqueItems": true,
 					"items": {
 						"type": "object",
@@ -93,6 +94,7 @@
 							},
 							"submodes": {
 								"type": "array",
+								"minItems": 1,
 								"uniqueItems": true,
 								"items": {
 									"type": "object",
@@ -166,6 +168,7 @@
 	"properties": {
 		"psionic": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"$ref": "#/definitions/psionic"

--- a/test/schema-template/races.json
+++ b/test/schema-template/races.json
@@ -144,6 +144,7 @@
 				"creatureTypeTags": {
 					"type": "array",
 					"uniqueItems": true,
+					"minItems": 1,
 					"items": {
 						"type": "string"
 					}
@@ -427,6 +428,7 @@
 		"race": {
 			"type": "array",
 			"uniqueItems": true,
+			"minItems": 1,
 			"items": {
 				"$ref": "#/definitions/race"
 			}
@@ -434,6 +436,7 @@
 		"subrace": {
 			"type": "array",
 			"uniqueItems": true,
+			"minItems": 1,
 			"items": {
 				"$ref": "#/definitions/subrace"
 			}

--- a/test/schema-template/recipes.json
+++ b/test/schema-template/recipes.json
@@ -152,6 +152,7 @@
 		"recipe": {
 			"type": "array",
 			"uniqueItems": true,
+			"minItems": 1,
 			"items": {
 				"$ref": "#/definitions/recipe"
 			}

--- a/test/schema-template/renderdemo.json
+++ b/test/schema-template/renderdemo.json
@@ -6,6 +6,7 @@
 	"properties": {
 		"data": {
 			"type": "array",
+			"minItems": 1,
 			"items": {
 				"$ref": "entry.json"
 			}

--- a/test/schema-template/rewards.json
+++ b/test/schema-template/rewards.json
@@ -77,6 +77,7 @@
 	"properties": {
 		"reward": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"$ref": "#/definitions/reward"

--- a/test/schema-template/senses.json
+++ b/test/schema-template/senses.json
@@ -31,6 +31,7 @@
 	"properties": {
 		"sense": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"$ref": "#/definitions/sense"

--- a/test/schema-template/skills.json
+++ b/test/schema-template/skills.json
@@ -31,6 +31,7 @@
 	"properties": {
 		"skill": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"$ref": "#/definitions/skill"

--- a/test/schema-template/spells/roll20.json
+++ b/test/schema-template/spells/roll20.json
@@ -100,7 +100,9 @@
 	"properties": {
 		"spell": {
 			"type": "array",
-			"items": {"$ref": "#/definitions/spellMeta"}
+			"items": {"$ref": "#/definitions/spellMeta"},
+			"minItems": 1,
+			"uniqueItems": true
 		}
 	}
 }

--- a/test/schema-template/spells/spells.json
+++ b/test/schema-template/spells/spells.json
@@ -39,7 +39,9 @@
 						"type": "array",
 						"items": {
 							"type": "string"
-						}
+						},
+						"minItems": 1,
+						"uniqueItems": true
 					},
 					"fluff": {
 						"description": "This is intended to be used for Homebrew only - site data should include a fluff file per source",
@@ -215,13 +217,17 @@
 							"type": "array",
 							"items": {
 								"$ref": "#/definitions/class"
-							}
+							},
+							"minItems": 1,
+							"uniqueItems": true
 						},
 						"fromClassListVariant": {
 							"type": "array",
 							"items": {
 								"$ref": "#/definitions/class"
-							}
+							},
+							"minItems": 1,
+							"uniqueItems": true
 						},
 						"fromSubclass": {
 							"type": "array",
@@ -256,7 +262,9 @@
 									"subclass"
 								],
 								"additionalProperties": false
-							}
+							},
+							"minItems": 1,
+							"uniqueItems": true
 						}
 					},
 					"additionalProperties": false
@@ -280,7 +288,9 @@
 							}
 						},
 						"required": ["name", "source"]
-					}
+					},
+					"minItems": 1,
+					"uniqueItems": true
 				},
 				"backgrounds": {
 					"type": "array",
@@ -295,7 +305,9 @@
 							}
 						},
 						"required": ["name", "source"]
-					}
+					},
+					"minItems": 1,
+					"uniqueItems": true
 				},
 				"eldritchInvocations": {
 					"type": "array",
@@ -310,7 +322,9 @@
 							}
 						},
 						"required": ["name", "source"]
-					}
+					},
+					"minItems": 1,
+					"uniqueItems": true
 				},
 				"source": {
 					"type": "string"
@@ -331,6 +345,7 @@
 				},
 				"damageResist": {
 					"type": "array",
+					"minItems": 1,
 					"uniqueItems": true,
 					"items": {
 						"$ref": "../util.json#/definitions/dataDamageType"
@@ -338,6 +353,7 @@
 				},
 				"damageImmune": {
 					"type": "array",
+					"minItems": 1,
 					"uniqueItems": true,
 					"items": {
 						"$ref": "../util.json#/definitions/dataDamageType"
@@ -345,6 +361,7 @@
 				},
 				"damageVulnerable": {
 					"type": "array",
+					"minItems": 1,
 					"uniqueItems": true,
 					"items": {
 						"$ref": "../util.json#/definitions/dataDamageType"
@@ -358,6 +375,7 @@
 				},
 				"savingThrow": {
 					"type": "array",
+					"minItems": 1,
 					"uniqueItems": true,
 					"items": {
 						"type": "string",
@@ -368,6 +386,7 @@
 				},
 				"abilityCheck": {
 					"type": "array",
+					"minItems": 1,
 					"uniqueItems": true,
 					"items": {
 						"type": "string",
@@ -378,6 +397,7 @@
 				},
 				"spellAttack": {
 					"type": "array",
+					"minItems": 1,
 					"uniqueItems": true,
 					"items": {
 						"type": "string",
@@ -390,6 +410,7 @@
 				"areaTags": {
 					"description": "By convention, only the effects of the spell cast at its base level are considered when populating these.\n C: Cube\n H: Hemisphere\n L: Line\n MT: Multiple Targets\n N: Cone\n Q: Square\n R: Circle\n ST: Single Target\n S: Sphere\n W: Wall\n Y: Cylinder",
 					"type": "array",
+					"minItems": 1,
 					"uniqueItems": true,
 					"items": {
 						"type": "string",
@@ -399,6 +420,7 @@
 				"miscTags": {
 					"type": "array",
 					"description": "FMV: Forced Movement\n HL: Healing\n LGT: Creates Light\n LGTS: Creates Sunlight\n MAC: Modifies AC\n PRM: Permanent Effects\n RO: Rollable Effects\n SCL: Scaling Effects\n  SMN: Summons Creature\n SGT: Requires Sight\n THP: Grants Temporary Hit Points\n TP: Teleportation",
+					"minItems": 1,
 					"uniqueItems": true,
 					"items": {
 						"type": "string",
@@ -407,6 +429,8 @@
 				},
 				"affectsCreatureType": {
 					"type": "array",
+					"minItems": 1,
+					"uniqueItems": true,
 					"items": {
 						"$ref": "../util.json#/definitions/creatureType"
 					}
@@ -618,7 +642,9 @@
 	"properties": {
 		"spell": {
 			"type": "array",
-			"items": {"$ref": "#/definitions/spell"}
+			"items": {"$ref": "#/definitions/spell"},
+			"minItems": 1,
+			"uniqueItems": true
 		},
 		"_meta": {
 			"$ref": "../util.json#/definitions/metaBlock"

--- a/test/schema-template/tables.json
+++ b/test/schema-template/tables.json
@@ -178,6 +178,7 @@
 	"properties": {
 		"table": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"$ref": "#/definitions/tableData"

--- a/test/schema-template/trapshazards.json
+++ b/test/schema-template/trapshazards.json
@@ -217,6 +217,7 @@
 	"properties": {
 		"trap": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"$ref": "#/definitions/trap"
@@ -224,6 +225,7 @@
 		},
 		"hazard": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"$ref": "#/definitions/hazard"

--- a/test/schema-template/util.json
+++ b/test/schema-template/util.json
@@ -396,14 +396,14 @@
 								"items": {
 									"$ref": "#/definitions/skillNameLower"
 								},
-								"uniqueItems": true
+								"uniqueItems": true,
+								"minItems": 2
 							},
 							"count": {
 								"type": "integer"
 							}
 						},
-						"additionalProperties": false,
-						"minItems": 2
+						"additionalProperties": false
 					}
 				},
 				"$$ifSite": {

--- a/test/schema-template/util.json
+++ b/test/schema-template/util.json
@@ -54,7 +54,8 @@
 				],
 				"additionalProperties": false
 			},
-			"uniqueItems": true
+			"uniqueItems": true,
+			"minItems": 1
 		},
 
 		"additionalSources": {
@@ -74,7 +75,8 @@
 				],
 				"additionalProperties": false
 			},
-			"uniqueItems": true
+			"uniqueItems": true,
+			"minItems": 1
 		},
 
 		"reprintedAs": {
@@ -102,7 +104,8 @@
 					}
 				]
 			},
-			"uniqueItems": true
+			"uniqueItems": true,
+			"minItems": 1
 		},
 
 		"tagNameStats": {
@@ -217,7 +220,8 @@
 					}
 				}
 			},
-			"uniqueItems": true
+			"uniqueItems": true,
+			"minItems": 1
 		},
 
 		"toolNameLower": {
@@ -312,7 +316,8 @@
 										{"type": "string", "enum": ["anyArtisansTool"]}
 									]
 								},
-								"uniqueItems": true
+								"uniqueItems": true,
+								"minItems": 2
 							},
 							"count": {
 								"type": "integer"
@@ -325,7 +330,8 @@
 					"additionalProperties": {"type": "boolean"}
 				}
 			},
-			"uniqueItems": true
+			"uniqueItems": true,
+			"minItems": 1
 		},
 
 		"skillNameLower": {
@@ -396,7 +402,8 @@
 								"type": "integer"
 							}
 						},
-						"additionalProperties": false
+						"additionalProperties": false,
+						"minItems": 2
 					}
 				},
 				"$$ifSite": {
@@ -507,7 +514,8 @@
 													{"$ref": "#/definitions/skillNameLower"},
 													{"type": "string", "enum": ["anySkill", "anyTool", "anyArtisansTool", "anyLanguage", "anyStandardLanguage"]}
 												]
-											}
+											},
+											"minItems": 2
 										},
 										"count": {"type": "integer"}
 									},
@@ -526,7 +534,8 @@
 								}
 							]
 						},
-						"uniqueItems": true
+						"uniqueItems": true,
+						"minItems": 1
 					}
 				},
 				"$$ifSite": {
@@ -536,7 +545,8 @@
 					"additionalProperties": {"type": "boolean"}
 				}
 			},
-			"uniqueItems": true
+			"uniqueItems": true,
+			"minItems": 1
 		},
 
 		"weaponProficiencies": {
@@ -604,7 +614,8 @@
 				},
 				"additionalProperties": false
 			},
-			"uniqueItems": true
+			"uniqueItems": true,
+			"minItems": 1
 		},
 
 		"armorProficiencies": {
@@ -619,7 +630,8 @@
 				},
 				"additionalProperties": false
 			},
-			"uniqueItems": true
+			"uniqueItems": true,
+			"minItems": 1
 		},
 
 		"savingThrowProficiencies": {
@@ -649,7 +661,8 @@
 										"cha"
 									]
 								},
-								"uniqueItems": true
+								"uniqueItems": true,
+								"minItems": 2
 							},
 							"count": {"type": "integer"}
 						},
@@ -659,7 +672,8 @@
 				},
 				"additionalProperties": false
 			},
-			"uniqueItems": true
+			"uniqueItems": true,
+			"minItems": 1
 		},
 
 		"expertise": {
@@ -725,7 +739,8 @@
 					"poisoner's kit": {"type": "boolean"}
 				}
 			},
-			"uniqueItems": true
+			"uniqueItems": true,
+			"minItems": 1
 		},
 
 		"additionalFeatsArray": {
@@ -737,7 +752,8 @@
 				},
 				"additionalProperties": {"type": "boolean"}
 			},
-			"uniqueItems": true
+			"uniqueItems": true,
+			"minItems": 1
 		},
 
 		"proficiencyTag": {
@@ -813,7 +829,8 @@
 											"swim"
 										]
 									},
-									"uniqueItems": true
+									"uniqueItems": true,
+									"minItems": 2
 								},
 								"amount": {
 									"type": "integer"
@@ -891,6 +908,7 @@
 
 		"prerequisite": {
 			"type": "array",
+			"minItems": 1,
 			"items": {
 				"type": "object",
 				"properties": {
@@ -1267,7 +1285,8 @@
 							}
 						]
 					},
-					"uniqueItems": true
+					"uniqueItems": true,
+					"minItems": 1
 				},
 				{
 					"type": "null"
@@ -1341,7 +1360,8 @@
 							}
 						]
 					},
-					"uniqueItems": true
+					"uniqueItems": true,
+					"minItems": 1
 				},
 				{
 					"type": "null"
@@ -1372,7 +1392,8 @@
 					}
 				]
 			},
-			"uniqueItems": true
+			"uniqueItems": true,
+			"minItems": 1
 		},
 
 		"damageVulnerabilityArray":  {
@@ -1446,7 +1467,8 @@
 					}
 				]
 			},
-			"uniqueItems": true
+			"uniqueItems": true,
+			"minItems": 1
 		},
 
 		"conditionImmunityArray": {
@@ -1486,7 +1508,8 @@
 							}
 						]
 					},
-					"uniqueItems": true
+					"uniqueItems": true,
+					"minItems": 1
 				},
 				{
 					"type": "null"
@@ -1517,7 +1540,8 @@
 					}
 				]
 			},
-			"uniqueItems": true
+			"uniqueItems": true,
+			"minItems": 1
 		},
 
 		"resourcesArray": {
@@ -1632,6 +1656,7 @@
 
 		"genericFluffArray": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"anyOf": [
@@ -2098,6 +2123,7 @@
 
 		"versionsArray": {
 			"type": "array",
+			"minItems": 1,
 			"items": {
 				"$ref": "#/definitions/version"
 			}
@@ -2251,6 +2277,7 @@
 
 		"_additionalSpellArrayOfStringOrChoiceObject": {
 			"type": "array",
+			"minItems": 1,
 			"items": {
 				"oneOf": [
 					{"type": "string"},
@@ -2295,6 +2322,7 @@
 		"additionalSpellsArray": {
 			"description": "A collection of additional spells which a feature grants.\nThis array enables import functionality for VTTs, and should be used in addition to \"classSpells\"/\"subclassSpells\"/\"subSubclassSpells\" blocks which enable references on the site.",
 			"type": "array",
+			"minItems": 1,
 			"items": {
 				"type": "object",
 				"properties": {
@@ -2460,6 +2488,7 @@
 
 		"reqAttuneTags": {
 			"type": "array",
+			"minItems": 1,
 			"items": {
 				"type": "object",
 				"properties": {
@@ -2492,11 +2521,13 @@
 
 		"adventureBookData": {
 			"type": "array",
-			"items": {"$ref": "entry.json"}
+			"items": {"$ref": "entry.json"},
+			"minItems": 1
 		},
 
 		"optionalfeatureProgression": {
 			"type": "array",
+			"minItems": 1,
 			"items": {
 				"type": "object",
 				"properties": {
@@ -2569,6 +2600,7 @@
 
 		"foundryAdvancementsArray": {
 			"type": "array",
+			"minItems": 1,
 			"items": {"$ref": "#/definitions/foundryAdvancementObject"},
 			"uniqueItems": true
 		},
@@ -2609,11 +2641,13 @@
 		"foundryEffectsArray": {
 			"type": "array",
 			"items": {"$ref": "#/definitions/foundryEffectObject"},
+			"minItems": 1,
 			"uniqueItems": true
 		},
 
 		"foundrySideDataGenericArray": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"type": "object",
@@ -2635,6 +2669,7 @@
 
 		"foundrySideDataGenericFeatureArray": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"type": "object",

--- a/test/schema-template/variantrules.json
+++ b/test/schema-template/variantrules.json
@@ -8,6 +8,7 @@
 	"properties": {
 		"variantrule": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {"$ref": "#/definitions/variantrule"}
 		}

--- a/test/schema-template/vehicles.json
+++ b/test/schema-template/vehicles.json
@@ -689,6 +689,7 @@
 	"properties": {
 		"vehicle": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"$ref": "#/definitions/vehicle"
@@ -696,6 +697,7 @@
 		},
 		"vehicleUpgrade": {
 			"type": "array",
+			"minItems": 1,
 			"uniqueItems": true,
 			"items": {
 				"$ref": "#/definitions/vehicleUpgrade"


### PR DESCRIPTION
## Note that: 
- Some duplicate data has been cleaned
- The schema does not check for empty monster arrays on the site because of `bestiary-nrh-tlt.json`
- A small change was made to `items-base.json` to satisfy strict type checks
- Some `choose` arrays have `minItems` set to `2` where they do not use filter strings
- The schema version numbers have not been incremented

## Working as anticipated:
![image](https://user-images.githubusercontent.com/52298102/196528188-1112e66e-d963-4e4e-b0d2-e7af2de3f835.png)
