### PR TITLE
Update Triton (VGM) race's Fog Cloud to daily use

### DIFF
--- a/data/races.json
+++ b/data/races.json
@@ -13258,9 +13258,13 @@
 			"additionalSpells": [
 				{
 					"innate": {
-						"1": [
-							"fog cloud"
-						],
+						"1": {
+							"daily": {
+								"1": [
+									"fog cloud"
+								]
+							}
+						},
 						"3": {
 							"daily": {
 								"1": [


### PR DESCRIPTION
This PR aims to fix a small entry error for Tritons in VGM.

Fog Cloud seem to have been omitted from its daily usage limit when using it with its trait.