### PR TITLE
Predefined actions patch

### DIFF
--- a/data/makebrew-creature.json
+++ b/data/makebrew-creature.json
@@ -1409,5 +1409,814 @@
 				"The <$name$> ignores movement restrictions caused by webbing."
 			]
 		}
-	]
+	],
+    "#makebrewCreatureAction": "No idea if I actually need this, but just in case...",
+    "makebrewCreatureAction":
+    [
+        {
+            "name": "Club",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 5 ft., one target. {@h}<$damage_avg__2.5+str$> ({@damage 1d4<$damage_mod__str$>}) bludgeoning damage."
+            ]
+        },
+        {
+            "name": "Dagger",
+            "entries":
+            [
+                "{@atk rw} {@hit <$to_hit__dex$>} to hit, reach 5 ft. or range 20/60 ft., one target. {@h}<$damage_avg__2.5+dex$> ({@damage 1d4<$damage_mod__dex$>}) piercing damage."
+            ]
+        },
+        {
+            "name": "Flail",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 5 ft., one target. {@h}<$damage_avg__4+str$> ({@damage 1d8<$damage_mod__str$>}) bludgeoning damage."
+            ]
+        },
+        {
+            "name": "Glaive / Halberd",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} reach 10 ft., one target. {@h}<$damage_avg__5+str$> ({@damage 1d10<$damage_mod__str$>})"
+            ]
+        },
+        {
+            "name": "Greataxe",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 5 ft., one target. {@h}<$damage_avg__6+str$> ({@damage 1d12<$damage_mod__str$>}) slashing damage."
+            ]
+        },
+        {
+            "name": "Greatsword",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 5 ft., one target. {@h}<$damage_avg__7+str$> ({@damage 2d6<$damage_mod__str$>}) slashing damage."
+            ]
+        },
+        {
+            "name": "Hand Crossbow",
+            "entries":
+            [
+                "{@atk rw} {@hit <$to_hit__dex$>} to hit, range 30/120 ft., one target. {@h}<$damage_avg__3+dex$> ({@damage 1d6<$damage_mod__dex$>}) piercing damage."
+            ]
+        },
+        {
+            "name": "Heavy Crossbow",
+            "entries":
+            [
+                "{@atk rw} {@hit <$to_hit__dex$>} to hit, range 100/400 ft., one target. {@h}<$damage_avg__5+dex$> ({@damage 1d10<$damage_mod__dex$>}) piercing damage."
+            ]
+        },
+        {
+            "name": "Javelin",
+            "entries":
+            [
+                "{@atk mw,rw} {@hit <$to_hit__str$>} to hit, reach 5 ft. or range 30/120 ft., one target. {@h}<$damage_avg__3+str$> ({@damage 1d6<$damage_mod__str$>}) piercing damage."
+            ]
+        },
+        {
+            "name": "Light Crossbow",
+            "entries":
+            [
+                "{@atk rw} {@hit <$to_hit__dex$>} to hit, range 80/320 ft., one target. {@h}<$damage_avg__4+dex$> ({@damage 1d8<$damage_mod__dex$>}) piercing damage."
+            ]
+        },
+        {
+            "name": "Light Hammer",
+            "entries":
+            [
+                "{@atk mw,rw} {@hit <$to_hit__str$>} to hit, reach 5 ft. or range 20/60 ft., one target. {@h}<$damage_avg__3+str$> ({@damage 1d6<$damage_mod__str$>}) bludgeoning damage."
+            ]
+        },
+        {
+            "name": "Longbow",
+            "entries":
+            [
+                "{@atk rw} {@hit <$to_hit__dex$>} to hit, range 150/600 ft., one target. {@h}<$damage_avg__3+str$> ({@damage 1d6<$damage_mod__str$>}) piercing damage."
+            ]
+        },
+        {
+            "name": "Longsword",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 5 ft., one target. {@h}<$damage_avg__4+str$> ({@damage 1d8<$damage_mod__str$>}) slashing damage."
+            ]
+        },
+        {
+            "name": "Mace",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 5 ft., one target. {@h}<$damage_avg__3+str$> ({@damage 1d6<$damage_mod__str$>}) bludgeoning damage."
+            ]
+        },
+        {
+            "name": "Maul",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 5 ft., one target. {@h}<$damage_avg__7+str$> ({@damage 2d6<$damage_mod__str$>}) bludgeoning damage."
+            ]
+        },
+        {
+            "name": "Net",
+            "entries":
+            [
+                "{@atk rw} {@hit <$to_hit__str$>} to hit, range 5/15 ft., one Large or smaller creature. {@h}The target is {@condition restrained}. A creature can use its action to make a {@dc 10} Strength check to free itself or another creature in a net, ending the effect on a success. Dealing 5 slashing damage to the net (AC 10) frees the target without harming it and destroys the net."
+            ]
+        },
+        {
+            "name": "Scimitar",
+            "entries":
+            [
+                "{@atk rw} {@hit <$to_hit__dex$>} to hit, reach 5 ft., one target. {@h}<$damage_avg__3+dex$> ({@damage 1d6<$damage_mod__dex$>}) slashing damage."
+            ]
+        },
+        {
+            "name": "Shortbow",
+            "entries":
+            [
+                "{@atk rw} {@hit <$to_hit__dex$>} to hit, range 80/320 ft., one target. {@h}<$damage_avg__3+dex$> ({@damage 1d6<$damage_mod__dex$>}) piercing damage."
+            ]
+        },
+        {
+            "name": "Shortsword",
+            "entries":
+            [
+                "{@atk rw} {@hit <$to_hit__dex$>} to hit, reach 5 ft., one target. {@h}<$damage_avg__3+dex$> ({@damage 1d6<$damage_mod__dex$>}) piercing damage."
+            ]
+        },
+        {
+            "name": "Sling",
+            "entries":
+            [
+                "{@atk rw} {@hit <$to_hit__dex$>} to hit, range 30/120 ft., one target. {@h}<$damage_avg__2.5+dex$> ({@damage 1d4<$damage_mod__dex$>}) bludgeoning damage."
+            ]
+        },
+        {
+            "name": "Spear / Trident",
+            "entries":
+            [
+                "{@atk mw,rw} {@hit <$to_hit__str$>} to hit, reach 5 ft. or range 20/60 ft., one target. {@h}<$damage_avg__3+str$> ({@damage 1d6<$damage_mod__str$>}) piercing damage, or <$damage_avg__4+str$> ({@damage 1d8<$damage_mod__str$>}) piercing damage if used with two hands to make a melee attack."
+            ]
+        },
+        {
+            "name": "Warhammer",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 5 ft., one target. {@h}<$damage_avg__4+str$> ({@damage 1d8<$damage_mod__str$>}) bludgeoning damage, or <$damage_avg__5+dex$> ({@damage 1d10<$damage_mod__dex$>}) bludgeoning damage if used with two hands to make a melee attack."
+            ]
+        },
+        {
+            "name": "Whip",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__dex$>} to hit, reach 10 ft., one target. {@h}<$damage_avg__2.5+dex$> ({@damage 1d4<$damage_mod__dex$>}) slashing damage."
+            ]
+        },
+        {
+            "name": "Acid Spray (Ankheg)",
+            "entries":
+            [
+                "The <$name$> spits acid in a line that is 30 feet long and 5 feet wide, provided that it has no creature {@condition grappled}. Each creature in that line must make a DC <$dc__dex$> Dexterity saving throw, taking 10 ({@damage 3d6}) acid damage on a failed save, or half as much damage on a successful one."
+            ]
+        },
+        {
+            "name": "Animate Chains (Chain Devil)",
+            "entries":
+            [
+                "Up to four chains the <$name$> can see within 60 feet of it magically sprout razor-edged barbs and animate under the <$name$>'s control, provided that the chains aren't being worn or carried.",
+                "Each animated chain is an object with AC 20, 20 hit points, resistance to piercing damage, and immunity to psychic and thunder damage. When the <$name$> uses Multiattack on its turn, it can use each animated chain to make one additional chain attack. An animated chain can grapple one creature of its own but can't make attacks while grappling. An animated chain reverts to its inanimate state if reduced to 0 hit points or if the <$name$> is {@condition incapacitated} or dies."
+            ]
+        },
+        {
+            "name": "Beard (Bearded Devil)",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 5 ft., one creature. {@h}<$damage_avg__5+str$> ({@damage 1d8<$damage_mod__str$>}) piercing damage, and the target must succeed on a DC <$dc__con$> Constitution saving throw or be {@condition poisoned} for 1 minute. While {@condition poisoned} in this way, the target can't regain hit points. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+            ]
+        },
+        {
+            "name": "Bite (Cloaker)",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 5 ft., one creature. {@h}10 ({@damage 2d6 + 3}) piercing damage, and if the target is Large or smaller, the <$name$> attaches to it. If the <$name$> has advantage against the target, the <$name$> attaches to the target's head, and the target is {@condition blinded} and unable to breathe while the <$name$> is attached. While attached, the <$name$> can make this attack only against the target and has advantage on the attack roll. The <$name$> can detach itself by spending 5 feet of its movement. A creature, including the target, can take its action to detach the <$name$> by succeeding on a {@dc 16} Strength check."
+            ]
+        },
+        {
+            "name": "Bite (Cockatrice)",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 5 ft., one creature. {@h}3 ({@damage 1d4 + 1}) piercing damage, and the target must succeed on a {@dc 11} Constitution saving throw against being magically {@condition petrified}. On a failed save, the creature begins to turn to stone and is {@condition restrained}. It must repeat the saving throw at the end of its next turn. On a success, the effect ends. On a failure, the creature is {@condition petrified} for 24 hours."
+            ]
+        },
+        {
+            "name": "Bite (Death Dog)",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 5 ft., one target. {@h}5 ({@damage 1d6 + 2}) piercing damage. If the target is a creature, it must succeed on a {@dc 12} Constitution saving throw against disease or become {@condition poisoned} until the disease is cured. Every 24 hours that elapse, the creature must repeat the saving throw, reducing its hit point maximum by 5 ({@dice 1d10}) on a failure. This reduction lasts until the disease is cured. The creature dies if the disease reduces its hit point maximum to 0."
+            ]
+        },
+        {
+            "name": "Bite (Kraken)",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 5 ft., one target. {@h}23 ({@damage 3d8 + 10}) piercing damage. If the target is a Large or smaller creature {@condition grappled} by the <$name$>, that creature is swallowed, and the grapple ends. While swallowed, the creature is {@condition blinded} and {@condition restrained}, it has total cover against attacks and other effects outside the <$name$>, and it takes 42 ({@damage 12d6}) acid damage at the start of each of the <$name$>'s turns. If the <$name$> takes 50 damage or more on a single turn from a creature inside it, the <$name$> must succeed on a {@dc 25} Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, which fall {@condition prone} in a space within 10 feet of the <$name$>. If the <$name$> dies, a swallowed creature is no longer {@condition restrained} by it and can escape from the corpse using 15 feet of movement, exiting {@condition prone}."
+            ]
+        },
+        {
+            "name": "Blinding Breath (Dust Mephit)",
+            "entries":
+            [
+                "The <$name$> exhales a 15-foot cone of blinding dust. Each creature in that area must succeed on a {@dc 10} Dexterity saving throw or be {@condition blinded} for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+            ]
+        },
+        {
+            "name": "Chain (Chain Devil)",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 10 ft., one target. {@h}11 ({@damage 2d6 + 4}) slashing damage. The target is {@condition grappled} (escape {@dc 14}) if the <$name$> isn't already grappling a creature. Until this grapple ends, the target is {@condition restrained} and takes 7 ({@damage 2d6}) piercing damage at the start of each of its turns."
+            ]
+        },
+        {
+            "name": "Change Shape (Couatl)",
+            "entries":
+            [
+                "The <$name$> magically polymorphs into a humanoid or beast that has a challenge rating equal to or less than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the <$name$>'s choice).",
+                "In a new form, the <$name$> retains its game statistics and ability to speak, but its AC, movement modes, Strength, Dexterity, and other actions are replaced by those of the new form, and it gains any statistics and capabilities (except class features, legendary actions, and lair actions) that the new form has but that it lacks. If the new form has a bite attack, the <$name$> can use its bite in that form."
+            ]
+        },
+        {
+            "name": "Change Shape (Oni)",
+            "entries":
+            [
+                "The <$name$> magically polymorphs into a Small or Medium humanoid, into a Large giant, or back into its true form. Other than its size, its statistics are the same in each form. The only equipment that is transformed is its glaive, which shrinks so that it can be wielded in humanoid form. If the <$name$> dies, it reverts to its true form, and its glaive reverts to its normal size."
+            ]
+        },
+        {
+            "name": "Charm (Succubus/Incubus)",
+            "entries":
+            [
+                "One humanoid the <$name$> can see within 30 feet of it must succeed on a DC <$dc__wis$> Wisdom saving throw or be magically {@condition charmed} for 1 day. The {@condition charmed} target obeys the <$name$>'s verbal or telepathic commands. If the target suffers any harm or receives a suicidal command, it can repeat the saving throw, ending the effect on a success. If the target successfully saves against the effect, or if the effect on it ends, the target is immune to this <$name$>'s Charm for the next 24 hours.",
+                "The <$name$> can have only one target {@condition charmed} at a time. If it charms another, the effect on the previous target ends."
+            ]
+        },
+        {
+            "name": "Claw (Rakshasa)",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 5 ft., one target. {@h}9 ({@damage 2d6 + 2}) slashing damage, and the target is cursed if it is a creature. The magical curse takes effect whenever the target takes a short or long rest, filling the target's thoughts with horrible images and dreams. The cursed target gains no benefit from finishing a short or long rest. The curse lasts until it is lifted by a {@spell remove curse} spell or similar magic."
+            ]
+        },
+        {
+            "name": "Constrict (Behir)",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 5 ft., one Large or smaller creature. {@h}17 ({@damage 2d10 + 6}) bludgeoning damage plus 17 ({@damage 2d10 + 6}) slashing damage. The target is {@condition grappled} (escape {@dc 16}) if the <$name$> isn't already constricting a creature, and the target is {@condition restrained} until this grapple ends."
+            ]
+        },
+        {
+            "name": "Constrict (Constrictor Snake)",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 5 ft., one creature. {@h}6 ({@damage 1d8 + 2}) bludgeoning damage, and the target is {@condition grappled} (escape {@dc 14}). Until this grapple ends, the creature is {@condition restrained}, and the <$name$> can't constrict another target."
+            ]
+        },
+        {
+            "name": "Create Specter (Wraith)",
+            "entries":
+            [
+                "The <$name$> targets a humanoid within 10 feet of it that has been dead for no longer than 1 minute and died violently. The target's spirit rises as a {@creature specter} in the space of its corpse or in the nearest unoccupied space. The {@creature specter} is under the <$name$>'s control. The <$name$> can have no more than seven specters under its control at one time."
+            ]
+        },
+        {
+            "name": "Create Whirlwind (Djinni)",
+            "entries":
+            [
+                "A 5-foot-radius, 30-foot-tall cylinder of swirling air magically forms on a point the <$name$> can see within 120 feet of it. The whirlwind lasts as long as the <$name$> maintains concentration (as if concentrating on a spell). Any creature but the <$name$> that enters the whirlwind must succeed on a {@dc 18} Strength saving throw or be {@condition restrained} by it. The <$name$> can move the whirlwind up to 60 feet as an action, and creatures {@condition restrained} by the whirlwind move with it. The whirlwind ends if the <$name$> loses sight of it.",
+                "A creature can use its action to free a creature {@condition restrained} by the whirlwind, including itself, by succeeding on a {@dc 18} Strength check. If the check succeeds, the creature is no longer {@condition restrained} and moves to the nearest space outside the whirlwind."
+            ]
+        },
+        {
+            "name": "Crush (Darkmantle)",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 5 ft., one creature. {@h}6 ({@damage 1d6 + 3}) bludgeoning damage, and the <$name$> attaches to the target. If the target is Medium or smaller and the <$name$> has advantage on the attack roll, it attaches by engulfing the target's head, and the target is also {@condition blinded} and unable to breathe while the <$name$> is attached in this way.",
+                "While attached to the target, the <$name$> can attack no other creature except the target but has advantage on its attack rolls. The <$name$>'s speed also becomes 0, it can't benefit from any bonus to its speed, and it moves with the target.",
+                "A creature can detach the <$name$> by making a successful {@dc 13} Strength check as an action. On its turn, the <$name$> can detach itself from the target by using 5 feet of movement."
+            ]
+        },
+        {
+            "name": "Darkness Aura (Darkmantle)",
+            "entries":
+            [
+                "A 15-foot radius of magical darkness extends out from the <$name$>, moves with it, and spreads around corners. The darkness lasts as long as the <$name$> maintains concentration, up to 10 minutes (as if concentrating on a spell). Darkvision can't penetrate this darkness, and no natural light can illuminate it. If any of the darkness overlaps with an area of light created by a spell of 2nd level or lower, the spell creating the light is dispelled."
+            ]
+        },
+        {
+            "name": "Deadly Leap (Bulette)",
+            "entries":
+            [
+                "If the <$name$> jumps at least 15 feet as part of its movement, it can then use this action to land on its feet in a space that contains one or more other creatures. Each of those creatures must succeed on a {@dc 16} Strength or Dexterity saving throw (target's choice) or be knocked {@condition prone} and take 14 ({@damage 3d6 + 4}) bludgeoning damage plus 14 ({@damage 3d6 + 4}) slashing damage. On a successful save, the creature takes only half the damage, isn't knocked {@condition prone}, and is pushed 5 feet out of the <$name$>'s space into an unoccupied space of the creature's choice. If no unoccupied space is within range, the creature instead falls {@condition prone} in the <$name$>'s space."
+            ]
+        },
+        {
+            "name": "Death Glare (Sea Hag)",
+            "entries":
+            [
+                "The <$name$> targets one {@condition frightened} creature she can see within 30 feet of it. If the target can see the <$name$>, it must succeed on a DC <$dc__wis$> Wisdom saving throw against this magic or drop to 0 hit points."
+            ]
+        },
+        {
+            "name": "Disrupt Life (Lich)",
+            "entries":
+            [
+                "Each non-undead creature within 20 feet of the <$name$> must make a {@dc 18} Constitution saving throw against this magic, taking 21 ({@damage 6d6}) necrotic damage on a failed save, or half as much damage on a successful one."
+            ]
+        },
+        {
+            "name": "Draining Kiss (Succubus/Incubus)",
+            "entries":
+            [
+                "The <$name$> kisses a creature {@condition charmed} by it or a willing creature. The target must make a {@dc 15} Constitution saving throw against this magic, taking 32 ({@damage 5d10 + 5}) psychic damage on a failed save, or half as much damage on a successful one. The target's hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0."
+            ]
+        },
+        {
+            "name": "Dreadful Glare (Mummy Lord)",
+            "entries":
+            [
+                "The <$name$> targets one creature it can see within 60 feet of it. If the target can see the <$name$>, it must succeed on a DC <$dc__wis$> Wisdom saving throw against this magic or become {@condition frightened} until the end of the mummy's next turn. If the target fails the saving throw by 5 or more, it is also {@condition paralyzed} for the same duration. A target that succeeds on the saving throw is immune to the Dreadful Glare of all mummies and <$name$>s for the next 24 hours."
+            ]
+        },
+        {
+            "name": "Engulf (Gelatinous Cube)",
+            "entries":
+            [
+                "The <$name$> moves up to its speed. While doing so, it can enter Large or smaller creatures' spaces. Whenever the <$name$> enters a creature's space, the creature must make a DC <$dc__dex$> Dexterity saving throw.",
+                "On a successful save, the creature can choose to be pushed 5 feet back or to the side of the <$name$>. A creature that chooses not to be pushed suffers the consequences of a failed saving throw.",
+                "On a failed save, the <$name$> enters the creature's space, and the creature takes 10 ({@damage 3d6}) acid damage and is engulfed. The engulfed creature can't breathe, is {@condition restrained}, and takes 21 ({@damage 6d6}) acid damage at the start of each of the <$name$>'s turns. When the <$name$> moves, the engulfed creature moves with it.",
+                "An engulfed creature can try to escape by taking an action to make a {@dc 12} Strength check. On a success, the creature escapes and enters a space of its choice within 5 feet of the <$name$>."
+            ]
+        },
+        {
+            "name": "Engulf (Shambling Mound)",
+            "entries":
+            [
+                "The <$name$> engulfs a Medium or smaller creature {@condition grappled} by it. The engulfed target is {@condition blinded}, {@condition restrained}, and unable to breathe, and it must succeed on a {@dc 14} Constitution saving throw at the start of each of the <$name$>'s turns or take 13 ({@damage 2d8 + 4}) bludgeoning damage. If the <$name$> moves, the engulfed target moves with it. The <$name$> can have only one creature engulfed at a time."
+            ]
+        },
+        {
+            "name": "Enlarge (Duergar)",
+            "entries":
+            [
+                "For 1 minute, the <$name$> magically increases in size, along with anything it is wearing or carrying. While enlarged, the <$name$> is Large, doubles its damage dice on Strength-based weapon attacks (included in the attacks), and makes Strength checks and Strength saving throws with advantage. If the <$name$> lacks the room to become Large, it attains the maximum size possible in the space available."
+            ]
+        },
+        {
+            "name": "Enslave (Aboleth)",
+            "entries":
+            [
+                "The <$name$> targets one creature it can see within 30 feet of it. The target must succeed on a DC <$dc__wis$> Wisdom saving throw or be magically {@condition charmed} by the <$name$> until the <$name$> dies or until it is on a different plane of existence from the target. The {@condition charmed} target is under the <$name$>'s control and can't take reactions, and the <$name$> and the target can communicate telepathically with each other over any distance.",
+                "Whenever the {@condition charmed} target takes damage, the target can repeat the saving throw. On a success, the effect ends. No more than once every 24 hours, the target can also repeat the saving throw when it is at least 1 mile away from the <$name$>."
+            ]
+        },
+        {
+            "name": "Etherealness (Ghost)",
+            "entries":
+            [
+                "The <$name$> enters the Ethereal Plane from the Material Plane, or vice versa. It is visible on the Material Plane while it is in the Border Ethereal, and vice versa, yet it can't affect or be affected by anything on the other plane."
+            ]
+        },
+        {
+            "name": "Etherealness (Succubus/Incubus)",
+            "entries":
+            [
+                "The <$name$> enters the Ethereal Plane from the Material Plane, or vice versa."
+            ]
+        },
+        {
+            "name": "Ethereal Stride (Nightmare)",
+            "entries":
+            [
+                "The <$name$> and up to three willing creatures within 5 feet of it magically enter the Ethereal Plane from the Material Plane, or vice versa."
+            ]
+        },
+        {
+            "name": "Fetid Cloud (Dretch)",
+            "entries":
+            [
+                "A 10-foot radius of disgusting green gas extends out from the <$name$>. The gas spreads around corners, and its area is lightly obscured. It lasts for 1 minute or until a strong wind disperses it. Any creature that starts its turn in that area must succeed on a {@dc 11} Constitution saving throw or be {@condition poisoned} until the start of its next turn. While {@condition poisoned} in this way, the target can take either an action or a bonus action on its turn, not both, and can't take reactions."
+            ]
+        },
+        {
+            "name": "Fey Charm (Dryad)",
+            "entries":
+            [
+                "The <$name$> targets one humanoid or beast that she can see within 30 feet of her. If the target can see the <$name$>, it must succeed on a DC <$dc__wis$> Wisdom saving throw or be magically {@condition charmed}. The {@condition charmed} creature regards the <$name$> as a trusted friend to be heeded and protected. Although the target isn't under the <$name$>'s control, it takes the <$name$>'s requests or actions in the most favorable way it can.",
+                "Each time the <$name$> or its allies do anything harmful to the target, it can repeat the saving throw, ending the effect on itself on a success. Otherwise, the effect lasts 24 hours or until the <$name$> dies, is on a different plane of existence from the target, or ends the effect as a bonus action. If a target's saving throw is successful, the target is immune to the <$name$>'s Fey Charm for the next 24 hours.",
+                "The <$name$> can have no more than one humanoid and up to three beasts {@condition charmed} at a time."
+            ]
+        },
+        {
+            "name": "Fling (Kraken)",
+            "entries":
+            [
+                "One Large or smaller object held or creature {@condition grappled} by the <$name$> is thrown up to 60 feet in a random direction and knocked {@condition prone}. If a thrown target strikes a solid surface, the target takes 3 ({@damage 1d6}) bludgeoning damage for every 10 feet it was thrown. If the target is thrown at another creature, that creature must succeed on a {@dc 18} Dexterity saving throw or take the same damage and be knocked {@condition prone}."
+            ]
+        },
+        {
+            "name": "Flying Sword (Solar)",
+            "entries":
+            [
+                "The <$name$> releases its greatsword to hover magically in an unoccupied space within 5 feet of it. If the <$name$> can see the sword, the <$name$> can mentally command it as a bonus action to fly up to 50 feet and either make one attack against a target or return to the <$name$>'s hands. If the hovering sword is targeted by any effect, the <$name$> is considered to be holding it. The hovering sword falls if the <$name$> dies."
+            ]
+        },
+        {
+            "name": "Frightening Gaze (Lich)",
+            "entries":
+            [
+                "The <$name$> fixes its gaze on one creature it can see within 10 feet of it. The target must succeed on a DC <$dc__wis$> Wisdom saving throw against this magic or become {@condition frightened} for 1 minute. The {@condition frightened} target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a target's saving throw is successful or the effect ends for it, the target is immune to the <$name$>'s gaze for the next 24 hours."
+            ]
+        },
+        {
+            "name": "Frightful Presence (Dragon)",
+            "entries":
+            [
+                "Each creature of the <$name$>'s choice that is within 120 feet of the <$name$> and aware of it must succeed on a DC <$dc__wis$> Wisdom saving throw or become {@condition frightened} for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the <$name$>'s Frightful Presence for the next 24 hours."
+            ]
+        },
+        {
+            "name": "Frightful Presence (Tarrasque)",
+            "entries":
+            [
+                "Each creature of the <$name$>'s choice within 120 feet of it and aware of it must succeed on a DC <$dc__wis$> Wisdom saving throw or become {@condition frightened} for 1 minute. A creature can repeat the saving throw at the end of each of its turns, with disadvantage if the <$name$> is within line of sight, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the <$name$>'s Frightful Presence for the next 24 hours."
+            ]
+        },
+        {
+            "name": "Glaive (Bearded Devil)",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 10 ft., one target. {@h}8 ({@damage 1d10 + 3}) slashing damage. If the target is a creature other than an undead or a construct, it must succeed on a {@dc 12} Constitution saving throw or lose 5 ({@dice 1d10}) hit points at the start of each of its turns due to an infernal wound. Each time the <$name$> hits the wounded target with this attack, the damage dealt by the wound increases by 5 ({@dice 1d10}). Any creature can take an action to stanch the wound with a successful {@dc 12} Wisdom (Medicine) check. The wound also closes if the target receives magical healing."
+            ]
+        },
+        {
+            "name": "Harpoon (Merrow)",
+            "entries":
+            [
+                "{@atk mw,rw} {@hit <$to_hit__str$>} to hit, reach 5 ft. or range 20/60 ft., one target. {@h}11 ({@damage 2d6 + 4}) piercing damage. If the target is a Huge or smaller creature, it must succeed on a Strength contest against the <$name$> or be pulled up to 20 feet toward the <$name$>."
+            ]
+        },
+        {
+            "name": "Haste (Clay Golem)",
+            "entries":
+            [
+                "Until the end of its next turn, the <$name$> magically gains a +2 bonus to its AC, has advantage on Dexterity saving throws, and can use its slam attack as a bonus action."
+            ]
+        },
+        {
+            "name": "Heart Sight (Sprite)",
+            "entries":
+            [
+                "The <$name$> touches a creature and magically knows the creature's current emotional state. If the target fails a DC <$dc__cha$> Charisma saving throw, the <$name$> also knows the creature's alignment. Celestials, fiends, and undead automatically fail the saving throw."
+            ]
+        },
+        {
+            "name": "Horrifying Visage (Ghost)",
+            "entries":
+            [
+                "Each non-undead creature within 60 feet of the <$name$> that can see it must succeed on a DC <$dc__wis$> Wisdom saving throw or be {@condition frightened} for 1 minute. If the save fails by 5 or more, the target also ages {@dice 1d4 × 10} years. A {@condition frightened} target can repeat the saving throw at the end of each of its turns, ending the {@condition frightened} condition on itself on a success. If a target's saving throw is successful or the effect ends for it, the target is immune to this <$name$>'s Horrifying Visage for the next 24 hours. The aging effect can be reversed with a  {@spell greater restoration} spell, but only within 24 hours of it occurring."
+            ]
+        },
+        {
+            "name": "Horror Nimbus (Nalfeshnee)",
+            "entries":
+            [
+                "The <$name$> magically emits scintillating, multicolored light. Each creature within 15 feet of the <$name$> that can see the light must succeed on a DC <$dc__wis$> Wisdom saving throw or be {@condition frightened} for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the <$name$>'s Horror Nimbus for the next 24 hours."
+            ]
+        },
+        {
+            "name": "Hurl Flame (Barbed Devil)",
+            "entries":
+            [
+                "{@atk rs} {@hit <$to_hit__str$>} to hit, range 150 ft., one target. {@h}10 ({@damage 3d6}) fire damage. If the target is a flammable object that isn't being worn or carried, it also catches fire."
+            ]
+        },
+        {
+            "name": "Illusory Appearance (Sea Hag)",
+            "entries":
+            [
+                "The <$name$> covers itself and anything she is wearing or carrying with a magical illusion that makes it look like an ugly creature of it general size and humanoid shape. The effect ends if the <$name$> takes a bonus action to end it or if it dies.",
+                "The changes wrought by this effect fail to hold up to physical inspection. For example, the <$name$> could appear to have no claws, but someone touching it hand might feel the claws. Otherwise, a creature must take an action to visually inspect the illusion and succeed on a {@dc 16} Intelligence (Investigation) check to discern that the <$name$> is disguised."
+            ]
+        },
+        {
+            "name": "Intoxicating Touch (Lamia)",
+            "entries":
+            [
+                "{@atk ms} {@hit <$to_hit__str$>} to hit, reach 5 ft., one creature. {@h}The target is magically cursed for 1 hour. Until the curse ends, the target has disadvantage on Wisdom saving throws and all ability checks."
+            ]
+        },
+        {
+            "name": "Invisibility (Duergar)",
+            "entries":
+            [
+                "The <$name$> magically turns {@condition invisible} until it attacks, casts a spell, or uses its Enlarge, or until its concentration is broken, up to 1 hour (as if concentrating on a spell). Any equipment the <$name$> wears or carries is {@condition invisible} with it."
+            ]
+        },
+        {
+            "name": "Invisibility (Quasit)",
+            "entries":
+            [
+                "The <$name$> magically turns {@condition invisible} until it attacks or uses Scare, or until its concentration ends (as if concentrating on a spell). Any equipment the <$name$> wears or carries is {@condition invisible} with it."
+            ]
+        },
+        {
+            "name": "Invisibility (Sprite)",
+            "entries":
+            [
+                "The <$name$> magically turns {@condition invisible} until it attacks or casts a spell, or until its concentration ends (as if concentrating on a spell). Any equipment the <$name$> wears or carries is {@condition invisible} with it."
+            ]
+        },
+        {
+            "name": "Leadership (Knight)",
+            "entries":
+            [
+                "For 1 minute, the <$name$> can utter a special command or warning whenever a nonhostile creature that it can see within 30 feet of it makes an attack roll or a saving throw. The creature can add a {@dice d4} to its roll provided it can hear and understand the <$name$>. A creature can benefit from only one Leadership die at a time. This effect ends if the <$name$> is {@condition incapacitated}."
+            ]
+        },
+        {
+            "name": "Life Drain (Wight)",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 5 ft., one creature. {@h}5 ({@damage 1d6 + 2}) necrotic damage. The target must succeed on a {@dc 13} Constitution saving throw or its hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0.",
+                "A humanoid slain by this attack rises 24 hours later as a {@creature zombie} under the <$name$>'s control, unless the humanoid is restored to life or its body is destroyed. The <$name$> can have no more than twelve zombies under its control at one time."
+            ]
+        },
+        {
+            "name": "Life Drain (Wraith)",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 5 ft., one creature. {@h}21 ({@damage 4d8 + 3}) necrotic damage. The target must succeed on a {@dc 14} Constitution saving throw or its hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0."
+            ]
+        },
+        {
+            "name": "Lightning Breath (Behir)",
+            "entries":
+            [
+                "The <$name$> exhales a line of lightning that is 20 feet long and 5 feet wide. Each creature in that line must make a DC <$dc__dex$> Dexterity saving throw, taking 66 ({@damage 12d10}) lightning damage on a failed save, or half as much damage on a successful one."
+            ]
+        },
+        {
+            "name": "Lightning Storm (Kraken)",
+            "entries":
+            [
+                "The <$name$> magically creates three bolts of lightning, each of which can strike a target the <$name$> can see within 120 feet of it. A target must make a DC <$dc__dex$> Dexterity saving throw, taking 22 ({@damage 4d10}) lightning damage on a failed save, or half as much damage on a successful one."
+            ]
+        },
+        {
+            "name": "Lightning Strike (Storm Giant)",
+            "entries":
+            [
+                "The <$name$> hurls a magical lightning bolt at a point it can see within 500 feet of it. Each creature within 10 feet of that point must make a DC <$dc__dex$> Dexterity saving throw, taking 54 ({@damage 12d8}) lightning damage on a failed save, or half as much damage on a successful one."
+            ]
+        },
+        {
+            "name": "Moan (Cloaker)",
+            "entries":
+            [
+                "Each creature within 60 feet of the <$name$> that can hear its moan and that isn't an aberration must succeed on a DC <$dc__wis$> Wisdom saving throw or become {@condition frightened} until the end of the <$name$>'s next turn. If a creature's saving throw is successful, the creature is immune to the <$name$>'s moan for the next 24 hours."
+            ]
+        },
+        {
+            "name": "Nightmare Haunting (Night Hag)",
+            "entries":
+            [
+                "While on the Ethereal Plane, the <$name$> magically touches a sleeping humanoid on the Material Plane. A {@spell protection from evil and good} spell cast on the target prevents this contact, as does a magic circle. As long as the contact persists, the target has dreadful visions. If these visions last for at least 1 hour, the target gains no benefit from its rest, and its hit point maximum is reduced by 5 ({@dice 1d10}). If this effect reduces the target's hit point maximum to 0, the target dies, and if the target was evil, its soul is trapped in the <$name$>'s soul bag. The reduction to the target's hit point maximum lasts until removed by the  {@spell greater restoration} spell or similar magic."
+            ]
+        },
+        {
+            "name": "Paralyzing Touch (Lich)",
+            "entries":
+            [
+                "{@atk ms} {@hit <$to_hit__str$>} to hit, reach 5 ft., one creature. {@h}10 ({@damage 3d6}) cold damage. The target must succeed on a {@dc 18} Constitution saving throw or be {@condition paralyzed} for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+            ]
+        },
+        {
+            "name": "Phantasms (Cloaker)",
+            "entries":
+            [
+                "The <$name$> magically creates three illusory duplicates of itself if it isn't in bright light. The duplicates move with it and mimic its actions, shifting position so as to make it impossible to track which <$name$> is the real one. If the <$name$> is ever in an area of bright light, the duplicates disappear.",
+                "Whenever any creature targets the <$name$> with an attack or a harmful spell while a duplicate remains, that creature rolls randomly to determine whether it targets the <$name$> or one of the duplicates. A creature is unaffected by this magical effect if it can't see or if it relies on senses other than sight.",
+                "A duplicate has the <$name$>'s AC and uses its saving throws. If an attack hits a duplicate, or if a duplicate fails a saving throw against an effect that deals damage, the duplicate disappears."
+            ]
+        },
+        {
+            "name": "Possession (Ghost)",
+            "entries":
+            [
+                "One humanoid that the <$name$> can see within 5 feet of it must succeed on a DC <$dc__cha$> Charisma saving throw or be possessed by the <$name$>; the <$name$> then disappears, and the target is {@condition incapacitated} and loses control of its body. The <$name$> now controls the body but doesn't deprive the target of awareness. The <$name$> can't be targeted by any attack, spell, or other effect, except ones that turn undead, and it retains its alignment, Intelligence, Wisdom, Charisma, and immunity to being {@condition charmed} and {@condition frightened}. It otherwise uses the possessed target's statistics, but doesn't gain access to the target's knowledge, class features, or proficiencies.",
+                "The possession lasts until the body drops to 0 hit points, the <$name$> ends it as a bonus action, or the <$name$> is turned or forced out by an effect like the {@spell dispel evil and good} spell. When the possession ends, the <$name$> reappears in an unoccupied space within 5 feet of the body. The target is immune to this <$name$>'s Possession for 24 hours after succeeding on the saving throw or after the possession ends."
+            ]
+        },
+        {
+            "name": "Pseudopod (Gray Ooze)",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 5 ft., one target. {@h}6 ({@damage 1d6 + 3}) bludgeoning damage plus 18 ({@damage 4d8}) acid damage. In addition, nonmagical armor worn by the target is partly dissolved and takes a permanent and cumulative −1 penalty to the AC it offers. The armor is destroyed if the penalty reduces its AC to 10."
+            ]
+        },
+        {
+            "name": "Read Thoughts (Doppelganger)",
+            "entries":
+            [
+                "The <$name$> magically reads the surface thoughts of one creature within 60 feet of it. The effect can penetrate barriers, but 3 feet of wood or dirt, 2 feet of stone, 2 inches of metal, or a thin sheet of lead blocks it. While the target is in range, the <$name$> can continue reading its thoughts, as long as the <$name$>'s concentration isn't broken (as if concentrating on a spell). While reading the target's mind, the <$name$> has advantage on Wisdom ({@skill Insight}) and Charisma ({@skill Deception}, {@skill Intimidation}, and {@skill Persuasion}) checks against the target."
+            ]
+        },
+        {
+            "name": "Reaping Scythe",
+            "entries":
+            [
+                "The <$name$> sweeps its spectral scythe through a creature within 5 feet of it, dealing 7 ({@damage 1d8 + 3}) slashing damage plus 4 ({@damage 1d8}) necrotic damage."
+            ]
+        },
+        {
+            "name": "Reel (Roper)",
+            "entries":
+            [
+                "The <$name$> pulls each creature {@condition grappled} by it up to 25 feet straight toward it."
+            ]
+        },
+        {
+            "name": "Rotting Fist (Mummy Lord)",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 5 ft., one target. {@h}14 ({@damage 3d6 + 4}) bludgeoning damage plus 21 ({@damage 6d6}) necrotic damage. If the target is a creature, it must succeed on a {@dc 16} Constitution saving throw or be cursed with mummy rot. The cursed target can't regain hit points, and its hit point maximum decreases by 10 ({@dice 3d6}) for every 24 hours that elapse. If the curse reduces the target's hit point maximum to 0, the target dies, and its body turns to dust. The curse lasts until removed by the {@spell remove curse} spell or other magic."
+            ]
+        },
+        {
+            "name": "Scare (Quasit)",
+            "entries":
+            [
+                "One creature of the <$name$>'s choice within 20 feet of it must succeed on a DC <$dc__wis$> Wisdom saving throw or be {@condition frightened} for 1 minute. The target can repeat the saving throw at the end of each of its turns, with disadvantage if the <$name$> is within line of sight, ending the effect on itself on a success."
+            ]
+        },
+        {
+            "name": "Slam (Clay Golem)",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 5 ft., one target. {@h}16 ({@damage 2d10 + 5}) bludgeoning damage. If the target is a creature, it must succeed on a {@dc 15} Constitution saving throw or have its hit point maximum reduced by an amount equal to the damage taken. The target dies if this attack reduces its hit point maximum to 0. The reduction lasts until removed by the  {@spell greater restoration} spell or other magic."
+            ]
+        },
+        {
+            "name": "Slaying Longbow (Solar)",
+            "entries":
+            [
+                "{@atk rw} {@hit <$to_hit__str$>} to hit, range 150/600 ft., one target. {@h}15 ({@damage 2d8 + 6}) piercing damage plus 27 ({@damage 6d8}) radiant damage. If the target is a creature that has 100 hit points or fewer, it must succeed on a {@dc 15} Constitution saving throw or die."
+            ]
+        },
+        {
+            "name": "Slow (Stone Golem)",
+            "entries":
+            [
+                "The <$name$> targets one or more creatures it can see within 10 feet of it. Each target must make a DC <$dc__wis$> Wisdom saving throw against this magic. On a failed save, a target can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the target can take either an action or a bonus action on its turn, not both. These effects last for 1 minute. A target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+            ]
+        },
+        {
+            "name": "Smother (Smothering Rug)",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 5 ft., one Medium or smaller creature. {@h}The creature is {@condition grappled} (escape {@dc 13}). Until this grapple ends, the target is {@condition restrained}, {@condition blinded}, and at risk of suffocating, and the <$name$> can't smother another target. In addition, at the start of each of the target's turns, the target takes 10 ({@damage 2d6 + 3}) bludgeoning damage."
+            ]
+        },
+        {
+            "name": "Spores (Vrock)",
+            "entries":
+            [
+                "A 15-foot-radius cloud of toxic spores extends out from the <$name$>. The spores spread around corners. Each creature in that area must succeed on a DC <$dc__con$> Constitution saving throw or become {@condition poisoned}. While {@condition poisoned} in this way, a target takes 5 ({@damage 1d10}) poison damage at the start of each of its turns. A target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. Emptying a vial of holy water on the target also ends the effect on it."
+            ]
+        },
+        {
+            "name": "Steam Breath (Dragon Turtle)",
+            "entries":
+            [
+                "The <$name$> exhales scalding steam in a 60-foot cone. Each creature in that area must make a DC <$dc__con$> Constitution saving throw, taking 52 ({@damage 15d6}) fire damage on a failed save, or half as much damage on a successful one. Being underwater doesn't grant resistance against this damage."
+            ]
+        },
+        {
+            "name": "Sting (Bone Devil)",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 10 ft., one target. {@h}13 ({@damage 2d8 + 4}) piercing damage plus 17 ({@damage 5d6}) poison damage, and the target must succeed on a {@dc 14} Constitution saving throw or become {@condition poisoned} for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+            ]
+        },
+        {
+            "name": "Strength Drain (Shadow)",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 5 ft., one creature. {@h}9 ({@damage 2d6 + 2}) necrotic damage, and the target's Strength score is reduced by {@dice 1d4}. The target dies if this reduces its Strength to 0. Otherwise, the reduction lasts until the target finishes a short or long rest.",
+                "If a non-evil humanoid dies from this attack, a new shadow rises from the corpse {@dice 1d4} hours later."
+            ]
+        },
+        {
+            "name": "Stunning Screech (Vrock)",
+            "entries":
+            [
+                "The <$name$> emits a horrific screech. Each creature within 20 feet of it that can hear it and that isn't a demon must succeed on a {@dc 14} Constitution saving throw or be {@condition stunned} until the end of the <$name$>'s next turn."
+            ]
+        },
+        {
+            "name": "Swallow (Behir)",
+            "entries":
+            [
+                "The <$name$> makes one bite attack against a Medium or smaller target it is grappling. If the attack hits, the target is also swallowed, and the grapple ends. While swallowed, the target is {@condition blinded} and {@condition restrained}, it has total cover against attacks and other effects outside the <$name$>, and it takes 21 ({@damage 6d6}) acid damage at the start of each of the <$name$>'s turns. A <$name$> can have only one creature swallowed at a time.",
+                "If the <$name$> takes 30 damage or more on a single turn from the swallowed creature, the <$name$> must succeed on a {@dc 14} Constitution saving throw at the end of that turn or regurgitate the creature, which falls {@condition prone} in a space within 10 feet of the <$name$>. If the <$name$> dies, a swallowed creature is no longer {@condition restrained} by it and can escape from the corpse by using 15 feet of movement, exiting {@condition prone}."
+            ]
+        },
+        {
+            "name": "Tail (Marilith)",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 10 ft., one creature. {@h}15 ({@damage 2d10 + 4}) bludgeoning damage. If the target is Medium or smaller, it is {@condition grappled} (escape {@dc 19}). Until this grapple ends, the target is {@condition restrained}, the <$name$> can automatically hit the target with its tail, and the <$name$> can't make tail attacks against other targets."
+            ]
+        },
+        {
+            "name": "Teleport (Balor)",
+            "entries":
+            [
+                "The <$name$> magically teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space it can see."
+            ]
+        },
+        {
+            "name": "Teleport (Blink Dog)",
+            "entries":
+            [
+                "The <$name$> magically teleports, along with any equipment it is wearing or carrying, up to 40 feet to an unoccupied space it can see. Before or after teleporting, the <$name$> can make one bite attack."
+            ]
+        },
+        {
+            "name": "Tendril (Roper)",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 50 ft., one creature. {@h}The target is {@condition grappled} (escape DC <$dc__str$>). Until the grapple ends, the target is {@condition restrained} and has disadvantage on Strength checks and Strength saving throws, and the <$name$> can't use the same tendril on another target."
+            ]
+        },
+        {
+            "name": "Tentacle (Aboleth)",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 10 ft., one target. {@h}12 ({@damage 2d6 + 5}) bludgeoning damage. If the target is a creature, it must succeed on a {@dc 14} Constitution saving throw or become diseased. The disease has no effect for 1 minute and can be removed by any magic that cures disease. After 1 minute, the diseased creature's skin becomes translucent and slimy, the creature can't regain hit points unless it is underwater, and the disease can be removed only by {@spell heal} or another disease-curing spell of 6th level or higher. When the creature is outside a body of water, it takes 6 ({@damage 1d12}) acid damage every 10 minutes unless moisture is applied to the skin before 10 minutes have passed."
+            ]
+        },
+        {
+            "name": "Tentacle (Kraken)",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 30 ft., one target. {@h}20 ({@damage 3d6 + 10}) bludgeoning damage, and the target is {@condition grappled} (escape {@dc 18}). Until this grapple ends, the target is {@condition restrained}. The <$name$> has ten tentacles, each of which can grapple one target."
+            ]
+        },
+        {
+            "name": "Tentacles (Chuul)",
+            "entries":
+            [
+                "One creature {@condition grappled} by the <$name$> must succeed on a {@dc 13} Constitution saving throw or be {@condition poisoned} for 1 minute. Until this poison ends, the target is {@condition paralyzed}. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+            ]
+        },
+        {
+            "name": "Touch (Magmin)",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 5 ft., one target. {@h}7 ({@damage 2d6}) fire damage. If the target is a creature or a flammable object, it ignites. Until a creature takes an action to douse the fire, the target takes 3 ({@damage 1d6}) fire damage at the end of each of its turns."
+            ]
+        },
+        {
+            "name": "Web (Ettercap)",
+            "entries":
+            [
+                "{@atk rw} {@hit <$to_hit__str$>} to hit, range 30/60 ft., one Large or smaller creature. {@h}The creature is {@condition restrained} by webbing. As an action, the {@condition restrained} creature can make a DC <$dc__str$> Strength check, escaping from the webbing on a success. The effect ends if the webbing is destroyed. The webbing has AC 10, 5 hit points, is vulnerable to fire damage and immune to bludgeoning, poison and psychic damage."
+            ]
+        },
+        {
+            "name": "Web Garrote (Ettercap)",
+            "entries":
+            [
+                "{@atk mw} {@hit <$to_hit__str$>} to hit, reach 5 ft., one Medium or Small creature against which the <$name$> has advantage on the attack roll. {@h}4 ({@damage 1d4 + 2}) bludgeoning damage, and the target is {@condition grappled} (escape DC <$dc__str$>). Until this grapple ends, the target can't breathe, and the <$name$> has advantage on attack rolls against it."
+            ]
+        },
+        {
+            "name": "Whelm (Water Elemental)",
+            "entries":
+            [
+                "Each creature in the <$name$>'s space must make a {@dc 15} Strength saving throw. On a failure, a target takes 13 ({@damage 2d8 + 4}) bludgeoning damage. If it is Large or smaller, it is also {@condition grappled} (escape DC <$dc__str$>). Until this grapple ends, the target is {@condition restrained} and unable to breathe unless it can breathe water. If the saving throw is successful, the target is pushed out of the <$name$>'s space.",
+                "The <$name$> can grapple one Large creature or up to two Medium or smaller creatures at one time. At the start of each of the <$name$>'s turns, each target {@condition grappled} by it takes 13 ({@damage 2d8 + 4}) bludgeoning damage. A creature within 5 feet of the <$name$> can pull a creature or object out of it by taking an action to make a DC <$dc__str$> Strength check and succeeding."
+            ]
+        },
+        {
+            "name": "Whirlwind (Air Elemental)",
+            "entries":
+            [
+                "Each creature in the <$name$>'s space must make a {@dc 13} Strength saving throw. On a failure, a target takes 15 ({@damage 3d8 + 2}) bludgeoning damage and is flung up 20 feet away from the <$name$> in a random direction and knocked {@condition prone}. If a thrown target strikes an object, such as a wall or floor, the target takes 3 ({@damage 1d6}) bludgeoning damage for every 10 feet it was thrown. If the target is thrown at another creature, that creature must succeed on a DC <$dc__dex$> Dexterity saving throw or take the same damage and be knocked {@condition prone}.",
+                "If the saving throw is successful, the target takes half the bludgeoning damage and isn't flung away or knocked {@condition prone}."
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
Adds a predefined actions button to add template actions, currently including most weapons (I think I forgot some) and SRD monster actions. Also appends a hacky "datatype" to makebrew-creature.json that exists just to pull the templates from, no idea if anything else needs to be done for this to be "official". Action to-hits and DCs automatically scale to the creature's stats (using code adapted from utils.js).

Dragon breaths intentionally omitted unless there's a way to add those without bloating the list with forty near-identical actions oof

This entire thing is hacky and this is my first time actually tinkering with the code and offering it to a github repo, I hope it's good enough! If not, I'll still find use for it and it was fun to try!