### PR TITLE
feat(test): Add local homebrew test

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"test:data": "node test/test-all.js",
 		"lint:data": "node node/prettify-data.js",
 		"test:json": "node test/test-json.js",
+		"test:brew": "node test/test-brew.js",
 		"test:tags": "node test/test-tags.js",
 		"test": "npm run test:js && npm run test:css && npm run test:data",
 		"build:css": "sass --style=compressed scss/:css/ && node node/rm.js css/includes/",

--- a/test/test-brew.js
+++ b/test/test-brew.js
@@ -22,7 +22,7 @@ async function main () {
 	const {errors, errorsFull} = results;
 
 	if (errors.length) {
-		if (!process.env.CI) fs.writeFileSync(`test/test-json.error.log`, errorsFull.join("\n\n=====\n\n"));
+		if (!process.env.CI) fs.writeFileSync(`test/test-brew.error.log`, errorsFull.join("\n\n=====\n\n"));
 		console.error(`Schema test failed (${errors.length} failure${errors.length === 1 ? "" : "s"}).`);
 		return false;
 	}

--- a/test/test-brew.js
+++ b/test/test-brew.js
@@ -1,0 +1,34 @@
+import * as fs from "fs";
+
+import {Um, Uf, JsonTester} from "5etools-utils";
+
+const LOG_TAG = "JSON";
+const _IS_FAIL_SLOW = !process.env.FAIL_SLOW;
+
+async function main () {
+	const jsonTester = new JsonTester({
+		isBrew: true,
+		tagLog: LOG_TAG,
+		fnGetSchemaId: (filePath) => "homebrew.json",
+	});
+
+	const fileList = Uf.listJsonFiles("homebrew").filter(item => item !== "homebrew/index.json");
+
+	const results = await jsonTester.pGetErrorsOnDirsWorkers({
+		isFailFast: !_IS_FAIL_SLOW,
+		fileList,
+	});
+
+	const {errors, errorsFull} = results;
+
+	if (errors.length) {
+		if (!process.env.CI) fs.writeFileSync(`test/test-json.error.log`, errorsFull.join("\n\n=====\n\n"));
+		console.error(`Schema test failed (${errors.length} failure${errors.length === 1 ? "" : "s"}).`);
+		return false;
+	}
+
+	Um.info(LOG_TAG, `All schema tests passed.`);
+	return true;
+}
+
+export default main();


### PR DESCRIPTION
```js
const fileList = Uf.listJsonFiles("homebrew").filter(item => item !== "homebrew/index.json");
```
ehhhhh, better would be to read the local index and then check the listed files, unsure how this would behave if there is a mix of remote and local links in an index
I also couldn't get `blocklistDir` to accept a single file so moved on.

The index itself could also be tested, though I couldn't be bothered doing a PR here and to the utils repo to add a schema there.
Getting the json in the index right is trivial, it wouldn't check the links which would be the helpful bit