### PR TITLE
Added item filter for damage dice size

### DIFF
--- a/js/filter-items.js
+++ b/js/filter-items.js
@@ -33,6 +33,7 @@ class PageFilterEquipment extends PageFilter {
 		this._weightFilter = new RangeFilter({header: "Weight", min: 0, max: 100, isAllowGreater: true, suffix: " lb."});
 		this._focusFilter = new Filter({header: "Spellcasting Focus", items: [...Parser.ITEM_SPELLCASTING_FOCUS_CLASSES]});
 		this._damageTypeFilter = new Filter({header: "Weapon Damage Type", displayFn: it => Parser.dmgTypeToFull(it).uppercaseFirst(), itemSortFn: (a, b) => SortUtil.ascSortLower(Parser.dmgTypeToFull(a), Parser.dmgTypeToFull(b))});
+		this._damageDiceFilter = new Filter({header: "Weapon Damage Dice", items: ["1", "1d4", "1d6", "1d8", "1d10", "1d12", "2d6"],});
 		this._miscFilter = new Filter({header: "Miscellaneous", items: ["Item Group", "Bundle", "SRD", "Basic Rules", "Has Images", "Has Info"], isMiscFilter: true});
 		this._poisonTypeFilter = new Filter({header: "Poison Type", items: ["ingested", "injury", "inhaled", "contact"], displayFn: StrUtil.toTitleCase});
 	}
@@ -85,6 +86,7 @@ class PageFilterEquipment extends PageFilter {
 		this._typeFilter.addItem(item._typeListText);
 		this._propertyFilter.addItem(item._fProperties);
 		this._damageTypeFilter.addItem(item.dmgType);
+		this._damageDiceFilter.addItem(item.dmg1);
 		this._poisonTypeFilter.addItem(item.poisonTypes);
 		this._miscFilter.addItem(item._fMisc);
 	}
@@ -99,6 +101,7 @@ class PageFilterEquipment extends PageFilter {
 			this._weightFilter,
 			this._focusFilter,
 			this._damageTypeFilter,
+			this._damageDiceFilter,
 			this._miscFilter,
 			this._poisonTypeFilter,
 		];
@@ -115,6 +118,7 @@ class PageFilterEquipment extends PageFilter {
 			it.weight,
 			it._fFocus,
 			it.dmgType,
+			it.dmg1,
 			it._fMisc,
 			it.poisonTypes,
 		);
@@ -319,6 +323,7 @@ class PageFilterItems extends PageFilterEquipment {
 			this._weightFilter,
 			this._focusFilter,
 			this._damageTypeFilter,
+			this._damageDiceFilter,
 			this._bonusFilter,
 			this._miscFilter,
 			this._rechargeTypeFilter,
@@ -345,6 +350,7 @@ class PageFilterItems extends PageFilterEquipment {
 			it.weight,
 			it._fFocus,
 			it.dmgType,
+			it.dmg1,
 			it._fBonus,
 			it._fMisc,
 			it.recharge,

--- a/js/filter-items.js
+++ b/js/filter-items.js
@@ -33,7 +33,6 @@ class PageFilterEquipment extends PageFilter {
 		this._weightFilter = new RangeFilter({header: "Weight", min: 0, max: 100, isAllowGreater: true, suffix: " lb."});
 		this._focusFilter = new Filter({header: "Spellcasting Focus", items: [...Parser.ITEM_SPELLCASTING_FOCUS_CLASSES]});
 		this._damageTypeFilter = new Filter({header: "Weapon Damage Type", displayFn: it => Parser.dmgTypeToFull(it).uppercaseFirst(), itemSortFn: (a, b) => SortUtil.ascSortLower(Parser.dmgTypeToFull(a), Parser.dmgTypeToFull(b))});
-		this._damageDiceFilter = new Filter({header: "Weapon Damage Dice", items: ["1", "1d4", "1d6", "1d8", "1d10", "1d12", "2d6"],});
 		this._miscFilter = new Filter({header: "Miscellaneous", items: ["Item Group", "Bundle", "SRD", "Basic Rules", "Has Images", "Has Info"], isMiscFilter: true});
 		this._poisonTypeFilter = new Filter({header: "Poison Type", items: ["ingested", "injury", "inhaled", "contact"], displayFn: StrUtil.toTitleCase});
 	}
@@ -86,7 +85,6 @@ class PageFilterEquipment extends PageFilter {
 		this._typeFilter.addItem(item._typeListText);
 		this._propertyFilter.addItem(item._fProperties);
 		this._damageTypeFilter.addItem(item.dmgType);
-		this._damageDiceFilter.addItem(item.dmg1);
 		this._poisonTypeFilter.addItem(item.poisonTypes);
 		this._miscFilter.addItem(item._fMisc);
 	}
@@ -101,7 +99,6 @@ class PageFilterEquipment extends PageFilter {
 			this._weightFilter,
 			this._focusFilter,
 			this._damageTypeFilter,
-			this._damageDiceFilter,
 			this._miscFilter,
 			this._poisonTypeFilter,
 		];
@@ -118,7 +115,6 @@ class PageFilterEquipment extends PageFilter {
 			it.weight,
 			it._fFocus,
 			it.dmgType,
-			it.dmg1,
 			it._fMisc,
 			it.poisonTypes,
 		);
@@ -323,7 +319,6 @@ class PageFilterItems extends PageFilterEquipment {
 			this._weightFilter,
 			this._focusFilter,
 			this._damageTypeFilter,
-			this._damageDiceFilter,
 			this._bonusFilter,
 			this._miscFilter,
 			this._rechargeTypeFilter,
@@ -350,7 +345,6 @@ class PageFilterItems extends PageFilterEquipment {
 			it.weight,
 			it._fFocus,
 			it.dmgType,
-			it.dmg1,
 			it._fBonus,
 			it._fMisc,
 			it.recharge,


### PR DESCRIPTION
Added a filter for weapon damage dice per tracker issue [5ET-1073](https://github.com/5etools/tracker/issues/1197#issue-1585968644) (lines 61-64).  VS Code editor autoformatted the line lengths.

_(This is my first pull request, so please let me know what I can do to improve my submissions.)_