### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ RUN apk update && apk add lighttpd rsync
 
 COPY docker/lighttpd.conf docker/mime-types.conf /etc/lighttpd/
 
-CMD [ "lighttpd", "-D", "-f", "/etc/lighttpd/lighttpd.conf" ]
+ENTRYPOINT [ "lighttpd" ]
+CMD [ "-D", "-f", "/etc/lighttpd/lighttpd.conf" ]
 EXPOSE 80
 
 COPY . /var/www/localhost/htdocs/


### PR DESCRIPTION
Latest Docker images of 5etools refuse to run properly due to a new Dockerfile configuration. With addition of ENTRYPOINT instruction Docker images begin to work (though it's not necessary to include both ENTRYPOINT and CMD instructions, so if we just fix the CMD instruction, it might work as intended).