### PR TITLE
feat(ScDun): Make Geomorph Cards Importable

### DIFF
--- a/data/book/book-screendungeonkit.json
+++ b/data/book/book-screendungeonkit.json
@@ -1801,7 +1801,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/001.webp"
 									},
 									"width": 564,
-									"height": 709
+									"height": 709,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -9,
+										"offsetY": 24,
+										"scale": 2
+									},
+									"title": "Geomorph Card 1"
 								},
 								{
 									"type": "image",
@@ -1810,7 +1819,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/002.webp"
 									},
 									"width": 564,
-									"height": 709
+									"height": 709,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -9,
+										"offsetY": 24,
+										"scale": 2
+									},
+									"title": "Geomorph Card 2"
 								},
 								{
 									"type": "image",
@@ -1819,7 +1837,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/003.webp"
 									},
 									"width": 564,
-									"height": 709
+									"height": 709,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -11,
+										"offsetY": 17,
+										"scale": 2
+									},
+									"title": "Geomorph Card 3"
 								},
 								{
 									"type": "image",
@@ -1828,7 +1855,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/004.webp"
 									},
 									"width": 564,
-									"height": 709
+									"height": 709,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -8,
+										"offsetY": -23,
+										"scale": 2
+									},
+									"title": "Geomorph Card 4"
 								},
 								{
 									"type": "image",
@@ -1837,7 +1873,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/005.webp"
 									},
 									"width": 564,
-									"height": 709
+									"height": 709,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -7,
+										"offsetY": -28,
+										"scale": 2
+									},
+									"title": "Geomorph Card 5"
 								},
 								{
 									"type": "image",
@@ -1846,7 +1891,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/006.webp"
 									},
 									"width": 564,
-									"height": 709
+									"height": 709,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -11,
+										"offsetY": 25,
+										"scale": 2
+									},
+									"title": "Geomorph Card 6"
 								},
 								{
 									"type": "image",
@@ -1855,7 +1909,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/007.webp"
 									},
 									"width": 564,
-									"height": 708
+									"height": 708,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -5,
+										"offsetY": -15,
+										"scale": 2
+									},
+									"title": "Geomorph Card 7"
 								},
 								{
 									"type": "image",
@@ -1864,7 +1927,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/008.webp"
 									},
 									"width": 564,
-									"height": 708
+									"height": 708,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -8,
+										"offsetY": -17,
+										"scale": 2
+									},
+									"title": "Geomorph Card 8"
 								},
 								{
 									"type": "image",
@@ -1873,7 +1945,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/009.webp"
 									},
 									"width": 564,
-									"height": 708
+									"height": 708,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -9,
+										"offsetY": -16,
+										"scale": 2
+									},
+									"title": "Geomorph Card 9"
 								},
 								{
 									"type": "image",
@@ -1882,7 +1963,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/010.webp"
 									},
 									"width": 564,
-									"height": 711
+									"height": 711,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -5,
+										"offsetY": -23,
+										"scale": 2
+									},
+									"title": "Geomorph Card 10"
 								},
 								{
 									"type": "image",
@@ -1891,7 +1981,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/011.webp"
 									},
 									"width": 564,
-									"height": 711
+									"height": 711,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -5,
+										"offsetY": -24,
+										"scale": 2
+									},
+									"title": "Geomorph Card 11"
 								},
 								{
 									"type": "image",
@@ -1900,7 +1999,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/012.webp"
 									},
 									"width": 564,
-									"height": 711
+									"height": 711,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -10,
+										"offsetY": -31,
+										"scale": 2
+									},
+									"title": "Geomorph Card 12"
 								},
 								{
 									"type": "image",
@@ -1909,7 +2017,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/013.webp"
 									},
 									"width": 564,
-									"height": 711
+									"height": 711,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -1,
+										"offsetY": -18,
+										"scale": 2
+									},
+									"title": "Geomorph Card 13"
 								},
 								{
 									"type": "image",
@@ -1918,7 +2035,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/014.webp"
 									},
 									"width": 564,
