### PR TITLE
ci(release): Generate release notes from changelog.json

### DIFF
--- a/.github/generate-release-notes.sh
+++ b/.github/generate-release-notes.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -e
+
+if [[ $# -eq 0 ]]; then
+    echo "No arguments provided. Usage: generate-release-notes.sh <version>"
+    exit 1
+fi
+
+version=$1
+
+# Release version number without "v" prefix to match the format of changelog.json.
+version_number="${version#v}"
+
+# This parses the JSON blob for this specific version from changelog.json.
+changelog="$(
+    jq --arg version "$version_number" --compact-output \
+    '.[] | select(.ver == $version)'                    \
+    data/changelog.json
+)"
+
+if [[ -z "$changelog" ]]; then
+    echo "Changelog entry for version $version does not exist."
+    exit 1
+fi
+
+{
+    # The "hub" tool reads all text up to the first empty line as the release
+    # title.
+    # * For changelog entries with a title, this is formatted as
+    #   '<version>, "<title>" Edition' to match the format of the site's
+    #   changelog page.
+    #
+    # * For changelog entries without a title, this is formatted as simply
+    #   '<version>'.
+    echo -n "$version"
+    jq -r 'if has("title") then ", \(.title | tojson) Edition\n" else "\n" end' <<< "$changelog"
+
+    # Some changelogs include an alternate title. This is included in the body
+    # of the release notes and formatted as 'AKA "<altTitle>" Edition' to match
+    # the site's changelog page.
+    jq -j 'if has("titleAlt") then "AKA \(.titleAlt | tojson) Edition\n" else "" end' <<< "$changelog"
+
+    # Changelog text is already markdown-formatted, so no additional formatting
+    # needs to be done here.
+    jq -r '.txt' <<< "$changelog"
+}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -23,8 +23,11 @@ jobs:
          -  uses: actions/checkout@master
 
          # See: https://stackoverflow.com/a/58178121
-         -  name: Set Env
+         -  name: Set Release Version
             run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+         -  name: Generate Release Notes
+            run: bash ./.github/generate-release-notes.sh ${{ env.RELEASE_VERSION }} | tee RELEASE_NOTES.md
 
          -  name: Archive Release
             run: |
@@ -37,7 +40,7 @@ jobs:
          -  name: Upload Release
             # Add the files one-by-one in an effort to avoid timeouts
             run: |
-               hub release create -a 5etools-${{ env.RELEASE_VERSION }}.zip -m ${{ env.RELEASE_VERSION }} ${{ env.RELEASE_VERSION }}
+               hub release create -a 5etools-${{ env.RELEASE_VERSION }}.zip -F RELEASE_NOTES.md ${{ env.RELEASE_VERSION }}
                for f in $(find . -name 'img-${{ env.RELEASE_VERSION }}.*' -print); do hub release edit ${{ env.RELEASE_VERSION }} -m '' -a $f; done
             env:
                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request adds a script to generate release notes to Github Releases from `data/changelog.json`. To validate the script functionality, I've used the Github workflow to generate [a release for the latest tag](https://github.com/wmedlar/5etools-mirror-1.github.io/releases/tag/v1.169.0) on my fork.

The script has been included in the release workflow, but can also be run independently of the release process for changelog introspection. Below are some examples of the script behavior.

<details>
<summary>Version without a title.</summary>

```shell
$ bash .github/generate-release-notes.sh v1.0.0  
v1.0.0

(Lost to time.)
```

</details>

<details>
<summary>Version with a title.</summary>

```shell
$ bash .github/generate-release-notes.sh v1.58.0
v1.58.0, "Bad at Version Numbers, Good at Friends" Edition

- Added a Shaped Companion Script data builder: https://5e.tools/makeshaped.html (courtesy of @ herodotus, the author of the Companion Script)
- Added Wayfarer's Guide to Eberron. Includes items, feats, (more) races, and optional/variant rules. We're (or at least I am, and I know Dusk agrees) categorising the entire book as Unearthed Arcana, for the time being.
- Added "Lock" button to DM Screen initiative tracker (credit @ BaumMeister)
- Invocation homebrew now supports custom level requirements
- Homebrew deletion performance no longer awful (credit @ herodotus)
- Statblock Converter now displays warning/errors, and handles a slightly greater range of garbage input
- (Typo fixes/rendering improvements)
```

</details>

<details>
<summary>Version with an alt-text title.</summary>

```shell
$ bash .github/generate-release-notes.sh v1.124.0
v1.124.0, "Folk Tales" Edition

AKA "Me → 💀🍷 ← That Fey Shit" Edition
- Added UA 2021 Folk of the Feywild
- Added rudimentary text indexing to list pages; this can be used by searching `text:<text>`. Note that this only searches the body text of entities, and so will not search creature types, spell durations, etc. (generally, anything covered by a filter will not be searchable as text, and vice versa).
- Added "Randomly Assign" button to Statgen Roll and Standard Array tabs
- Added Blocklist support for recipes
- Added Sunlight Sensitivity filter to Races page
- (Homebrew) Fixed custom image max sizing breaking layout
- (Fixed typos/added tags)
```

</details>

<details>
<summary>Version without a changelog entry.</summary>

```shell
$ bash .github/generate-release-notes.sh v420.69 
Changelog entry for version v420.69 does not exist.
$ echo $?
1
```

</details>

This was a fun lil change to work on that I hope improves visibility of changes for users that maintain mirrors of the site.