-									"height": 711
+									"height": 711,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -5,
+										"offsetY": -24,
+										"scale": 2
+									},
+									"title": "Geomorph Card 14"
 								},
 								{
 									"type": "image",
@@ -1927,7 +2053,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/015.webp"
 									},
 									"width": 564,
-									"height": 711
+									"height": 711,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -7,
+										"offsetY": -30,
+										"scale": 2
+									},
+									"title": "Geomorph Card 15"
 								},
 								{
 									"type": "image",
@@ -1936,7 +2071,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/016.webp"
 									},
 									"width": 564,
-									"height": 709
+									"height": 709,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": 1,
+										"offsetY": -16,
+										"scale": 2
+									},
+									"title": "Geomorph Card 16"
 								},
 								{
 									"type": "image",
@@ -1945,7 +2089,15 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/017.webp"
 									},
 									"width": 564,
-									"height": 709
+									"height": 709,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetY": -15,
+										"scale": 2
+									},
+									"title": "Geomorph Card 17"
 								},
 								{
 									"type": "image",
@@ -1954,7 +2106,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/018.webp"
 									},
 									"width": 564,
-									"height": 709
+									"height": 709,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -3,
+										"offsetY": -18,
+										"scale": 2
+									},
+									"title": "Geomorph Card 18"
 								},
 								{
 									"type": "image",
@@ -1963,7 +2124,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/019.webp"
 									},
 									"width": 564,
-									"height": 711
+									"height": 711,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -11,
+										"offsetY": -31,
+										"scale": 2
+									},
+									"title": "Geomorph Card 19"
 								},
 								{
 									"type": "image",
@@ -1972,7 +2142,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/020.webp"
 									},
 									"width": 564,
-									"height": 711
+									"height": 711,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -10,
+										"offsetY": 18,
+										"scale": 2
+									},
+									"title": "Geomorph Card 20"
 								},
 								{
 									"type": "image",
@@ -1981,7 +2160,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/021.webp"
 									},
 									"width": 564,
-									"height": 711
+									"height": 711,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -16,
+										"offsetY": 11,
+										"scale": 2
+									},
+									"title": "Geomorph Card 21"
 								},
 								{
 									"type": "image",
@@ -1990,7 +2178,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/022.webp"
 									},
 									"width": 564,
-									"height": 711
+									"height": 711,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -6,
+										"offsetY": -25,
+										"scale": 2
+									},
+									"title": "Geomorph Card 22"
 								},
 								{
 									"type": "image",
@@ -1999,7 +2196,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/023.webp"
 									},
 									"width": 564,
-									"height": 711
+									"height": 711,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -6,
+										"offsetY": 20,
+										"scale": 2
+									},
+									"title": "Geomorph Card 23"
 								},
 								{
 									"type": "image",
@@ -2008,7 +2214,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/024.webp"
 									},
 									"width": 564,
-									"height": 711
+									"height": 711,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -10,
+										"offsetY": 18,
+										"scale": 2
+									},
+									"title": "Geomorph Card 24"
 								},
 								{
 									"type": "image",
@@ -2017,7 +2232,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/025.webp"
 									},
 									"width": 564,
-									"height": 710
+									"height": 710,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -5,
+										"offsetY": -22,
+										"scale": 2
+									},
+									"title": "Geomorph Card 25"
 								},
 								{
 									"type": "image",
@@ -2026,7 +2250,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/026.webp"
 									},
 									"width": 564,
-									"height": 710
+									"height": 710,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -5,
+										"offsetY": -22,
+										"scale": 2
+									},
+									"title": "Geomorph Card 26"
 								},
 								{
 									"type": "image",
@@ -2035,7 +2268,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/027.webp"
 									},
 									"width": 564,
-									"height": 710
+									"height": 710,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -6,
+										"offsetY": -27,
+										"scale": 2
+									},
+									"title": "Geomorph Card 27"
 								},
 								{
 									"type": "image",
@@ -2044,7 +2286,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/028.webp"
 									},
 									"width": 566,
-									"height": 712
+									"height": 712,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -10,
+										"offsetY": 19,
+										"scale": 2
+									},
+									"title": "Geomorph Card 28"
 								},
 								{
 									"type": "image",
@@ -2053,7 +2304,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/029.webp"
 									},
 									"width": 566,
-									"height": 712
+									"height": 712,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -13,
+										"offsetY": 14,
+										"scale": 2
+									},
+									"title": "Geomorph Card 29"
 								},
 								{
 									"type": "image",
@@ -2062,7 +2322,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/030.webp"
 									},
 									"width": 566,
-									"height": 712
+									"height": 712,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -20,
+										"offsetY": 10,
+										"scale": 2
+									},
+									"title": "Geomorph Card 30"
 								},
 								{
 									"type": "image",
@@ -2071,7 +2340,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/031.webp"
 									},
 									"width": 566,
-									"height": 712
+									"height": 712,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -9,
+										"offsetY": 22,
+										"scale": 2
+									},
+									"title": "Geomorph Card 31"
 								},
 								{
 									"type": "image",
@@ -2080,7 +2358,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/032.webp"
 									},
 									"width": 566,
-									"height": 712
+									"height": 712,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -12,
+										"offsetY": 21,
+										"scale": 2
+									},
+									"title": "Geomorph Card 32"
 								},
 								{
 									"type": "image",
@@ -2089,7 +2376,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/033.webp"
 									},
 									"width": 566,
-									"height": 712
+									"height": 712,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -20,
+										"offsetY": 17,
+										"scale": 2
+									},
+									"title": "Geomorph Card 33"
 								},
 								{
 									"type": "image",
@@ -2098,7 +2394,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/034.webp"
 									},
 									"width": 566,
-									"height": 712
+									"height": 712,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -7,
+										"offsetY": 27,
+										"scale": 2
+									},
+									"title": "Geomorph Card 34"
 								},
 								{
 									"type": "image",
@@ -2107,7 +2412,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/035.webp"
 									},
 									"width": 566,
-									"height": 712
+									"height": 712,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -11,
+										"offsetY": -28,
+										"scale": 2
+									},
+									"title": "Geomorph Card 35"
 								},
 								{
 									"type": "image",
@@ -2116,7 +2430,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/036.webp"
 									},
 									"width": 566,
-									"height": 712
+									"height": 712,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -18,
+										"offsetY": -30,
+										"scale": 2
+									},
+									"title": "Geomorph Card 36"
 								},
 								{
 									"type": "image",
@@ -2140,7 +2463,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/Print1.png"
 									},
 									"width": 1692,
-									"height": 2126
+									"height": 2126,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -17,
+										"offsetY": -38,
+										"scale": 2
+									},
+									"title": "Geomorph Page 1"
 								},
 								{
 									"type": "image",
@@ -2149,7 +2481,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/Print2.png"
 									},
 									"width": 1692,
-									"height": 2131
+									"height": 2131,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -9,
+										"offsetY": -30,
+										"scale": 2
+									},
+									"title": "Geomorph Page 2"
 								},
 								{
 									"type": "image",
@@ -2158,7 +2499,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/Print3.png"
 									},
 									"width": 1692,
-									"height": 2132
+									"height": 2132,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -13,
+										"offsetY": -41,
+										"scale": 2
+									},
+									"title": "Geomorph Page 3"
 								},
 								{
 									"type": "image",
@@ -2167,7 +2517,16 @@
 										"path": "book/ScreenDungeonKit/Cards-Geomorph/Print4.png"
 									},
 									"width": 1698,
-									"height": 2136
+									"height": 2136,
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 54,
+										"offsetX": -13,
+										"offsetY": 15,
+										"scale": 2
+									},
+									"title": "Geomorph Page 4"
 								},
 								{
 									"type": "image",


### PR DESCRIPTION
This PR makes the DM's Screen: Dungeon Kit, geomorph card accessories importable as maps.
This effectively adds 36 new generic importable maps.
It adds titles and grid data to the images.
The four 3x3 pages are also individually importable adding a further four larger maps to the options.