### PR TITLE
Monster fluff touch-up

### DIFF
--- a/data/bestiary/bestiary-mm.json
+++ b/data/bestiary/bestiary-mm.json
@@ -9912,7 +9912,22 @@
 			],
 			"hasToken": true,
 			"hasFluff": true,
-			"hasFluffImages": true
+			"hasFluffImages": true,
+			"variant": [
+				{
+					"type": "variant",
+					"name": "Summon Devil (1/Day)",
+					"entries": [
+						"The devil chooses what to summon and attempts a magical summoning.",
+						"A barbed devil has a {@chance 30|30 percent} chance of summoning one barbed devil.",
+						"A summoned devil appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other devils. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+					],
+					"_version": {
+						"name": "Barbed Devil (Summoner)",
+						"addAs": "action"
+					}
+				}
+			]
 		},
 		{
 			"name": "Barlgura",
@@ -10467,7 +10482,22 @@
 			],
 			"hasToken": true,
 			"hasFluff": true,
-			"hasFluffImages": true
+			"hasFluffImages": true,
+			"variant": [
+				{
+					"type": "variant",
+					"name": "Summon Devil (1/Day)",
+					"entries": [
+						"The devil chooses what to summon and attempts a magical summoning.",
+						"A bearded devil has a {@chance 30|30 percent} chance of summoning one bearded devil.",
+						"A summoned devil appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other devils. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+					],
+					"_version": {
+						"name": "Bearded Devil (Summoner)",
+						"addAs": "action"
+					}
+				}
+			]
 		},
 		{
 			"name": "Behir",
@@ -12488,6 +12518,19 @@
 					"_version": {
 						"name": "Bone Devil (Polearm)",
 						"addHeadersAs": "action"
+					}
+				},
+				{
+					"type": "variant",
+					"name": "Summon Devil (1/Day)",
+					"entries": [
+						"The devil chooses what to summon and attempts a magical summoning.",
+						"A bone devil has a {@chance 40|40 percent} chance of summoning {@dice 2d6} {@creature spined devil||spined devils} or one bone devil.",
+						"A summoned devil appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other devils. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+					],
+					"_version": {
+						"name": "Bone Devil (Summoner)",
+						"addAs": "action"
 					}
 				}
 			],
@@ -23171,6 +23214,19 @@
 					"entries": [
 						"Some erinyes carry a {@item rope of entanglement} (detailed in the Dungeon Master's Guide). When such an erinyes uses its Multiattack, the erinyes can use the rope in place of two of the attacks."
 					]
+				},
+				{
+					"type": "variant",
+					"name": "Summon Devil (1/Day)",
+					"entries": [
+						"The devil chooses what to summon and attempts a magical summoning.",
+						"An erinyes has a {@chance 50|50 percent} chance of summoning {@dice 3d6} {@creature spined devil||spined devils}, {@dice 1d6} {@creature bearded devil||bearded devils}, or one {@creature erinyes}.",
+						"A summoned devil appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other devils. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+					],
+					"_version": {
+						"name": "Erinyes (Summoner)",
+						"addAs": "action"
+					}
 				}
 			],
 			"soundClip": {
@@ -36899,7 +36955,22 @@
 			],
 			"hasToken": true,
 			"hasFluff": true,
-			"hasFluffImages": true
+			"hasFluffImages": true,
+			"variant": [
+				{
+					"type": "variant",
+					"name": "Summon Devil (1/Day)",
+					"entries": [
+						"The devil chooses what to summon and attempts a magical summoning.",
+						"A horned devil has a {@chance 30|30 percent} chance of summoning one horned devil.",
+						"A summoned devil appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other devils. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+					],
+					"_version": {
+						"name": "Horned Devil (Summoner)",
+						"addAs": "action"
+					}
+				}
+			]
 		},
 		{
 			"name": "Hunter Shark",
@@ -37397,6 +37468,19 @@
 					"_version": {
 						"name": "Ice Devil (Spear)",
 						"addHeadersAs": "action"
+					}
+				},
+				{
+					"type": "variant",
+					"name": "Summon Devil (1/Day)",
+					"entries": [
+						"The devil chooses what to summon and attempts a magical summoning.",
+						"An ice devil has a {@chance 60|60 percent} chance of summoning one ice devil.",
+						"A summoned devil appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other devils. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+					],
+					"_version": {
+						"name": "Ice Devil (Summoner)",
+						"addAs": "action"
 					}
 				}
 			],
@@ -49475,7 +49559,22 @@
 			],
 			"hasToken": true,
 			"hasFluff": true,
-			"hasFluffImages": true
+			"hasFluffImages": true,
+			"variant": [
+				{
+					"type": "variant",
+					"name": "Summon Devil (1/Day)",
+					"entries": [
+						"The devil chooses what to summon and attempts a magical summoning.",
+						"A pit fiend summons {@dice 2d4} {@creature bearded devil||bearded devils}, {@dice 1d4} {@creature barbed devil||barbed devils}, or one {@creature erinyes} with no chance of failure.",
+						"A summoned devil appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other devils. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+					],
+					"_version": {
+						"name": "Pit Fiend (Summoner)",
+						"addAs": "action"
+					}
+				}
+			]
 		},
 		{
 			"name": "Pixie",

--- a/data/bestiary/bestiary-mm.json
+++ b/data/bestiary/bestiary-mm.json
@@ -45230,7 +45230,8 @@
 				"stunned"
 			],
 			"hasToken": true,
-			"hasFluff": true
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Myconid Adult",

--- a/data/bestiary/fluff-bestiary-mm.json
+++ b/data/bestiary/fluff-bestiary-mm.json
@@ -2537,19 +2537,6 @@
 									]
 								}
 							]
-						},
-						{
-							"type": "insetReadaloud",
-							"entries": [
-								{
-									"type": "quote",
-									"entries": [
-										"Beyond the unopenable doors lay a grand hall ending before a towering stone throne, upon which sat an iron statue taller and wider than two men. In one  and it clutched an iron sword, in the other, a feather whip. We should have turned back then."
-									],
-									"by": "Mordenkainen the Archmage",
-									"from": "chronicling his party's harrowing exploits in the dungeons below Maure Castle"
-								}
-							]
 						}
 					]
 				}
@@ -9018,7 +9005,20 @@
 						"mode": "prependArr",
 						"items": [
 							"The mightiest of the golems, the iron golem is a massive, towering giant wrought of heavy metal. An iron golem's shape can be worked into any form, though most are fashioned to look like giant suits of armor. Its fist can destroy creatures with a single blow, and its clanging steps shake the earth beneath its feet. Iron golems wield enormous blades to extend their reach, and all can belch clouds of deadly poison.",
-							"An iron golem's body is smelted with rare tinctures and admixtures. Though other golems bear weaknesses inherent in their materials or the power of the elemental spirit bound within them, iron golems were designed to be nearly invulnerable. Their iron bodies imprison the spirits that drive them, and are susceptible only to weapons imbued with magic or the strength of adamantine."
+							"An iron golem's body is smelted with rare tinctures and admixtures. Though other golems bear weaknesses inherent in their materials or the power of the elemental spirit bound within them, iron golems were designed to be nearly invulnerable. Their iron bodies imprison the spirits that drive them, and are susceptible only to weapons imbued with magic or the strength of adamantine.",
+							{
+								"type": "insetReadaloud",
+								"entries": [
+									{
+										"type": "quote",
+										"entries": [
+											"Beyond the unopenable doors lay a grand hall ending before a towering stone throne, upon which sat an iron statue taller and wider than two men. In one  and it clutched an iron sword, in the other, a feather whip. We should have turned back then."
+										],
+										"by": "Mordenkainen the Archmage",
+										"from": "chronicling his party's harrowing exploits in the dungeons below Maure Castle"
+									}
+								]
+							}
 						]
 					}
 				}

--- a/data/bestiary/fluff-bestiary-mm.json
+++ b/data/bestiary/fluff-bestiary-mm.json
@@ -12862,7 +12862,7 @@
 						"items": [
 							"Would-be thieves and careless heroes arrive at the doorsteps of an enemy's abode, eyes and ears alert for traps, only to end their quest prematurely as the rugs beneath their feet animate and smother them to death.",
 							"A rug of smothering can be made in many different forms, from a finely woven carpet fit for a queen to a coarse mat in a peasant's hovel. Creatures with the ability to sense magic detect the rug's false magical aura.",
-							"In some cases, a rug of smothering is disguised as a {@item carpet of flying} or another beneficial magic item. However, a character who stands or sits on the rug, or who attempts to utter a word of command, is quickly trapped as the rug of smothering rolls itself tightly around its victim.",
+							"In some cases, a rug of smothering is disguised as a {@item carpet of flying} or another beneficial magic item. However, a character who stands or sits on the rug, or who attempts to utter a word of command, is quickly trapped as the rug of smothering rolls itself tightly around its victim."
 						]
 					}
 				}

--- a/data/bestiary/fluff-bestiary-mm.json
+++ b/data/bestiary/fluff-bestiary-mm.json
@@ -7868,84 +7868,94 @@
 						"Hags represent all that is evil and cruel. Though they resemble withered crones, there is nothing mortal about these monstrous creatures, whose forms reflect only the wickedness in their hearts.",
 						{
 							"type": "entries",
-							"name": "Faces of Evil",
 							"entries": [
-								"Ancient beings with origins in the Feywild, hags are cankers on the mortal world. Their withered faces are framed by long, frayed hair, horrid moles and warts dot their blotchy skin, and their long, skinny fingers are tipped by claws that can slice open flesh with a touch. Their simple clothes are always tattered and filthy.",
-								"All hags possess magical powers, and some have an affinity for spellcasting. They can alter their forms or curse their foes, and their arrogance inspires them to view their magic as a challenge to the magic of the gods, whom they blaspheme at every opportunity.",
-								"Hags name themselves in darkly whimsical ways, claiming monikers such as Black Morwen, Peggy Pigknuckle, Grandmother Titchwillow, Nanna Shug, Rotten Ethel, or Auntie Wormtooth."
-							]
-						},
-						{
-							"type": "entries",
-							"name": "Monstrous Motherhood",
-							"entries": [
-								"Hags propagate by snatching and devouring human infants. After stealing a baby from its cradle or its mother's womb, the hag consumes the poor child. A week later, the hag gives birth to a daughter who looks human until her thirteenth birthday, whereupon the child transforms into the spitting image of her hag mother.",
-								"Hags sometimes raise the daughters they spawn, creating covens. A hag might also return the child to its grieving parents, only to watch from the shadows as the child grows up to become a horror."
-							]
-						},
-						{
-							"type": "entries",
-							"name": "Dark Bargains",
-							"entries": [
-								"Arrogant to a fault, hags believe themselves to be the most cunning of creatures, and they treat all others as inferior. Even so, a hag is open to dealing with mortals as long as those mortals show the proper respect and deference. Over their long lives, hags accumulate much knowledge of local lore, dark creatures, and magic, which they are pleased to sell.",
-								"Hags enjoy watching mortals bring about their own downfall, and a bargain with a hag is always dangerous. The terms of such bargains typically involve demands to compromise principles or give up something dear-especially if the thing lost diminishes or negates the knowledge gained through the bargain."
-							]
-						},
-						{
-							"type": "entries",
-							"name": "A Foul Nature",
-							"entries": [
-								"Hags love the macabre and festoon their garb with dead things and accentuate their appearance with bones, bits of flesh, and filth. They nurture blemishes and pick at wounds to produce weeping, suppurating flesh. Attractive creatures evoke disgust in a hag, which might \"help\" such creatures by disfiguring or transforming them.",
-								"This embrace of the disturbing and unpleasant extends to all aspects of a hag's life. A hag might fly in a magical giant's skull, landing it on a tree shaped to resemble an enormous headless body. Another might travel with a menagerie of monsters and slaves kept in cages, and disguised by illusions to lure unwary creatures close. Hags sharpen their teeth on millstones and spin cloth from the intestines of their victims, reacting with glee to the horror their actions invoke."
-							]
-						},
-						{
-							"type": "entries",
-							"name": "Dark Sorority",
-							"entries": [
-								"Hags maintain contact with each other and share knowledge. Through such contacts, it is likely that any given hag knows of every other hag in existence. Hags don't like each other, but they abide by an ageless code of conduct. Hags announce their presence before crossing into another hag's territory, bring gifts when entering another hag's dwelling, and break no oaths given to other hags-as long as the oath isn't given with the fingers crossed.",
-								"Some humanoids make the mistake of thinking that the hags' rules of conduct apply to all creatures. When confronted by such an individual, a hag might find it amusing to string the fool along for a while before teaching it a permanent lesson."
-							]
-						},
-						{
-							"type": "entries",
-							"name": "Dark Lairs",
-							"entries": [
-								"Hags dwell in dark and twisted woods, bleak moors, storm-lashed seacoasts, and gloomy swamps. In time, the landscape around a hag's lair reflects the creature's noxiousness, such that the land itself can attack and kill trespassers. Trees twisted by darkness attack passersby, while vines snake through the undergrowth to snare and drag off creatures one at a time. Foul stinking fogs turn the air to poison, and conceal pools of quicksand and sinkholes that consume unwary wanderers."
-							]
-						},
-						{
-							"type": "inset",
-							"name": "Hag Covens",
-							"entries": [
-								"When hags must work together, they form covens, in spite of their selfish natures. A coven is made up of hags of any type, all of whom are equals within the group. However, each of the hags continues to desire more personal power.",
-								"A coven consists of three hags so that any arguments between two hags can be settled by the third. If more than three hags ever come together, as might happen if two covens come into conflict, the result is usually chaos.",
 								{
 									"type": "entries",
-									"name": "Shared Spellcasting",
 									"entries": [
-										"While all three members of a hag coven are within 30 feet of one another, they can each cast the following spells from the wizard's spell list but must share the spell slots among themselves:",
 										{
-											"type": "list",
-											"style": "list-no-bullets",
-											"items": [
-												"1st level (4 slots): {@spell identify}, {@spell ray of sickness}",
-												"2nd level (3 slots): {@spell hold person}, {@spell locate object}",
-												"3rd level (3 slots): {@spell bestow curse}, {@spell counterspell}, {@spell lightning bolt}",
-												"4th level (3 slots): {@spell phantasmal killer}, {@spell polymorph}",
-												"5th level (2 slots): {@spell contact other plane}, {@spell scrying}",
-												"6th level (1 slot): {@spell eyebite}"
+											"type": "entries",
+											"name": "Faces of Evil",
+											"entries": [
+												"Ancient beings with origins in the Feywild, hags are cankers on the mortal world. Their withered faces are framed by long, frayed hair, horrid moles and warts dot their blotchy skin, and their long, skinny fingers are tipped by claws that can slice open flesh with a touch. Their simple clothes are always tattered and filthy.",
+												"All hags possess magical powers, and some have an affinity for spellcasting. They can alter their forms or curse their foes, and their arrogance inspires them to view their magic as a challenge to the magic of the gods, whom they blaspheme at every opportunity.",
+												"Hags name themselves in darkly whimsical ways, claiming monikers such as Black Morwen, Peggy Pigknuckle, Grandmother Titchwillow, Nanna Shug, Rotten Ethel, or Auntie Wormtooth."
 											]
 										},
-										"For casting these spells, each hag is a 12th-level spellcaster that uses Intelligence as her spellcasting ability. The spell save DC is 12 + the hag's Intelligence modifier, and the spell attack bonus is 4 + the hag's Intelligence modifier."
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Hag Eye",
-									"entries": [
-										"A hag coven can craft a magic item called a hag eye, which is made from a real eye coated in varnish and often fitted to a pendant or other wearable item. The hag eye is usually entrusted to a minion for safekeeping and transport. A hag in the coven can take an action to see what the hag eye sees if the hag eye is on the same plane of existence. A hag eye has AC 10, 1 hit point, and {@sense darkvision} with a radius of 60 feet. If it is destroyed, each coven member takes {@damage 3d10} psychic damage and is {@condition blinded} for 24 hours.",
-										"A hag coven can have only one hag eye at a time, and creating a new one requires all three members of the coven to perform a ritual. The ritual takes 1 hour, and the hags can't perform it while {@condition blinded}. During the ritual, if the hags take any action other than performing the ritual, they must start over."
+										{
+											"type": "entries",
+											"name": "Monstrous Motherhood",
+											"entries": [
+												"Hags propagate by snatching and devouring human infants. After stealing a baby from its cradle or its mother's womb, the hag consumes the poor child. A week later, the hag gives birth to a daughter who looks human until her thirteenth birthday, whereupon the child transforms into the spitting image of her hag mother.",
+												"Hags sometimes raise the daughters they spawn, creating covens. A hag might also return the child to its grieving parents, only to watch from the shadows as the child grows up to become a horror."
+											]
+										},
+										{
+											"type": "entries",
+											"name": "Dark Bargains",
+											"entries": [
+												"Arrogant to a fault, hags believe themselves to be the most cunning of creatures, and they treat all others as inferior. Even so, a hag is open to dealing with mortals as long as those mortals show the proper respect and deference. Over their long lives, hags accumulate much knowledge of local lore, dark creatures, and magic, which they are pleased to sell.",
+												"Hags enjoy watching mortals bring about their own downfall, and a bargain with a hag is always dangerous. The terms of such bargains typically involve demands to compromise principles or give up something dear-especially if the thing lost diminishes or negates the knowledge gained through the bargain."
+											]
+										},
+										{
+											"type": "entries",
+											"name": "A Foul Nature",
+											"entries": [
+												"Hags love the macabre and festoon their garb with dead things and accentuate their appearance with bones, bits of flesh, and filth. They nurture blemishes and pick at wounds to produce weeping, suppurating flesh. Attractive creatures evoke disgust in a hag, which might \"help\" such creatures by disfiguring or transforming them.",
+												"This embrace of the disturbing and unpleasant extends to all aspects of a hag's life. A hag might fly in a magical giant's skull, landing it on a tree shaped to resemble an enormous headless body. Another might travel with a menagerie of monsters and slaves kept in cages, and disguised by illusions to lure unwary creatures close. Hags sharpen their teeth on millstones and spin cloth from the intestines of their victims, reacting with glee to the horror their actions invoke."
+											]
+										},
+										{
+											"type": "entries",
+											"name": "Dark Sorority",
+											"entries": [
+												"Hags maintain contact with each other and share knowledge. Through such contacts, it is likely that any given hag knows of every other hag in existence. Hags don't like each other, but they abide by an ageless code of conduct. Hags announce their presence before crossing into another hag's territory, bring gifts when entering another hag's dwelling, and break no oaths given to other hags-as long as the oath isn't given with the fingers crossed.",
+												"Some humanoids make the mistake of thinking that the hags' rules of conduct apply to all creatures. When confronted by such an individual, a hag might find it amusing to string the fool along for a while before teaching it a permanent lesson."
+											]
+										},
+										{
+											"type": "entries",
+											"name": "Dark Lairs",
+											"entries": [
+												"Hags dwell in dark and twisted woods, bleak moors, storm-lashed seacoasts, and gloomy swamps. In time, the landscape around a hag's lair reflects the creature's noxiousness, such that the land itself can attack and kill trespassers. Trees twisted by darkness attack passersby, while vines snake through the undergrowth to snare and drag off creatures one at a time. Foul stinking fogs turn the air to poison, and conceal pools of quicksand and sinkholes that consume unwary wanderers."
+											]
+										},
+										{
+											"type": "inset",
+											"name": "Hag Covens",
+											"entries": [
+												"When hags must work together, they form covens, in spite of their selfish natures. A coven is made up of hags of any type, all of whom are equals within the group. However, each of the hags continues to desire more personal power.",
+												"A coven consists of three hags so that any arguments between two hags can be settled by the third. If more than three hags ever come together, as might happen if two covens come into conflict, the result is usually chaos.",
+												{
+													"type": "entries",
+													"name": "Shared Spellcasting",
+													"entries": [
+														"While all three members of a hag coven are within 30 feet of one another, they can each cast the following spells from the wizard's spell list but must share the spell slots among themselves:",
+														{
+															"type": "list",
+															"style": "list-no-bullets",
+															"items": [
+																"1st level (4 slots): {@spell identify}, {@spell ray of sickness}",
+																"2nd level (3 slots): {@spell hold person}, {@spell locate object}",
+																"3rd level (3 slots): {@spell bestow curse}, {@spell counterspell}, {@spell lightning bolt}",
+																"4th level (3 slots): {@spell phantasmal killer}, {@spell polymorph}",
+																"5th level (2 slots): {@spell contact other plane}, {@spell scrying}",
+																"6th level (1 slot): {@spell eyebite}"
+															]
+														},
+														"For casting these spells, each hag is a 12th-level spellcaster that uses Intelligence as her spellcasting ability. The spell save DC is 12 + the hag's Intelligence modifier, and the spell attack bonus is 4 + the hag's Intelligence modifier."
+													]
+												},
+												{
+													"type": "entries",
+													"name": "Hag Eye",
+													"entries": [
+														"A hag coven can craft a magic item called a hag eye, which is made from a real eye coated in varnish and often fitted to a pendant or other wearable item. The hag eye is usually entrusted to a minion for safekeeping and transport. A hag in the coven can take an action to see what the hag eye sees if the hag eye is on the same plane of existence. A hag eye has AC 10, 1 hit point, and {@sense darkvision} with a radius of 60 feet. If it is destroyed, each coven member takes {@damage 3d10} psychic damage and is {@condition blinded} for 24 hours.",
+														"A hag coven can have only one hag eye at a time, and creating a new one requires all three members of the coven to perform a ritual. The ritual takes 1 hour, and the hags can't perform it while {@condition blinded}. During the ritual, if the hags take any action other than performing the ritual, they must start over."
+													]
+												}
+											]
+										}
 									]
 								}
 							]

--- a/data/bestiary/fluff-bestiary-mm.json
+++ b/data/bestiary/fluff-bestiary-mm.json
@@ -26,7 +26,7 @@
 										{
 											"name": "Search for the Seven Shards",
 											"entries": [
-												" The Wind Dukes of Aaqa come from a race of elemental beings called the vaati, which once ruled many worlds. A creature known as the Queen of Chaos arose and initiated an interplanar war against vaati rule. To combat the threat, seven vaati heroes combined their powers to create the mighty {@i Rod of Law}. In a battle against the queen's greatest general, Mishka the Wolf Spider, a vaati killed Mishka by thrusting the rod into him like a spear. The rod shattered into seven shards that scattered across the multiverse. Aaracokra seek signs of the pieces' locations in order to rebuild what is now known as the {@i Rod of Seven Parts}."
+												"The Wind Dukes of Aaqa come from a race of elemental beings called the vaati, which once ruled many worlds. A creature known as the Queen of Chaos arose and initiated an interplanar war against vaati rule. To combat the threat, seven vaati heroes combined their powers to create the mighty {@i Rod of Law}. In a battle against the queen's greatest general, Mishka the Wolf Spider, a vaati killed Mishka by thrusting the rod into him like a spear. The rod shattered into seven shards that scattered across the multiverse. Aaracokra seek signs of the pieces' locations in order to rebuild what is now known as the {@i Rod of Seven Parts}."
 											],
 											"type": "entries"
 										}
@@ -74,7 +74,7 @@
 										{
 											"name": "Gods in the Lake",
 											"entries": [
-												" Aboleths dwell in watery environments, including ocean abysses, deep lakes, and the Elemental Plane of Water. In these domains and the lands that adjoin them, aboleths are like gods, demanding worship and obedience from their subjects. When they consume other creatures, aboleths add the knowledge and experiences of their prey to their eternal memories. Aboleths use their telepathic powers to read the minds of creatures and know their desires. An aboleth uses this knowledge to gain a creature's loyalty, promising to fulfill such wants in exchange for obedience. Within its lair, the aboleth can further use its powers to override senses, granting creatures, such as its followers, the illusion of promised rewards."
+												"Aboleths dwell in watery environments, including ocean abysses, deep lakes, and the Elemental Plane of Water. In these domains and the lands that adjoin them, aboleths are like gods, demanding worship and obedience from their subjects. When they consume other creatures, aboleths add the knowledge and experiences of their prey to their eternal memories. Aboleths use their telepathic powers to read the minds of creatures and know their desires. An aboleth uses this knowledge to gain a creature's loyalty, promising to fulfill such wants in exchange for obedience. Within its lair, the aboleth can further use its powers to override senses, granting creatures, such as its followers, the illusion of promised rewards."
 											],
 											"type": "entries"
 										}
@@ -179,35 +179,35 @@
 										{
 											"name": "Type",
 											"entries": [
-												" The dracolich's type changes from dragon to undead, and it no longer requires air, food, drink, or sleep."
+												"The dracolich's type changes from dragon to undead, and it no longer requires air, food, drink, or sleep."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Damage Resistance",
 											"entries": [
-												" The dracolich has resistance to necrotic damage."
+												"The dracolich has resistance to necrotic damage."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Damage Immunities",
 											"entries": [
-												" The dracolich has immunity to poison. It also retains any immunities it had prior to becoming a dracolich."
+												"The dracolich has immunity to poison. It also retains any immunities it had prior to becoming a dracolich."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Condition Immunities",
 											"entries": [
-												" The dracolich can't be {@condition charmed}, {@condition frightened}, {@condition paralyzed}, or {@condition poisoned}. It also doesn't suffer from {@condition exhaustion}."
+												"The dracolich can't be {@condition charmed}, {@condition frightened}, {@condition paralyzed}, or {@condition poisoned}. It also doesn't suffer from {@condition exhaustion}."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Magic Resistance",
 											"entries": [
-												" The dracolich has advantage on saving throws against spells and other magical effects."
+												"The dracolich has advantage on saving throws against spells and other magical effects."
 											],
 											"type": "entries"
 										}
@@ -477,22 +477,20 @@
 			}
 		},
 		{
-			"name": "Androsphinx",
+			"name": "Sphinxes",
 			"source": "MM",
 			"entries": [
 				{
-					"type": "entries",
+					"type": "section",
+					"name": "Sphinxes",
 					"entries": [
+						"In sacred isolation, a sphinx guards the secrets and treasures of the gods. As it calmly regards each new party that comes before it, the bones of supplicants and quest seekers that failed to pass its tests lie scattered around its lair. Its great wings sweep along its flanks, its tawny leonine body rippling with muscle and possessed of forepaws powerful enough to tear a humanoid in half.",
 						{
 							"type": "entries",
 							"entries": [
-								"An androsphinx bears the head of a humanoid male on its lion's body. Outwardly gruff and downcast, it often begins conversations with insults or negative observations. Beneath this gruff exterior, however, an androsphinx has a noble heart. It has no wish to lie or deceive, but it doesn't give away information readily, choosing its words as wisely as it guards its secrets.",
-								"An androsphinx tests the courage and valor of supplicants, not only by forcing them to complete quests but also with its terrible roar, which echoes for miles as it terrifies and deafens nearby creatures. Those who pass its tests may be rewarded with a heroes' feast.",
 								{
 									"type": "entries",
-									"name": "Sphinxes",
 									"entries": [
-										"In sacred isolation, a sphinx guards the secrets and treasures of the gods. As it calmly regards each new party that comes before it, the bones of supplicants and quest seekers that failed to pass its tests lie scattered around its lair. Its great wings sweep along its flanks, its tawny leonine body rippling with muscle and possessed of forepaws powerful enough to tear a humanoid in half.",
 										{
 											"type": "entries",
 											"name": "Divine Guardians",
@@ -504,7 +502,7 @@
 										{
 											"name": "Magical Tests",
 											"entries": [
-												" The secrets and treasures a sphinx guards remain under divine protection, so that when a creature fails a sphinx's test, the path to the object or knowledge it guards vanishes. Even if a sphinx is attacked and defeated, a quester will still fail to gain the secret it sought-and will make an enemy of the god that placed the sphinx as a guardian.",
+												"The secrets and treasures a sphinx guards remain under divine protection, so that when a creature fails a sphinx's test, the path to the object or knowledge it guards vanishes. Even if a sphinx is attacked and defeated, a quester will still fail to gain the secret it sought-and will make an enemy of the god that placed the sphinx as a guardian.",
 												"Benign deities sometimes grant a sphinx the power to remove supplicants that fail their tests, transporting them away and ensuring that they never encounter the sphinx again. However, those who fail a sphinx's test typically meet a gruesome end beneath its claws."
 											],
 											"type": "entries"
@@ -512,16 +510,31 @@
 										{
 											"name": "Extraplanar Beings",
 											"entries": [
-												" Mortals that encounter sphinxes do so most often in ancient tombs and ruins, but some sphinxes can access extraplanar realms. A conversation with a sphinx that begins between tumbled stone walls might suddenly shift to an alien locale, such as a life-sized game board or a daunting cliff that must be climbed in a howling storm. Sometimes a sphinx must be summoned from such an extradimensional space, with supplicants calling it from its empty lair. Only those the sphinx deems worthy gain admittance to its realm."
+												"Mortals that encounter sphinxes do so most often in ancient tombs and ruins, but some sphinxes can access extraplanar realms. A conversation with a sphinx that begins between tumbled stone walls might suddenly shift to an alien locale, such as a life-sized game board or a daunting cliff that must be climbed in a howling storm. Sometimes a sphinx must be summoned from such an extradimensional space, with supplicants calling it from its empty lair. Only those the sphinx deems worthy gain admittance to its realm."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Fallen Sphinxes",
 											"entries": [
-												" Whether through the weariness of the ages, regret at the slaughter of innocents, or dreams of worship by supplicants that attempt to bargain their way to knowledge, some sphinxes break free of their divine command. However, even if a sphinx's alignment and loyalties drift in this way, it never leaves the place it guards or grants its secrets to any except creatures it deems worthy."
+												"Whether through the weariness of the ages, regret at the slaughter of innocents, or dreams of worship by supplicants that attempt to bargain their way to knowledge, some sphinxes break free of their divine command. However, even if a sphinx's alignment and loyalties drift in this way, it never leaves the place it guards or grants its secrets to any except creatures it deems worthy."
 											],
 											"type": "entries"
+										}
+									]
+								},
+								{
+									"type": "insetReadaloud",
+									"entries": [
+										{
+											"type": "quote",
+											"entries": [
+												"Round she is, yet flat as a board",
+												"Altar of the Lupine Lords",
+												"Jewel on black velvet, pearl in the sea",
+												"Unchanged but e'erchanging, eternally."
+											],
+											"by": "Riddle of the gynosphinx of White Plume Mountain"
 										}
 									]
 								},
@@ -535,6 +548,23 @@
 							]
 						}
 					]
+				}
+			]
+		},
+		{
+			"name": "Androsphinx",
+			"source": "MM",
+			"_copy": {
+				"name": "Sphinxes",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": [
+							"An androsphinx bears the head of a humanoid male on its lion's body. Outwardly gruff and downcast, it often begins conversations with insults or negative observations. Beneath this gruff exterior, however, an androsphinx has a noble heart. It has no wish to lie or deceive, but it doesn't give away information readily, choosing its words as wisely as it guards its secrets.",
+							"An androsphinx tests the courage and valor of supplicants, not only by forcing them to complete quests but also with its terrible roar, which echoes for miles as it terrifies and deafens nearby creatures. Those who pass its tests may be rewarded with a heroes' feast."
+						]
+					}
 				}
 			],
 			"images": [
@@ -822,7 +852,7 @@
 								{
 									"name": "Made, Not Born",
 									"entries": [
-										" Azers don't reproduce. They are each crafted from bronze by another azer and imbued with a portion of the crafter's inner flame. Each azer is sculpted with unique features. This crafting process limits the growth of the azer population and is the primary reason that these creatures remain rare."
+										"Azers don't reproduce. They are each crafted from bronze by another azer and imbued with a portion of the crafter's inner flame. Each azer is sculpted with unique features. This crafting process limits the growth of the azer population and is the primary reason that these creatures remain rare."
 									],
 									"type": "entries"
 								},
@@ -1418,7 +1448,7 @@
 										{
 											"name": "Slow Death",
 											"entries": [
-												" An ooze kills its prey slowly. Some varieties, such as black puddings and gelatinous cubes, engulf creatures to prevent escape. The only upside of this torturous death is that a victim's comrades can come to the rescue before it is too late.",
+												"An ooze kills its prey slowly. Some varieties, such as black puddings and gelatinous cubes, engulf creatures to prevent escape. The only upside of this torturous death is that a victim's comrades can come to the rescue before it is too late.",
 												"Since not every ooze digests every type of substance, some have coins, metal gear, bones, and other debris suspended within their quivering bodies. A slain ooze can be a rich source of treasure for its killers.",
 												"Whether this is true or not, the Faceless Lord is one of the few beings that can control oozes and imbue them with a modicum of intelligence. Most of the time, oozes have no sense of tactics or self-preservation. They are direct and predictable, attacking and eating without cunning. Under the control of Juiblex, they exhibit glimmers of sentience and malevolent intent."
 											],
@@ -1427,21 +1457,21 @@
 										{
 											"name": "Unwitting Servants",
 											"entries": [
-												" Although an ooze lacks the intelligence to ally itself with other creatures, others that understand an ooze's need to feed might lure it into a location where it can be of use to them. Clever monsters keep oozes around to defend passageways or consume refuse. Likewise, an ooze can be enticed into a pit trap, where its captors feed it often enough to prevent it from coming after them. Crafty creatures place torches and flaming braziers in strategic areas to dissuade an ooze from leaving a particular tunnel or room."
+												"Although an ooze lacks the intelligence to ally itself with other creatures, others that understand an ooze's need to feed might lure it into a location where it can be of use to them. Clever monsters keep oozes around to defend passageways or consume refuse. Likewise, an ooze can be enticed into a pit trap, where its captors feed it often enough to prevent it from coming after them. Crafty creatures place torches and flaming braziers in strategic areas to dissuade an ooze from leaving a particular tunnel or room."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Spawn of Juiblex",
 											"entries": [
-												" According to the Demonomicon of Iggwilv and other sources, oozes are scattered fragments or offspring of the demon lord Juiblex."
+												"According to the Demonomicon of Iggwilv and other sources, oozes are scattered fragments or offspring of the demon lord Juiblex."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Ooze Nature",
 											"entries": [
-												" An ooze doesn't require sleep."
+												"An ooze doesn't require sleep."
 											],
 											"type": "entries"
 										}
@@ -1689,21 +1719,21 @@
 										{
 											"name": "Benevolent Dictators and Brutal Tyrants",
 											"entries": [
-												" A naga rules its domain with absolute authority. Whether it rules with compassion or by terrorizing its subjects, the naga believes itself the master of all other creatures that inhabit its domain."
+												"A naga rules its domain with absolute authority. Whether it rules with compassion or by terrorizing its subjects, the naga believes itself the master of all other creatures that inhabit its domain."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Rivalry",
 											"entries": [
-												" Nagas have a long-standing enmity with the yuan-ti, with each race seeing itself as the epitome of serpentine evolution. Though cooperation between them is rare, nagas and yuan-ti sometimes set aside their differences to work toward common objectives. However, yuan-ti always chafe under a naga's authority."
+												"Nagas have a long-standing enmity with the yuan-ti, with each race seeing itself as the epitome of serpentine evolution. Though cooperation between them is rare, nagas and yuan-ti sometimes set aside their differences to work toward common objectives. However, yuan-ti always chafe under a naga's authority."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Immortal Nature",
 											"entries": [
-												" A naga doesn't require air, food, drink, or sleep."
+												"A naga doesn't require air, food, drink, or sleep."
 											],
 											"type": "entries"
 										}
@@ -1838,7 +1868,7 @@
 												{
 													"name": "Well-Organized Wealth",
 													"entries": [
-														" Bronze dragons loot sunken ships and also collect colorful coral and pearls from the reefs and seabeds near their lairs. When a bronze dragon pledges to help an army wage war against tyranny, it asks for nominal payment. If such a request is beyond its allies' means, it might settle for a collection of old books on military history or a ceremonial item commemorating the alliance. A bronze dragon might also lay claim to a treasure held by the enemy that it feels would be safer under its protection."
+														"Bronze dragons loot sunken ships and also collect colorful coral and pearls from the reefs and seabeds near their lairs. When a bronze dragon pledges to help an army wage war against tyranny, it asks for nominal payment. If such a request is beyond its allies' means, it might settle for a collection of old books on military history or a ceremonial item commemorating the alliance. A bronze dragon might also lay claim to a treasure held by the enemy that it feels would be safer under its protection."
 													],
 													"type": "entries"
 												}
@@ -2305,7 +2335,7 @@
 								{
 									"name": "Driven by Greed",
 									"entries": [
-										" Chromatic dragons lust after treasure, and this greed colors their every scheme and plot. They believe that the world's wealth belongs to them by right, and a chromatic dragon seizes that wealth without regard for the humanoids and other creatures that have \"stolen\" it. With its piles of coins, gleaming gems, and magic items, a dragon's hoard is the stuff of legend. However, chromatic dragons have no interest in commerce, amassing wealth for no other reason than to have it."
+										"Chromatic dragons lust after treasure, and this greed colors their every scheme and plot. They believe that the world's wealth belongs to them by right, and a chromatic dragon seizes that wealth without regard for the humanoids and other creatures that have \"stolen\" it. With its piles of coins, gleaming gems, and magic items, a dragon's hoard is the stuff of legend. However, chromatic dragons have no interest in commerce, amassing wealth for no other reason than to have it."
 									],
 									"type": "entries"
 								},
@@ -2389,27 +2419,25 @@
 			]
 		},
 		{
-			"name": "Clay Golem",
+			"name": "Golems",
 			"source": "MM",
 			"entries": [
 				{
-					"type": "entries",
+					"type": "section",
+					"name": "Golems",
 					"entries": [
+						"Golems are made from humble materials-clay, flesh and bones, iron, or stone-but they possess astonishing power and durability. A golem has no ambitions, needs no sustenance, feels no pain, and knows no remorse. An unstoppable juggernaut, it exists to follow its creator's orders, and it protects or attacks as that creator demands.",
+						"To create a golem, one requires a {@item manual of golems}. The comprehensive illustrations and instructions in a manual detail the process for creating a golem of a particular type.",
 						{
 							"type": "entries",
 							"entries": [
-								"Sculpted from clay, this bulky golem stands head and shoulders taller than most human-sized creatures. It is human shaped, but its proportions are off.",
-								"Clay golems are often divinely endowed with purpose by priests of great faith. However, clay is a weak vessel for life force. If the golem is damaged, the elemental spirit bound into it can break free. Such a golem runs amok, smashing everything around it until it is destroyed or completely repaired.",
 								{
 									"type": "entries",
-									"name": "Golems",
 									"entries": [
-										"Golems are made from humble materials-clay, flesh and bones, iron, or stone-but they possess astonishing power and durability. A golem has no ambitions, needs no sustenance, feels no pain, and knows no remorse. An unstoppable juggernaut, it exists to follow its creator's orders, and it protects or attacks as that creator demands.",
-										"To create a golem, one requires a manual of golems (see the Dungeon Master's Guide). The comprehensive illustrations and instructions in a manual detail the process for creating a golem of a particular type.",
 										{
 											"name": "Elemental Spirit in Material Form",
 											"entries": [
-												" The construction of a golem begins with the building of its body, requiring great command of the craft of sculpting, stonecutting, ironworking, or surgery. Sometimes a golem's creator is the master of the art, but often the individual who desires a golem must enlist master artisans to do the work.",
+												"The construction of a golem begins with the building of its body, requiring great command of the craft of sculpting, stonecutting, ironworking, or surgery. Sometimes a golem's creator is the master of the art, but often the individual who desires a golem must enlist master artisans to do the work.",
 												"After constructing the body from clay, flesh, iron, or stone, the golem's creator infuses it with a spirit from the Elemental Plane of Earth. This tiny spark of life has no memory, personality, or history. It is simply the impetus to move and obey. This process binds the spirit to the artificial body and subjects it to the will of the golem's creator.",
 												"A golem can be created with a special amulet or other item that allows the possessor of the item to control the golem. Golems whose creators are long dead can thus be harnessed to serve a new master.",
 												"A golem can't think or act for itself. Though it understands its commands perfectly, it has no grasp of language beyond that understanding, and can't be reasoned with or tricked with words."
@@ -2419,31 +2447,61 @@
 										{
 											"name": "Ageless Guardians",
 											"entries": [
-												" Golems can guard sacred sites, tombs, and treasure vaults long after the deaths of their creators, carrying out their appointed tasks for all eternity while brushing off physical damage and ignoring all but the most potent spells."
+												"Golems can guard sacred sites, tombs, and treasure vaults long after the deaths of their creators, carrying out their appointed tasks for all eternity while brushing off physical damage and ignoring all but the most potent spells."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Blind Obedience",
 											"entries": [
-												" When its creator or possessor is on hand to command it, a golem performs flawlessly. If the golem is left without instructions or is {@condition incapacitated}, it continues to follow its last orders to the best of its ability. When it can't fulfill its orders, a golem might react violently-or stand and do nothing. A golem that has been given conflicting orders sometimes alternates between them."
+												"When its creator or possessor is on hand to command it, a golem performs flawlessly. If the golem is left without instructions or is {@condition incapacitated}, it continues to follow its last orders to the best of its ability. When it can't fulfill its orders, a golem might react violently-or stand and do nothing. A golem that has been given conflicting orders sometimes alternates between them."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Constructed Nature",
 											"entries": [
-												" A golem doesn't require air, food, drink, or sleep."
+												"A golem doesn't require air, food, drink, or sleep."
 											],
 											"type": "entries"
 										}
 									]
 								}
 							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"Beyond the unopenable doors lay a grand hall ending before a towering stone throne, upon which sat an iron statue taller and wider than two men. In one  and it clutched an iron sword, in the other, a feather whip. We should have turned back then."
+									],
+									"by": "Mordenkainen the Archmage",
+									"from": "chronicling his party's harrowing exploits in the dungeons below Maure Castle"
+								}
+							]
 						}
 					]
 				}
-			],
+			]
+		},
+		{
+			"name": "Clay Golem",
+			"source": "MM",
+			"_copy": {
+				"name": "Golems",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": [
+							"Sculpted from clay, this bulky golem stands head and shoulders taller than most human-sized creatures. It is human shaped, but its proportions are off.",
+							"Clay golems are often divinely endowed with purpose by priests of great faith. However, clay is a weak vessel for life force. If the golem is damaged, the elemental spirit bound into it can break free. Such a golem runs amok, smashing everything around it until it is destroyed or completely repaired."
+						]
+					}
+				}
+			},
 			"images": [
 				{
 					"type": "image",
@@ -2940,7 +2998,7 @@
 										{
 											"name": "Creatures of the Elements",
 											"entries": [
-												" A genie is born when the soul of a sentient living creature melds with the primordial matter of an elemental plane. Only under rare circumstances does such an elemental-infused soul coalesce into a manifest form and create a genie.",
+												"A genie is born when the soul of a sentient living creature melds with the primordial matter of an elemental plane. Only under rare circumstances does such an elemental-infused soul coalesce into a manifest form and create a genie.",
 												"A genie usually retains no connection to the soul that gave it form. That life force is a building block that determines the genie's form and apparent gender, as well as one or two key personality traits. Although they resemble humanoid beings, genies are elemental spirits given physical form. They don't mate with other genies or produce genie offspring, as all new genies are born out of the same mysterious fusion of spirit energy and elemental power. A genie with a stronger connection to its mortal soul might choose to sire a child with a mortal, although such offspring are rare.",
 												"When a genie perishes, it leaves nothing behind except what it was wearing or carrying, along with a small trace of its native element: a pile of dust, a gust of wind, a flash of fire and smoke, or a burst of water and foam.",
 												"In contrast to their love of slaves, most genies loathe being bound to service themselves. A genie obeys the will of another only when bribed or compelled by magic. All genies command the power of their native element, but a rare few also possess the power to grant wishes. For both these reasons, mortal mages often seek to bind genies into service.",
@@ -2952,21 +3010,21 @@
 										{
 											"name": "Rule or Be Ruled",
 											"entries": [
-												" Mortal slaves serve to validate a genie's power and high self-opinion. A hundred flattering voices are music to a genie's ears, while two hundred mortal slaves prostrated at its feet are proof that it is lord and master. Genies view slaves as living property, and a genie without property amounts to nothing among its own kind. As a result, many genies treasure their slaves, treating them as honored members of their households. Evil genies freely threaten and abuse their slaves, but never to the extent that the slaves are no longer of use."
+												"Mortal slaves serve to validate a genie's power and high self-opinion. A hundred flattering voices are music to a genie's ears, while two hundred mortal slaves prostrated at its feet are proof that it is lord and master. Genies view slaves as living property, and a genie without property amounts to nothing among its own kind. As a result, many genies treasure their slaves, treating them as honored members of their households. Evil genies freely threaten and abuse their slaves, but never to the extent that the slaves are no longer of use."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Decadent Nobility",
 											"entries": [
-												" Noble genies are the rarest of their kind. They are used to getting what they want, and have learned to trade their ability to grant wishes to attain the objects of their desire. This constant indulgence has made them decadent, while their supreme power over reality makes them haughty and arrogant. Their vast palaces overflow with wonders and sensory delights beyond imagination."
+												"Noble genies are the rarest of their kind. They are used to getting what they want, and have learned to trade their ability to grant wishes to attain the objects of their desire. This constant indulgence has made them decadent, while their supreme power over reality makes them haughty and arrogant. Their vast palaces overflow with wonders and sensory delights beyond imagination."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "The Power of Worship",
 											"entries": [
-												" Genies acknowledge the gods as powerful entities but have no desire to court or worship them. They find the endless fawning and mewling of religious devotees tiresome-except as it is directed toward them by their worshipful slaves."
+												"Genies acknowledge the gods as powerful entities but have no desire to court or worship them. They find the endless fawning and mewling of religious devotees tiresome-except as it is directed toward them by their worshipful slaves."
 											],
 											"type": "entries"
 										}
@@ -3277,7 +3335,7 @@
 										{
 											"name": "Trap Soul",
 											"entries": [
-												" The demilich targets one creature that it can see within 30 feet of it. The target must make a DC 19 Charisma saving throw. On a failed save, the target's soul is magically trapped inside one of the demilich's gems. While the soul is trapped, the target's body and all the equipment it is carrying cease to exist. On a successful save, the target takes 24 ({@damage 7d6}) necrotic damage, and if this damage reduces the target to 0 hit points, its soul is trapped as if it failed the saving throw. A soul trapped in a gem for 24 hours is devoured and ceases to exist.",
+												"The demilich targets one creature that it can see within 30 feet of it. The target must make a DC 19 Charisma saving throw. On a failed save, the target's soul is magically trapped inside one of the demilich's gems. While the soul is trapped, the target's body and all the equipment it is carrying cease to exist. On a successful save, the target takes 24 ({@damage 7d6}) necrotic damage, and if this damage reduces the target to 0 hit points, its soul is trapped as if it failed the saving throw. A soul trapped in a gem for 24 hours is devoured and ceases to exist.",
 												"If the demilich drops to 0 hit points, it is destroyed and turns to powder, leaving behind its gems. Crushing a gem releases any soul trapped within, at which point the target's body re-forms in an unoccupied space nearest to the gem and in the same state as when it was trapped."
 											],
 											"type": "entries"
@@ -3722,151 +3780,39 @@
 			"name": "Devils",
 			"source": "MM",
 			"entries": [
-				"Devils personify tyranny, with a totalitarian society dedicated to the domination of mortal life. The shadow of the Nine Hells of Baator extends far across the multiverse, and Asmodeus, the dark lord of Nessus, strives to subjugate the cosmos to satisfy his thirst for power. To do so, he must continually expand his infernal armies, sending his servants to the mortal realm to corrupt the souls from which new devils are spawned.",
 				{
-					"type": "entries",
+					"type": "section",
+					"name": "Devils",
 					"entries": [
+						"Devils personify tyranny, with a totalitarian society dedicated to the domination of mortal life. The shadow of the Nine Hells of Baator extends far across the multiverse, and Asmodeus, the dark lord of Nessus, strives to subjugate the cosmos to satisfy his thirst for power. To do so, he must continually expand his infernal armies, sending his servants to the mortal realm to corrupt the souls from which new devils are spawned.",
 						{
 							"type": "entries",
 							"entries": [
 								{
 									"type": "entries",
-									"name": "Lords of Tyranny",
 									"entries": [
-										"Devils live to conquer, enslave, and oppress. They take perverse delight in exercising authority over the weak, and any creature that defies the authority of a devil faces swift and cruel punishment. Every interaction is an opportunity for a devil to display its power, and all devils have a keen understanding of how to use and abuse their power.",
-										"Devils understand the failings that plague intelligent mortals, and they use that knowledge to lead mortals into temptation and darkness, turning creatures into slaves to their own corruption. Devils on the Material Plane use their influence to manipulate humanoid rulers, whispering evil thoughts, fomenting paranoia, and eventually driving them to tyrannical actions."
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Obedience and Ambition",
-									"entries": [
-										"In accordance with their lawful alignment, devils obey even when they envy or dislike their superiors, knowing that their obedience will be rewarded. The hierarchy of the Nine Hells depends on this unswerving loyalty, without which that fiendish plane would become as anarchic as the Abyss.",
-										"At the same time, it is in the nature of devils to scheme, creating in some a desire to rule that eclipses their contentment to be ruled. This singular ambition is strongest among the archdevils whom Asmodeus appoints to rule the nine layers of the Nine Hells. These high-ranking fiends are the only devils to ever sample true power, which they crave like the sweetest ambrosia."
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Dark Dealers and Soul Mongers",
-									"entries": [
-										"Devils are confined to the Lower Planes, but they can travel beyond those planes by way of portals or powerful summoning magic. They love to strike bargains with mortals seeking to gain some benefit or prize, but a mortal making such a bargain must be wary. Devils are crafty negotiators and positively ruthless at enforcing the terms of an agreement. Moreover, a contract with even the lowliest devil is enforced by Asmodeus's will. Any mortal creature that breaks such a contract instantly forfeits its soul, which is spirited away to the Nine Hells.",
-										"To own a creature's soul is to have absolute control over that creature, and most devils accept no other currency in exchange for the fiendish power and boons they can provide. A soul is usually forfeited when a mortal dies naturally, for devils are immortal and can wait years for a contract to play out. If a contract allows a devil to claim a mortal's soul before death, it can instantly return to the Nine Hells with the soul in its possession. Only divine intervention can release a soul after a devil has claimed it."
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					"type": "entries",
-					"name": "The Infernal Hierarchy",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								"The Nine Hells has a rigid hierarchy that defines every aspect of its society. Asmodeus is the supreme ruler of all devils, and the only creature in the Nine Hells with the powers of a lesser god. Worshiped as such in the Material Plane, Asmodeus inspires the evil humanoid cults that take his name. In the Nine Hells, he commands scores of pit fiend generals, which in turn command legions of subordinates.",
-								"A supreme tyrant, a brilliant deceiver, and a master of subtlety, Asmodeus protects his throne by keeping his friends close and his enemies closer. He delegates most matters of rulership to the pit fiends and lesser archdevils that make up the infernal bureaucracy of the Nine Hells, even as he knows that those powerful devils conspire to usurp the Throne of Baator from which he rules. Asmodeus appoints archdevils, and he can strip any member of the infernal hierarchy of rank and status as he likes.",
-								"If it dies outside the Nine Hells, a devil disappears in a cloud of sulfurous smoke or dissolves into a pool of ichor, instantly returning to its home layer, where it reforms at full strength. Devils that die in the Nine Hells are destroyed forever-a fate that even Asmodeus fears.",
-								{
-									"type": "entries",
-									"name": "Archdevils",
-									"entries": [
-										"The archdevils include all the current and deposed rulers of the Nine Hells (see the Layers and Lords of the Nine Hells table), as well as the dukes and duchesses that make up their courts, attend them as advisers, and hope to supplant them. Every archdevil is a unique being with an appearance that reflects its particular evil nature."
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Greater Devils",
-									"entries": [
-										"The greater devils include the pit fiends, erinyes, horned devils, and ice devils that command lesser devils and attend the archdevils."
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Lesser Devils",
-									"entries": [
-										"The lesser devils include numerous strains of fiends, including imps, chain devils, spined devils, bearded devils, barbed devils, and bone devils."
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Lemures",
-									"entries": [
-										"The lowest form of devil, lemures are the twisted and tormented souls of evil and corrupted mortals. A lemure killed in the Nine Hells is only permanently destroyed if it is killed with a blessed weapon or if its shapeless corpse is splashed with holy water before it can return to life."
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Promotion and Demotion",
-									"entries": [
-										"When the soul of an evil mortal sinks into the Nine Hells, it takes on the physical form of a wretched lemure. Archdevils and greater devils have the power to promote lemures to lesser devils. Archdevils can promote lesser devils to greater devils, and Asmodeus alone can promote a greater devil to archdevil status. This diabolic promotion invokes a brief, painful transformation, with the devil's memories passing intact from one form to the next.",
-										"Low-level promotions are typically based on need, such as when a pit fiend transforms lemures into imps to gain invisible spies under its command. High-level promotions are almost always based on merit, such as when a bone devil that distinguishes itself in battle is transformed into a horned devil by the archdevil it serves. A devil is seldom promoted more than one step at a time in the hierarchy of infernal forms.",
-										"Demotion is the customary punishment for failure or disobedience among the devils. Archdevils or greater devils can demote a lesser devil to a lemure, which loses all memory of its prior existence. An archdevil can demote a greater devil to lesser devil status, but the demoted devil retains its memories-and might seek vengeance if the severity of the demotion is excessive.",
-										"No devil can promote or demote another devil that has not sworn fealty to it, preventing rival archdevils from demoting each other's most powerful servants. Since all devils swear fealty to Asmodeus, he can freely demote any other devil, transforming it into whatever infernal form he desires.",
 										{
-											"type": "table",
-											"caption": "Infernal Hierarchy",
-											"colLabels": [
-												"Rank",
-												"Devil(s)"
-											],
-											"colStyles": [
-												"col-4",
-												"col-8"
-											],
-											"rows": [
-												[
-													"1.",
-													"lemure"
-												],
-												[
-													"2. (Lesser devils)",
-													"imp"
-												],
-												[
-													"3.",
-													"spined devil"
-												],
-												[
-													"4.",
-													"bearded devil"
-												],
-												[
-													"5.",
-													"barbed devil"
-												],
-												[
-													"6.",
-													"chain devil"
-												],
-												[
-													"7.",
-													"bone devil"
-												],
-												[
-													"8. (Greater devils)",
-													"horned devil"
-												],
-												[
-													"9.",
-													"erinyes"
-												],
-												[
-													"10.",
-													"ice devil"
-												],
-												[
-													"11.",
-													"pit fiend"
-												],
-												[
-													"12. (Archdevils)",
-													"duke or duchess"
-												],
-												[
-													"13.",
-													"archduke or archduchess"
-												]
+											"type": "entries",
+											"name": "Lords of Tyranny",
+											"entries": [
+												"Devils live to conquer, enslave, and oppress. They take perverse delight in exercising authority over the weak, and any creature that defies the authority of a devil faces swift and cruel punishment. Every interaction is an opportunity for a devil to display its power, and all devils have a keen understanding of how to use and abuse their power.",
+												"Devils understand the failings that plague intelligent mortals, and they use that knowledge to lead mortals into temptation and darkness, turning creatures into slaves to their own corruption. Devils on the Material Plane use their influence to manipulate humanoid rulers, whispering evil thoughts, fomenting paranoia, and eventually driving them to tyrannical actions."
+											]
+										},
+										{
+											"type": "entries",
+											"name": "Obedience and Ambition",
+											"entries": [
+												"In accordance with their lawful alignment, devils obey even when they envy or dislike their superiors, knowing that their obedience will be rewarded. The hierarchy of the Nine Hells depends on this unswerving loyalty, without which that fiendish plane would become as anarchic as the Abyss.",
+												"At the same time, it is in the nature of devils to scheme, creating in some a desire to rule that eclipses their contentment to be ruled. This singular ambition is strongest among the archdevils whom Asmodeus appoints to rule the nine layers of the Nine Hells. These high-ranking fiends are the only devils to ever sample true power, which they crave like the sweetest ambrosia."
+											]
+										},
+										{
+											"type": "entries",
+											"name": "Dark Dealers and Soul Mongers",
+											"entries": [
+												"Devils are confined to the Lower Planes, but they can travel beyond those planes by way of portals or powerful summoning magic. They love to strike bargains with mortals seeking to gain some benefit or prize, but a mortal making such a bargain must be wary. Devils are crafty negotiators and positively ruthless at enforcing the terms of an agreement. Moreover, a contract with even the lowliest devil is enforced by Asmodeus's will. Any mortal creature that breaks such a contract instantly forfeits its soul, which is spirited away to the Nine Hells.",
+												"To own a creature's soul is to have absolute control over that creature, and most devils accept no other currency in exchange for the fiendish power and boons they can provide. A soul is usually forfeited when a mortal dies naturally, for devils are immortal and can wait years for a contract to play out. If a contract allows a devil to claim a mortal's soul before death, it can instantly return to the Nine Hells with the soul in its possession. Only divine intervention can release a soul after a devil has claimed it."
 											]
 										}
 									]
@@ -3875,130 +3821,248 @@
 						},
 						{
 							"type": "entries",
-							"name": "The Nine Hells",
+							"name": "The Infernal Hierarchy",
 							"entries": [
-								"The Nine Hells are a single plane comprising nine separate layers (see the Layers and Lords of the Nine Hells table). The first eight layers are each ruled by archdevils that answer to the greatest archdevil of all: Asmodeus, the Archduke of Nessus, the ninth layer. To reach the deepest layer of the Nine Hells, one must descend through all eight of the layers above it, in order. The most expeditious means of doing so is the River Styx, which plunges ever deeper as it flows from one layer to the next. Only the most courageous adventurers can withstand the torment and horror of that journey.",
 								{
-									"type": "table",
-									"caption": "Layers and Lords of the Nine Hells Layer",
-									"colLabels": [
-										"Layer",
-										"Layer Name",
-										"Archduke or Archduchess",
-										"Previous Rulers",
-										"Primary Inhabitants"
-									],
-									"colStyles": [
-										"col-1",
-										"col-2",
-										"col-3",
-										"col-3",
-										"col-3"
-									],
-									"rows": [
-										[
-											"1",
-											"Avernus",
-											"Zariel",
-											"Bel, Tiamat",
-											"Erinyes, imps, spined devils"
-										],
-										[
-											"2",
-											"Dis",
-											"Dispater",
-											"\u2014",
-											"Bearded devils, erinyes, imps, spined devils"
-										],
-										[
-											"3",
-											"Minauros",
-											"Mammon",
-											"\u2014",
-											"Bearded devils, chain devils, imps, spined devils"
-										],
-										[
-											"4",
-											"Phlegethos",
-											"Belial and Fierna",
-											"\u2014",
-											"Barbed devils, bone devils, imps, spined devils"
-										],
-										[
-											"5",
-											"Stygia",
-											"Levistus",
-											"Geryon",
-											"Bone devils, erinyes, ice devils, imps"
-										],
-										[
-											"6",
-											"Malbolge",
-											"Glasya",
-											"Malagard, Moloch",
-											"Barbed devils, bone devils, horned devils, imps"
-										],
-										[
-											"7",
-											"Maladomini",
-											"Baalzebul",
-											"\u2014",
-											"Barbed devils, bone devils, horned devils, imps"
-										],
-										[
-											"8",
-											"Cania",
-											"Mephistopheles",
-											"\u2014",
-											"Horned devils, ice devils, imps, pit fiends"
-										],
-										[
-											"9",
-											"Nessus",
-											"Asmodeus",
-											"\u2014",
-											"All devils"
-										]
+									"type": "entries",
+									"entries": [
+										"The Nine Hells has a rigid hierarchy that defines every aspect of its society. Asmodeus is the supreme ruler of all devils, and the only creature in the Nine Hells with the powers of a lesser god. Worshiped as such in the Material Plane, Asmodeus inspires the evil humanoid cults that take his name. In the Nine Hells, he commands scores of pit fiend generals, which in turn command legions of subordinates.",
+										"A supreme tyrant, a brilliant deceiver, and a master of subtlety, Asmodeus protects his throne by keeping his friends close and his enemies closer. He delegates most matters of rulership to the pit fiends and lesser archdevils that make up the infernal bureaucracy of the Nine Hells, even as he knows that those powerful devils conspire to usurp the Throne of Baator from which he rules. Asmodeus appoints archdevils, and he can strip any member of the infernal hierarchy of rank and status as he likes.",
+										"If it dies outside the Nine Hells, a devil disappears in a cloud of sulfurous smoke or dissolves into a pool of ichor, instantly returning to its home layer, where it reforms at full strength. Devils that die in the Nine Hells are destroyed forever-a fate that even Asmodeus fears.",
+										{
+											"type": "entries",
+											"name": "Archdevils",
+											"entries": [
+												"The archdevils include all the current and deposed rulers of the Nine Hells (see the Layers and Lords of the Nine Hells table), as well as the dukes and duchesses that make up their courts, attend them as advisers, and hope to supplant them. Every archdevil is a unique being with an appearance that reflects its particular evil nature."
+											]
+										},
+										{
+											"type": "entries",
+											"name": "Greater Devils",
+											"entries": [
+												"The greater devils include the pit fiends, erinyes, horned devils, and ice devils that command lesser devils and attend the archdevils."
+											]
+										},
+										{
+											"type": "entries",
+											"name": "Lesser Devils",
+											"entries": [
+												"The lesser devils include numerous strains of fiends, including imps, chain devils, spined devils, bearded devils, barbed devils, and bone devils."
+											]
+										},
+										{
+											"type": "entries",
+											"name": "Lemures",
+											"entries": [
+												"The lowest form of devil, lemures are the twisted and tormented souls of evil and corrupted mortals. A lemure killed in the Nine Hells is only permanently destroyed if it is killed with a blessed weapon or if its shapeless corpse is splashed with holy water before it can return to life."
+											]
+										},
+										{
+											"type": "entries",
+											"name": "Promotion and Demotion",
+											"entries": [
+												"When the soul of an evil mortal sinks into the Nine Hells, it takes on the physical form of a wretched lemure. Archdevils and greater devils have the power to promote lemures to lesser devils. Archdevils can promote lesser devils to greater devils, and Asmodeus alone can promote a greater devil to archdevil status. This diabolic promotion invokes a brief, painful transformation, with the devil's memories passing intact from one form to the next.",
+												"Low-level promotions are typically based on need, such as when a pit fiend transforms lemures into imps to gain invisible spies under its command. High-level promotions are almost always based on merit, such as when a bone devil that distinguishes itself in battle is transformed into a horned devil by the archdevil it serves. A devil is seldom promoted more than one step at a time in the hierarchy of infernal forms.",
+												"Demotion is the customary punishment for failure or disobedience among the devils. Archdevils or greater devils can demote a lesser devil to a lemure, which loses all memory of its prior existence. An archdevil can demote a greater devil to lesser devil status, but the demoted devil retains its memories-and might seek vengeance if the severity of the demotion is excessive.",
+												"No devil can promote or demote another devil that has not sworn fealty to it, preventing rival archdevils from demoting each other's most powerful servants. Since all devils swear fealty to Asmodeus, he can freely demote any other devil, transforming it into whatever infernal form he desires.",
+												{
+													"type": "table",
+													"caption": "Infernal Hierarchy",
+													"colLabels": [
+														"Rank",
+														"Devil(s)"
+													],
+													"colStyles": [
+														"col-4",
+														"col-8"
+													],
+													"rows": [
+														[
+															"1.",
+															"lemure"
+														],
+														[
+															"2. (Lesser devils)",
+															"imp"
+														],
+														[
+															"3.",
+															"spined devil"
+														],
+														[
+															"4.",
+															"bearded devil"
+														],
+														[
+															"5.",
+															"barbed devil"
+														],
+														[
+															"6.",
+															"chain devil"
+														],
+														[
+															"7.",
+															"bone devil"
+														],
+														[
+															"8. (Greater devils)",
+															"horned devil"
+														],
+														[
+															"9.",
+															"erinyes"
+														],
+														[
+															"10.",
+															"ice devil"
+														],
+														[
+															"11.",
+															"pit fiend"
+														],
+														[
+															"12. (Archdevils)",
+															"duke or duchess"
+														],
+														[
+															"13.",
+															"archduke or archduchess"
+														]
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"type": "entries",
+									"name": "The Nine Hells",
+									"entries": [
+										"The Nine Hells are a single plane comprising nine separate layers (see the Layers and Lords of the Nine Hells table). The first eight layers are each ruled by archdevils that answer to the greatest archdevil of all: Asmodeus, the Archduke of Nessus, the ninth layer. To reach the deepest layer of the Nine Hells, one must descend through all eight of the layers above it, in order. The most expeditious means of doing so is the River Styx, which plunges ever deeper as it flows from one layer to the next. Only the most courageous adventurers can withstand the torment and horror of that journey.",
+										{
+											"type": "table",
+											"caption": "Layers and Lords of the Nine Hells Layer",
+											"colLabels": [
+												"Layer",
+												"Layer Name",
+												"Archduke or Archduchess",
+												"Previous Rulers",
+												"Primary Inhabitants"
+											],
+											"colStyles": [
+												"col-1",
+												"col-2",
+												"col-3",
+												"col-3",
+												"col-3"
+											],
+											"rows": [
+												[
+													"1",
+													"Avernus",
+													"Zariel",
+													"Bel, Tiamat",
+													"Erinyes, imps, spined devils"
+												],
+												[
+													"2",
+													"Dis",
+													"Dispater",
+													"\u2014",
+													"Bearded devils, erinyes, imps, spined devils"
+												],
+												[
+													"3",
+													"Minauros",
+													"Mammon",
+													"\u2014",
+													"Bearded devils, chain devils, imps, spined devils"
+												],
+												[
+													"4",
+													"Phlegethos",
+													"Belial and Fierna",
+													"\u2014",
+													"Barbed devils, bone devils, imps, spined devils"
+												],
+												[
+													"5",
+													"Stygia",
+													"Levistus",
+													"Geryon",
+													"Bone devils, erinyes, ice devils, imps"
+												],
+												[
+													"6",
+													"Malbolge",
+													"Glasya",
+													"Malagard, Moloch",
+													"Barbed devils, bone devils, horned devils, imps"
+												],
+												[
+													"7",
+													"Maladomini",
+													"Baalzebul",
+													"\u2014",
+													"Barbed devils, bone devils, horned devils, imps"
+												],
+												[
+													"8",
+													"Cania",
+													"Mephistopheles",
+													"\u2014",
+													"Horned devils, ice devils, imps, pit fiends"
+												],
+												[
+													"9",
+													"Nessus",
+													"Asmodeus",
+													"\u2014",
+													"All devils"
+												]
+											]
+										}
 									]
 								}
 							]
-						}
-					]
-				},
-				{
-					"type": "inset",
-					"name": "Devil True Names and Talismans",
-					"entries": [
-						"Though devils all have common names, every devil above a lemure in station also has a true name that it keeps secret. A devil can be forced to disclose its true name if {@condition charmed}, and ancient scrolls and tomes are said to exist that list the true names of certain devils.",
-						"A mortal who learns a devil's true name can use powerful summoning magic to call the devil from the Nine Hells and bind it into service. Binding can also be accomplished with the help of a devil talisman. Each of these ancient relics is inscribed with the true name of a devil it controls, and was bathed in the blood of a worthy sacrifice-typically someone the creator loved-when crafted.",
-						"However it is summoned, a devil brought to the Material Plane typically resents being pressed into service. However, the devil seizes every opportunity to corrupt its summoner so that the summoner's soul ends up in the Nine Hells. Only imps are truly content to be summoned, and they easily commit to serving a summoner as a familiar, but they still do their utmost to corrupt those who summon them."
-					]
-				},
-				{
-					"type": "inset",
-					"name": "Variant: Devil Summoning",
-					"entries": [
-						"Some devils can have an action option that allows them to summon other devils.",
-						{
-							"name": "Summon Devil (1/Day)",
-							"entries": [
-								" The devil chooses what to summon and attempts a magical summoning."
-							],
-							"type": "entries"
 						},
 						{
-							"type": "list",
-							"items": [
-								"A barbed devil has a {@chance 30|30 percent} chance of summoning one barbed devil.",
-								"A bearded devil has a {@chance 30|30 percent} chance of summoning one bearded devil.",
-								"A bone devil has a {@chance 40|40 percent} chance of summoning {@dice 2d6} spined devils or one bone devil.",
-								"An erinyes has a {@chance 50|50 percent} chance of summoning {@dice 3d6} spined devils, {@dice 1d6} bearded devils, or one erinyes.",
-								"A horned devil has a {@chance 30|30 percent} chance of summoning one horned devil.",
-								"An ice devil has a {@chance 60|60 percent} chance of summoning one ice devil.",
-								"A pit fiend summons {@dice 2d4} bearded devils, {@dice 1d4} barbed devils, or one erinyes with no chance of failure."
+							"type": "inset",
+							"name": "Devil True Names and Talismans",
+							"entries": [
+								"Though devils all have common names, every devil above a lemure in station also has a true name that it keeps secret. A devil can be forced to disclose its true name if {@condition charmed}, and ancient scrolls and tomes are said to exist that list the true names of certain devils.",
+								"A mortal who learns a devil's true name can use powerful summoning magic to call the devil from the Nine Hells and bind it into service. Binding can also be accomplished with the help of a devil talisman. Each of these ancient relics is inscribed with the true name of a devil it controls, and was bathed in the blood of a worthy sacrifice-typically someone the creator loved-when crafted.",
+								"However it is summoned, a devil brought to the Material Plane typically resents being pressed into service. However, the devil seizes every opportunity to corrupt its summoner so that the summoner's soul ends up in the Nine Hells. Only imps are truly content to be summoned, and they easily commit to serving a summoner as a familiar, but they still do their utmost to corrupt those who summon them."
 							]
 						},
-						"A summoned devil appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other devils. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+						{
+							"type": "inset",
+							"name": "Variant: Devil Summoning",
+							"entries": [
+								"Some devils can have an action option that allows them to summon other devils.",
+								{
+									"name": "Summon Devil (1/Day)",
+									"entries": [
+										"The devil chooses what to summon and attempts a magical summoning."
+									],
+									"type": "entries"
+								},
+								{
+									"type": "list",
+									"items": [
+										"A barbed devil has a {@chance 30|30 percent} chance of summoning one barbed devil.",
+										"A bearded devil has a {@chance 30|30 percent} chance of summoning one bearded devil.",
+										"A bone devil has a {@chance 40|40 percent} chance of summoning {@dice 2d6} spined devils or one bone devil.",
+										"An erinyes has a {@chance 50|50 percent} chance of summoning {@dice 3d6} spined devils, {@dice 1d6} bearded devils, or one erinyes.",
+										"A horned devil has a {@chance 30|30 percent} chance of summoning one horned devil.",
+										"An ice devil has a {@chance 60|60 percent} chance of summoning one ice devil.",
+										"A pit fiend summons {@dice 2d4} bearded devils, {@dice 1d4} barbed devils, or one erinyes with no chance of failure."
+									]
+								},
+								"A summoned devil appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other devils. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+							]
+						}
 					]
 				}
 			]
@@ -4102,7 +4166,7 @@
 										{
 											"name": "Creatures of the Elements",
 											"entries": [
-												" A genie is born when the soul of a sentient living creature melds with the primordial matter of an elemental plane. Only under rare circumstances does such an elemental-infused soul coalesce into a manifest form and create a genie.",
+												"A genie is born when the soul of a sentient living creature melds with the primordial matter of an elemental plane. Only under rare circumstances does such an elemental-infused soul coalesce into a manifest form and create a genie.",
 												"A genie usually retains no connection to the soul that gave it form. That life force is a building block that determines the genie's form and apparent gender, as well as one or two key personality traits. Although they resemble humanoid beings, genies are elemental spirits given physical form. They don't mate with other genies or produce genie offspring, as all new genies are born out of the same mysterious fusion of spirit energy and elemental power. A genie with a stronger connection to its mortal soul might choose to sire a child with a mortal, although such offspring are rare.",
 												"When a genie perishes, it leaves nothing behind except what it was wearing or carrying, along with a small trace of its native element: a pile of dust, a gust of wind, a flash of fire and smoke, or a burst of water and foam.",
 												"In contrast to their love of slaves, most genies loathe being bound to service themselves. A genie obeys the will of another only when bribed or compelled by magic. All genies command the power of their native element, but a rare few also possess the power to grant wishes. For both these reasons, mortal mages often seek to bind genies into service.",
@@ -4114,21 +4178,21 @@
 										{
 											"name": "Rule or Be Ruled",
 											"entries": [
-												" Mortal slaves serve to validate a genie's power and high self-opinion. A hundred flattering voices are music to a genie's ears, while two hundred mortal slaves prostrated at its feet are proof that it is lord and master. Genies view slaves as living property, and a genie without property amounts to nothing among its own kind. As a result, many genies treasure their slaves, treating them as honored members of their households. Evil genies freely threaten and abuse their slaves, but never to the extent that the slaves are no longer of use."
+												"Mortal slaves serve to validate a genie's power and high self-opinion. A hundred flattering voices are music to a genie's ears, while two hundred mortal slaves prostrated at its feet are proof that it is lord and master. Genies view slaves as living property, and a genie without property amounts to nothing among its own kind. As a result, many genies treasure their slaves, treating them as honored members of their households. Evil genies freely threaten and abuse their slaves, but never to the extent that the slaves are no longer of use."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Decadent Nobility",
 											"entries": [
-												" Noble genies are the rarest of their kind. They are used to getting what they want, and have learned to trade their ability to grant wishes to attain the objects of their desire. This constant indulgence has made them decadent, while their supreme power over reality makes them haughty and arrogant. Their vast palaces overflow with wonders and sensory delights beyond imagination."
+												"Noble genies are the rarest of their kind. They are used to getting what they want, and have learned to trade their ability to grant wishes to attain the objects of their desire. This constant indulgence has made them decadent, while their supreme power over reality makes them haughty and arrogant. Their vast palaces overflow with wonders and sensory delights beyond imagination."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "The Power of Worship",
 											"entries": [
-												" Genies acknowledge the gods as powerful entities but have no desire to court or worship them. They find the endless fawning and mewling of religious devotees tiresome-except as it is directed toward them by their worshipful slaves."
+												"Genies acknowledge the gods as powerful entities but have no desire to court or worship them. They find the endless fawning and mewling of religious devotees tiresome-except as it is directed toward them by their worshipful slaves."
 											],
 											"type": "entries"
 										}
@@ -4674,7 +4738,7 @@
 										{
 											"name": "Absolute Law and Order",
 											"entries": [
-												" Under the direction of their leader, Primus, modrons increase order in the multiverse in accordance with laws beyond the comprehension of mortal minds. Their own minds are networked in a hierarchal pyramid, in which each modron receives commands from superiors and delegates orders to underlings. A modron carries out commands with total obedience, utmost efficiency, and an absence of morality or ego. Modrons have no sense of self beyond what is necessary to fulfill their duties. They exist as a unified collective, divided by ranks, yet they always refer to themselves collectively. To a modron, there is no \"I,\" but only \"we\" or \"us.\"",
+												"Under the direction of their leader, Primus, modrons increase order in the multiverse in accordance with laws beyond the comprehension of mortal minds. Their own minds are networked in a hierarchal pyramid, in which each modron receives commands from superiors and delegates orders to underlings. A modron carries out commands with total obedience, utmost efficiency, and an absence of morality or ego. Modrons have no sense of self beyond what is necessary to fulfill their duties. They exist as a unified collective, divided by ranks, yet they always refer to themselves collectively. To a modron, there is no \"I,\" but only \"we\" or \"us.\"",
 												{
 													"type": "inset",
 													"name": "Variant: Rogue Modrons",
@@ -4689,21 +4753,21 @@
 										{
 											"name": "Absolute Hierarchy",
 											"entries": [
-												" Modrons communicate only with their own rank and the ranks immediately above and below them. Modrons more than one rank away are either too advanced or too simple to understand."
+												"Modrons communicate only with their own rank and the ranks immediately above and below them. Modrons more than one rank away are either too advanced or too simple to understand."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Cogs of the Great Machine",
 											"entries": [
-												" If a modron is destroyed, its remains disintegrate. A replacement from the next lowest rank then transforms in a flash of light, gaining the physical form of its new rank. The promoted modron is replaced by one of its underlings in the same manner, all the way to the lowest levels of the hierarchy. There, a new modron is created by Primus, with a steady stream of monodrones leaving the Great Modron Cathedral on Mechanus as a result."
+												"If a modron is destroyed, its remains disintegrate. A replacement from the next lowest rank then transforms in a flash of light, gaining the physical form of its new rank. The promoted modron is replaced by one of its underlings in the same manner, all the way to the lowest levels of the hierarchy. There, a new modron is created by Primus, with a steady stream of monodrones leaving the Great Modron Cathedral on Mechanus as a result."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "The Great Modron March",
 											"entries": [
-												" When the gears of Mechanus complete seventeen cycles once every 289 years, Primus sends a vast army of modrons across the Outer Planes, ostensibly on a reconnaissance mission. The march is long and dangerous, and only a small number of modrons returns to Mechanus."
+												"When the gears of Mechanus complete seventeen cycles once every 289 years, Primus sends a vast army of modrons across the Outer Planes, ostensibly on a reconnaissance mission. The march is long and dangerous, and only a small number of modrons returns to Mechanus."
 											],
 											"type": "entries"
 										}
@@ -4849,7 +4913,7 @@
 										{
 											"name": "Creatures of the Elements",
 											"entries": [
-												" A genie is born when the soul of a sentient living creature melds with the primordial matter of an elemental plane. Only under rare circumstances does such an elemental-infused soul coalesce into a manifest form and create a genie.",
+												"A genie is born when the soul of a sentient living creature melds with the primordial matter of an elemental plane. Only under rare circumstances does such an elemental-infused soul coalesce into a manifest form and create a genie.",
 												"A genie usually retains no connection to the soul that gave it form. That life force is a building block that determines the genie's form and apparent gender, as well as one or two key personality traits. Although they resemble humanoid beings, genies are elemental spirits given physical form. They don't mate with other genies or produce genie offspring, as all new genies are born out of the same mysterious fusion of spirit energy and elemental power. A genie with a stronger connection to its mortal soul might choose to sire a child with a mortal, although such offspring are rare.",
 												"When a genie perishes, it leaves nothing behind except what it was wearing or carrying, along with a small trace of its native element: a pile of dust, a gust of wind, a flash of fire and smoke, or a burst of water and foam.",
 												"In contrast to their love of slaves, most genies loathe being bound to service themselves. A genie obeys the will of another only when bribed or compelled by magic. All genies command the power of their native element, but a rare few also possess the power to grant wishes. For both these reasons, mortal mages often seek to bind genies into service.",
@@ -4861,21 +4925,21 @@
 										{
 											"name": "Rule or Be Ruled",
 											"entries": [
-												" Mortal slaves serve to validate a genie's power and high self-opinion. A hundred flattering voices are music to a genie's ears, while two hundred mortal slaves prostrated at its feet are proof that it is lord and master. Genies view slaves as living property, and a genie without property amounts to nothing among its own kind. As a result, many genies treasure their slaves, treating them as honored members of their households. Evil genies freely threaten and abuse their slaves, but never to the extent that the slaves are no longer of use."
+												"Mortal slaves serve to validate a genie's power and high self-opinion. A hundred flattering voices are music to a genie's ears, while two hundred mortal slaves prostrated at its feet are proof that it is lord and master. Genies view slaves as living property, and a genie without property amounts to nothing among its own kind. As a result, many genies treasure their slaves, treating them as honored members of their households. Evil genies freely threaten and abuse their slaves, but never to the extent that the slaves are no longer of use."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Decadent Nobility",
 											"entries": [
-												" Noble genies are the rarest of their kind. They are used to getting what they want, and have learned to trade their ability to grant wishes to attain the objects of their desire. This constant indulgence has made them decadent, while their supreme power over reality makes them haughty and arrogant. Their vast palaces overflow with wonders and sensory delights beyond imagination."
+												"Noble genies are the rarest of their kind. They are used to getting what they want, and have learned to trade their ability to grant wishes to attain the objects of their desire. This constant indulgence has made them decadent, while their supreme power over reality makes them haughty and arrogant. Their vast palaces overflow with wonders and sensory delights beyond imagination."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "The Power of Worship",
 											"entries": [
-												" Genies acknowledge the gods as powerful entities but have no desire to court or worship them. They find the endless fawning and mewling of religious devotees tiresome-except as it is directed toward them by their worshipful slaves."
+												"Genies acknowledge the gods as powerful entities but have no desire to court or worship them. They find the endless fawning and mewling of religious devotees tiresome-except as it is directed toward them by their worshipful slaves."
 											],
 											"type": "entries"
 										}
@@ -5427,7 +5491,7 @@
 										{
 											"name": "Wreathed in Flame",
 											"entries": [
-												" The fire wreathing a flameskull burns continually, giving off bright light that the creature controls. It uses those flames as a weapon, focusing them to loose them as fiery rays from its eye sockets."
+												"The fire wreathing a flameskull burns continually, giving off bright light that the creature controls. It uses those flames as a weapon, focusing them to loose them as fiery rays from its eye sockets."
 											],
 											"type": "entries"
 										}
@@ -5465,59 +5529,19 @@
 		{
 			"name": "Flesh Golem",
 			"source": "MM",
-			"entries": [
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								"A flesh golem is a grisly assortment of humanoid body parts stitched and bolted together into a muscled brute imbued with formidable strength. Its brain is capable of simple reason, though its thoughts are no more sophisticated than those of a young child. The golem's muscle tissue responds to the power of lightning, invigorating the creature with vitality and strength. Powerful enchantments protect the golem's skin, deflecting spells and all but the most potent weapons.",
-								"A flesh golem lurches with a stiff-jointed gait, as if not in complete control of its body. Its dead flesh isn't an ideal container for an elemental spirit, which sometimes howls incoherently to vent its outrage. If the spirit breaks free of its creator's will, the golem goes berserk until calmed, or until its shell of flesh is destroyed or completely healed.",
-								{
-									"type": "entries",
-									"name": "Golems",
-									"entries": [
-										"Golems are made from humble materials-clay, flesh and bones, iron, or stone-but they possess astonishing power and durability. A golem has no ambitions, needs no sustenance, feels no pain, and knows no remorse. An unstoppable juggernaut, it exists to follow its creator's orders, and it protects or attacks as that creator demands.",
-										"To create a golem, one requires a manual of golems (see the Dungeon Master's Guide). The comprehensive illustrations and instructions in a manual detail the process for creating a golem of a particular type.",
-										{
-											"name": "Elemental Spirit in Material Form",
-											"entries": [
-												" The construction of a golem begins with the building of its body, requiring great command of the craft of sculpting, stonecutting, ironworking, or surgery. Sometimes a golem's creator is the master of the art, but often the individual who desires a golem must enlist master artisans to do the work.",
-												"After constructing the body from clay, flesh, iron, or stone, the golem's creator infuses it with a spirit from the Elemental Plane of Earth. This tiny spark of life has no memory, personality, or history. It is simply the impetus to move and obey. This process binds the spirit to the artificial body and subjects it to the will of the golem's creator.",
-												"A golem can be created with a special amulet or other item that allows the possessor of the item to control the golem. Golems whose creators are long dead can thus be harnessed to serve a new master.",
-												"A golem can't think or act for itself. Though it understands its commands perfectly, it has no grasp of language beyond that understanding, and can't be reasoned with or tricked with words."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Ageless Guardians",
-											"entries": [
-												" Golems can guard sacred sites, tombs, and treasure vaults long after the deaths of their creators, carrying out their appointed tasks for all eternity while brushing off physical damage and ignoring all but the most potent spells."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Blind Obedience",
-											"entries": [
-												" When its creator or possessor is on hand to command it, a golem performs flawlessly. If the golem is left without instructions or is {@condition incapacitated}, it continues to follow its last orders to the best of its ability. When it can't fulfill its orders, a golem might react violently-or stand and do nothing. A golem that has been given conflicting orders sometimes alternates between them."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Constructed Nature",
-											"entries": [
-												" A golem doesn't require air, food, drink, or sleep."
-											],
-											"type": "entries"
-										}
-									]
-								}
-							]
-						}
-					]
+			"_copy": {
+				"name": "Golems",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": [
+							"A flesh golem is a grisly assortment of humanoid body parts stitched and bolted together into a muscled brute imbued with formidable strength. Its brain is capable of simple reason, though its thoughts are no more sophisticated than those of a young child. The golem's muscle tissue responds to the power of lightning, invigorating the creature with vitality and strength. Powerful enchantments protect the golem's skin, deflecting spells and all but the most potent weapons.",
+							"A flesh golem lurches with a stiff-jointed gait, as if not in complete control of its body. Its dead flesh isn't an ideal container for an elemental spirit, which sometimes howls incoherently to vent its outrage. If the spirit breaks free of its creator's will, the golem goes berserk until calmed, or until its shell of flesh is destroyed or completely healed."
+						]
+					}
 				}
-			],
+			},
 			"images": [
 				{
 					"type": "image",
@@ -5670,7 +5694,7 @@
 										{
 											"name": "Ruined Flesh, Evil Minds",
 											"entries": [
-												" The deformities visited on the fomorians prevent them from hurling rocks like their giant kin, or wearing anything more than scraps of cloth. However, the grotesque positioning of their eyes, noses, and ears gives fomorians keen perceptive abilities, making it hard to surprise or ambush them. The greed and evil of the fomorians lies at the heart of their degeneration and fall, and continues to plague them. Fomorians make alliances with other creatures when it suits them, but they are disloyal by nature and betray their allies on a whim."
+												"The deformities visited on the fomorians prevent them from hurling rocks like their giant kin, or wearing anything more than scraps of cloth. However, the grotesque positioning of their eyes, noses, and ears gives fomorians keen perceptive abilities, making it hard to surprise or ambush them. The greed and evil of the fomorians lies at the heart of their degeneration and fall, and continues to plague them. Fomorians make alliances with other creatures when it suits them, but they are disloyal by nature and betray their allies on a whim."
 											],
 											"type": "entries"
 										}
@@ -5972,7 +5996,7 @@
 										{
 											"name": "Slow Death",
 											"entries": [
-												" An ooze kills its prey slowly. Some varieties, such as black puddings and gelatinous cubes, engulf creatures to prevent escape. The only upside of this torturous death is that a victim's comrades can come to the rescue before it is too late.",
+												"An ooze kills its prey slowly. Some varieties, such as black puddings and gelatinous cubes, engulf creatures to prevent escape. The only upside of this torturous death is that a victim's comrades can come to the rescue before it is too late.",
 												"Since not every ooze digests every type of substance, some have coins, metal gear, bones, and other debris suspended within their quivering bodies. A slain ooze can be a rich source of treasure for its killers.",
 												"Whether this is true or not, the Faceless Lord is one of the few beings that can control oozes and imbue them with a modicum of intelligence. Most of the time, oozes have no sense of tactics or self-preservation. They are direct and predictable, attacking and eating without cunning. Under the control of Juiblex, they exhibit glimmers of sentience and malevolent intent."
 											],
@@ -5981,21 +6005,21 @@
 										{
 											"name": "Unwitting Servants",
 											"entries": [
-												" Although an ooze lacks the intelligence to ally itself with other creatures, others that understand an ooze's need to feed might lure it into a location where it can be of use to them. Clever monsters keep oozes around to defend passageways or consume refuse. Likewise, an ooze can be enticed into a pit trap, where its captors feed it often enough to prevent it from coming after them. Crafty creatures place torches and flaming braziers in strategic areas to dissuade an ooze from leaving a particular tunnel or room."
+												"Although an ooze lacks the intelligence to ally itself with other creatures, others that understand an ooze's need to feed might lure it into a location where it can be of use to them. Clever monsters keep oozes around to defend passageways or consume refuse. Likewise, an ooze can be enticed into a pit trap, where its captors feed it often enough to prevent it from coming after them. Crafty creatures place torches and flaming braziers in strategic areas to dissuade an ooze from leaving a particular tunnel or room."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Spawn of Juiblex",
 											"entries": [
-												" According to the Demonomicon of Iggwilv and other sources, oozes are scattered fragments or offspring of the demon lord Juiblex."
+												"According to the Demonomicon of Iggwilv and other sources, oozes are scattered fragments or offspring of the demon lord Juiblex."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Ooze Nature",
 											"entries": [
-												" An ooze doesn't require sleep."
+												"An ooze doesn't require sleep."
 											],
 											"type": "entries"
 										}
@@ -6030,7 +6054,7 @@
 									"type": "inset",
 									"name": "The Nature of Swarms",
 									"entries": [
-										"The swarms presented here aren't ordinary or benign assemblies of little creatures. They form as a result of some sinister or unwholesome influence. A vampire can summon swarms of bats and rats from the darkest corners of the night, while the very presence of a mummy lord can cause scarab beetles to boil up from the sand-filled depths of its tomb. A hag might have the power to turn swarms of ravens against her enemies, while a yuan-ti abomination might have swarms of poisonous snakes slithering in its wake. Even druids can't charm these swarms, and their aggressiveness is borderline unnatural."
+										"The swarms presented here aren't ordinary or benign assemblies of little creatures. They form as a result of some sinister or unwholesome influence. A vampire can summon swarms of bats and rats from the darkest corners of the night, while the very presence of a mummy lord can cause scarab beetles to boil up from the sand-filled depths of its tomb. A hag might have the power to turn swarms of ravens against her enemies, while a {@creature yuan-ti abomination} might have {@creature swarm of poisonous snakes||swarms of poisonous snakes} slithering in its wake. Even druids can't charm these swarms, and their aggressiveness is borderline unnatural."
 									]
 								}
 							]
@@ -6496,7 +6520,7 @@
 										{
 											"name": "All-Consuming",
 											"entries": [
-												" Driven to devour any creature it can reach, a gibbering mouther flows over victims transfixed by its mad ranting, its multitudinous voices temporarily silenced as it gnaws and swallows living flesh. The monster liquefies stone with which it comes into contact, hindering creatures that overcome its gibbering and attempt to flee.",
+												"Driven to devour any creature it can reach, a gibbering mouther flows over victims transfixed by its mad ranting, its multitudinous voices temporarily silenced as it gnaws and swallows living flesh. The monster liquefies stone with which it comes into contact, hindering creatures that overcome its gibbering and attempt to flee.",
 												"A gibbering mouther leaves nothing of its prey behind. However, even as the last of a victim's body is consumed, its eyes and mouth boil to the surface, ready to join the chorus of tormented gibbering that welcomes the monster's next meal."
 											],
 											"type": "entries"
@@ -6519,69 +6543,82 @@
 			]
 		},
 		{
-			"name": "Githyanki",
+			"name": "Gith",
 			"source": "MM",
 			"entries": [
 				{
-					"type": "entries",
+					"type": "section",
+					"name": "Gith",
 					"entries": [
-						{
+						"The warlike githyanki and the contemplative githzerai are a sundered people-two cultures that utterly despise one another. Before there were githyanki or githzerai, these creatures were a single race enslaved by the {@creature mind flayer||mind flayers}. Although they attempted to overthrow their masters many times, their rebellions were repeatedly crushed until a great leader named Gith arose.",
+						"After much bloodshed, Gith and her followers threw off the yoke of their illithid masters, but another leader named Zerthimon emerged in the aftermath of battle.",
+						"Zerthimon challenged Gith's motives, claiming that her strict martial leadership and desire for vengeance amounted to little more than another form of slavery for her people. A rift erupted between followers of each leader, and they eventually became the two races whose enmity endures to this day.",
+						"Whether these tall, gaunt creatures were peaceful or savage, cultured or primitive before the {@creature mind flayer||mind flayers} enslaved and changed them, none can say. Not even the original name of their race remains from that distant time."
+					]
+				}
+			]
+		},
+		{
+			"name": "Githyanki",
+			"source": "MM",
+			"_copy": {
+				"name": "Gith",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": {
 							"type": "entries",
 							"entries": [
-								"The githyanki plunder countless worlds from the decks of their astral vessels and the backs of red dragons. Feathers, beads, gems, and precious metals decorate their armor and weapons-the legendary silver swords with which they cut through their foes. Since winning their freedom from the mind flayers, the githyanki have become ruthless conquerors under the rulership of their dread lich-queen, Vlaakith.",
-								{
-									"name": "Astral Raiders",
-									"type": "entries",
-									"entries": [
-										"The githyanki despise all other races, undertaking devastating raids that take them from their strongholds in the Astral Plane to the far flung corners of the multiverse. War is the ultimate expression of githyanki culture, and their pitiless black eyes know no mercy. After a raid, they leave shattered survivors enough food and resources to weakly endure. Later, the githyanki return to their conquered foes, plundering them again and again."
-									]
-								},
-								{
-									"name": "Followers of Gith",
-									"type": "entries",
-									"entries": [
-										"In their own language, githyanki means \"followers of Gith.\" Under the guidance of Gith, the githyanki stratified into a militaristic society, with a strict caste system, dedicated to the ongoing fight against the victims and sworn enemies of their race. When their leader Gith perished, she was replaced by her undead adviser, Vlaakith. The lich-queen forbade worship of all beings except herself.",
-										"Of all their enemies, the githyanki most hate their former masters, the mind flayers. Their close kin, the githzerai, are second in their enmity. All other creatures are treated with simple contempt by the githyanki, whose xenophobic pride defines their view of inferior races."
-									]
-								},
 								{
 									"type": "entries",
-									"name": "Silver Swords",
 									"entries": [
-										"In ancient times, gith knights created special weapons to combat their mind flayer masters.",
-										"These silver swords channel the force of the wielder's will, dealing psychic as well as physical damage. A githyanki can't become a knight until it masters the singular discipline needed to will such a blade into existence. A silver sword is equivalent to a greatsword, and takes on the properties of a +3 greatsword in the hands of its creator.",
-										"In the eyes of the githyanki, each silver sword is a priceless relic and a work of art. Githyanki knights will hunt down and destroy any non-githyanki that dares to carry or wield a silver sword, reclaiming it for their people."
-									]
-								},
-								{
-									"name": "Red Dragon Riders",
-									"type": "entries",
-									"entries": [
-										"In the uprising against the illithids, Gith sought allies. Her adviser Vlaakith appealed to Tiamat, the goddess of evil dragonkind, and Gith ventured into the Nine Hells to meet with her. Only Tiamat now knows what passed between them, but Vlaakith returned to the Astral Plane with the Dragon Queen's red dragon consort Ephelomon, who proclaimed that his kind would forever act as allies to the githyanki. Not all red dragons honor the alliance kindled so long ago, but most at least don't consider the githyanki their enemies.",
+										"The githyanki plunder countless worlds from the decks of their astral vessels and the backs of red dragons. Feathers, beads, gems, and precious metals decorate their armor and weapons-the legendary silver swords with which they cut through their foes. Since winning their freedom from the mind flayers, the githyanki have become ruthless conquerors under the rulership of their dread lich-queen, Vlaakith.",
 										{
-											"name": "Outposts in the Mortal Realm",
+											"name": "Astral Raiders",
+											"type": "entries",
 											"entries": [
-												" Since creatures that dwell on the Astral Plane don't age, the githyanki establish creches in remote areas of the Material Plane to raise their young. Doubling as military academies, these creches train young githyanki to harness their psychic and combat abilities. When a githyanki grows to adulthood and slays a mind flayer as part of a sacred rite of passage, it is permitted to rejoin its people on the Astral Plane."
-											],
-											"type": "entries"
+												"The githyanki despise all other races, undertaking devastating raids that take them from their strongholds in the Astral Plane to the far flung corners of the multiverse. War is the ultimate expression of githyanki culture, and their pitiless black eyes know no mercy. After a raid, they leave shattered survivors enough food and resources to weakly endure. Later, the githyanki return to their conquered foes, plundering them again and again."
+											]
+										},
+										{
+											"name": "Followers of Gith",
+											"type": "entries",
+											"entries": [
+												"In their own language, githyanki means \"followers of Gith.\" Under the guidance of Gith, the githyanki stratified into a militaristic society, with a strict caste system, dedicated to the ongoing fight against the victims and sworn enemies of their race. When their leader Gith perished, she was replaced by her undead adviser, Vlaakith. The lich-queen forbade worship of all beings except herself.",
+												"Of all their enemies, the githyanki most hate their former masters, the mind flayers. Their close kin, the githzerai, are second in their enmity. All other creatures are treated with simple contempt by the githyanki, whose xenophobic pride defines their view of inferior races."
+											]
+										},
+										{
+											"type": "entries",
+											"name": "Silver Swords",
+											"entries": [
+												"In ancient times, gith knights created special weapons to combat their mind flayer masters.",
+												"These silver swords channel the force of the wielder's will, dealing psychic as well as physical damage. A githyanki can't become a knight until it masters the singular discipline needed to will such a blade into existence. A silver sword is equivalent to a {@item greatsword|phb}, and takes on the properties of a {@item +3 greatsword} in the hands of its creator.",
+												"In the eyes of the githyanki, each silver sword is a priceless relic and a work of art. Githyanki knights will hunt down and destroy any non-githyanki that dares to carry or wield a silver sword, reclaiming it for their people."
+											]
+										},
+										{
+											"name": "Red Dragon Riders",
+											"type": "entries",
+											"entries": [
+												"In the uprising against the illithids, Gith sought allies. Her adviser Vlaakith appealed to {@deity Tiamat|dawn war|DMG}, the goddess of evil dragonkind, and Gith ventured into the Nine Hells to meet with her. Only Tiamat now knows what passed between them, but Vlaakith returned to the Astral Plane with the Dragon Queen's red dragon consort Ephelomon, who proclaimed that his kind would forever act as allies to the githyanki. Not all red dragons honor the alliance kindled so long ago, but most at least don't consider the githyanki their enemies.",
+												{
+													"name": "Outposts in the Mortal Realm",
+													"entries": [
+														"Since creatures that dwell on the Astral Plane don't age, the githyanki establish creches in remote areas of the Material Plane to raise their young. Doubling as military academies, these creches train young githyanki to harness their psychic and combat abilities. When a githyanki grows to adulthood and slays a mind flayer as part of a sacred rite of passage, it is permitted to rejoin its people on the Astral Plane."
+													],
+													"type": "entries"
+												}
+											]
 										}
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Gith",
-									"entries": [
-										"The warlike githyanki and the contemplative githzerai are a sundered people-two cultures that utterly despise one another. Before there were githyanki or githzerai, these creatures were a single race enslaved by the mind flayers. Although they attempted to overthrow their masters many times, their rebellions were repeatedly crushed until a great leader named Gith arose.",
-										"After much bloodshed, Gith and her followers threw off the yoke of their illithid masters, but another leader named Zerthimon emerged in the aftermath of battle.",
-										"Zerthimon challenged Gith's motives, claiming that her strict martial leadership and desire for vengeance amounted to little more than another form of slavery for her people. A rift erupted between followers of each leader, and they eventually became the two races whose enmity endures to this day.",
-										"Whether these tall, gaunt creatures were peaceful or savage, cultured or primitive before the mind flayers enslaved and changed them, none can say. Not even the original name of their race remains from that distant time."
 									]
 								}
 							]
 						}
-					]
+					}
 				}
-			],
+			},
 			"images": [
 				{
 					"type": "image",
@@ -6611,64 +6648,61 @@
 		{
 			"name": "Githzerai",
 			"source": "MM",
-			"entries": [
-				{
-					"type": "entries",
-					"entries": [
-						{
+			"_copy": {
+				"name": "Gith",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": {
 							"type": "entries",
 							"entries": [
-								"Focused philosophers and austere ascetics, the githzerai pursue lives of rigid order. Lean and muscular, they wear unadorned clothing free of ornamentation, keeping their own counsel and trusting few creatures outside of their own kind. Having turned their backs on their warlike githyanki kin, the githzerai maintain a strict monastic lifestyle, dwelling on islands of order in the vast sea of chaos that is the plane of Limbo.",
-								{
-									"name": "Psionic Adepts",
-									"type": "entries",
-									"entries": [
-										"The progenitors of the githzerai adapted to-and were transformed by-the psychic environment imposed on them by their illithid overlords. Under the teachings of Zerthimon, who called on his people to abandon the warlike ambitions of Gith, the githzerai focused their mental energy on creating physical and psychic barriers to protect them from attack, psychic or otherwise. Fighting is personal to a githzerai, which uses its mind to daze and incapacitate opponents, leaving them vulnerable to physical punishment."
-									]
-								},
-								{
-									"name": "Order amid Chaos",
-									"type": "entries",
-									"entries": [
-										"The githzerai willingly dwell in the heart of utter chaos in Limbo-a twisting, mercurial plane prone to manipulation and subjugation by githzerai minds strong enough to master it. Limbo is a maelstrom of primal matter and energy, its terrain a storm of rock and earth swept up in torrents of murky liquid, buffeted by strong winds, blasted by fire, and chilled by crushing walls of ice.",
-										"The forces of Limbo react to sentience, however. Using the power of their minds, the githzerai tame the plane's chaotic elements, causing them to settle into fixed and survivable forms and creating oases and sanctuaries within the maelstrom.",
-										"Githzerai fortress-monasteries stand resolute against the chaos that surrounds them, virtually impervious to the turmoil of their surroundings, because the githzerai will it. Each monastery is overseen by monks that impose a strict schedule of chants, meals, martial arts training, and devotions according to their own philosophy. Behind their psionically fortified walls, the githzerai embrace thought, learning, psionic power, order, and discipline above all other things.",
-										"The social hierarchy of the githzerai is based on merit, and those githzerai who are the wisest teachers and the most skilled at physical and mental combat become leaders. The githzerai revere great heroes and teachers of the past, emulating those figures' virtues in their everyday lives."
-									]
-								},
-								{
-									"name": "Disciples of Zerthimon",
-									"type": "entries",
-									"entries": [
-										"Githzerai revere Zerthimon, the founder of their race. Although Gith won their people's freedom, Zerthimon saw her as unfit to lead. He believed that her warmongering would soon make her a tyrant no better than the mind flayers.",
-										"Skilled githzerai monks that best exemplify the teachings and principles of Zerthimon are called zerths.",
-										"These powerful and disciplined monks can shift their bodies from one plane to another using only the power of their minds."
-									]
-								},
-								{
-									"name": "Beyond Limbo",
-									"type": "entries",
-									"entries": [
-										"Though githzerai rarely deal with the realms beyond Limbo, advanced monks of other races sometimes seek out a githzerai monastery and attempt to gain admittance as students. More rarely, a githzerai master establishes a hidden monastery on the Material Plane to train young githzerai or to spread the philosophy and teachings of Zerthimon.",
-										"As disciplined as they are, the githzerai have never forgotten their long imprisonment by the mind flayers.",
-										"As a special devotion, they organize a rrakkma-an illithid hunting party-to other planes, not returning to their monasteries until they slay at least as many illithids as there are hunters in the party."
-									]
-								},
 								{
 									"type": "entries",
-									"name": "Gith",
 									"entries": [
-										"The warlike githyanki and the contemplative githzerai are a sundered people-two cultures that utterly despise one another. Before there were githyanki or githzerai, these creatures were a single race enslaved by the mind flayers. Although they attempted to overthrow their masters many times, their rebellions were repeatedly crushed until a great leader named Gith arose.",
-										"After much bloodshed, Gith and her followers threw off the yoke of their illithid masters, but another leader named Zerthimon emerged in the aftermath of battle.",
-										"Zerthimon challenged Gith's motives, claiming that her strict martial leadership and desire for vengeance amounted to little more than another form of slavery for her people. A rift erupted between followers of each leader, and they eventually became the two races whose enmity endures to this day.",
-										"Whether these tall, gaunt creatures were peaceful or savage, cultured or primitive before the mind flayers enslaved and changed them, none can say. Not even the original name of their race remains from that distant time."
+										"Focused philosophers and austere ascetics, the githzerai pursue lives of rigid order. Lean and muscular, they wear unadorned clothing free of ornamentation, keeping their own counsel and trusting few creatures outside of their own kind. Having turned their backs on their warlike githyanki kin, the githzerai maintain a strict monastic lifestyle, dwelling on islands of order in the vast sea of chaos that is the plane of Limbo.",
+										{
+											"name": "Psionic Adepts",
+											"type": "entries",
+											"entries": [
+												"The progenitors of the githzerai adapted to\u2014and were transformed by\u2014the psychic environment imposed on them by their illithid overlords. Under the teachings of Zerthimon, who called on his people to abandon the warlike ambitions of Gith, the githzerai focused their mental energy on creating physical and psychic barriers to protect them from attack, psychic or otherwise. Fighting is personal to a githzerai, which uses its mind to daze and incapacitate opponents, leaving them vulnerable to physical punishment."
+											]
+										},
+										{
+											"name": "Order amid Chaos",
+											"type": "entries",
+											"entries": [
+												"The githzerai willingly dwell in the heart of utter chaos in Limbo\u2014a twisting, mercurial plane prone to manipulation and subjugation by githzerai minds strong enough to master it. Limbo is a maelstrom of primal matter and energy, its terrain a storm of rock and earth swept up in torrents of murky liquid, buffeted by strong winds, blasted by fire, and chilled by crushing walls of ice.",
+												"The forces of Limbo react to sentience, however. Using the power of their minds, the githzerai tame the plane's chaotic elements, causing them to settle into fixed and survivable forms and creating oases and sanctuaries within the maelstrom.",
+												"Githzerai fortress-monasteries stand resolute against the chaos that surrounds them, virtually impervious to the turmoil of their surroundings, because the githzerai will it. Each monastery is overseen by monks that impose a strict schedule of chants, meals, martial arts training, and devotions according to their own philosophy. Behind their psionically fortified walls, the githzerai embrace thought, learning, psionic power, order, and discipline above all other things.",
+												"The social hierarchy of the githzerai is based on merit, and those githzerai who are the wisest teachers and the most skilled at physical and mental combat become leaders. The githzerai revere great heroes and teachers of the past, emulating those figures' virtues in their everyday lives."
+											]
+										},
+										{
+											"name": "Disciples of Zerthimon",
+											"type": "entries",
+											"entries": [
+												"Githzerai revere Zerthimon, the founder of their race. Although Gith won their people's freedom, Zerthimon saw her as unfit to lead. He believed that her warmongering would soon make her a tyrant no better than the {@creature mind flayer||mind flayers}.",
+												"Skilled githzerai monks that best exemplify the teachings and principles of Zerthimon are called zerths.",
+												"These powerful and disciplined monks can shift their bodies from one plane to another using only the power of their minds."
+											]
+										},
+										{
+											"name": "Beyond Limbo",
+											"type": "entries",
+											"entries": [
+												"Though githzerai rarely deal with the realms beyond Limbo, advanced monks of other races sometimes seek out a githzerai monastery and attempt to gain admittance as students. More rarely, a githzerai master establishes a hidden monastery on the Material Plane to train young githzerai or to spread the philosophy and teachings of Zerthimon.",
+												"As disciplined as they are, the githzerai have never forgotten their long imprisonment by the mind flayers.",
+												"As a special devotion, they organize a rrakkma\u2014an illithid hunting party\u2014to other planes, not returning to their monasteries until they slay at least as many illithids as there are hunters in the party."
+											]
+										}
 									]
 								}
 							]
 						}
-					]
+					}
 				}
-			],
+			},
 			"images": [
 				{
 					"type": "image",
@@ -6774,7 +6808,7 @@
 										{
 											"name": "Thirst for Blood",
 											"entries": [
-												" No goodness or compassion resides in the heart of a gnoll. Like a demon, it lacks anything resembling a conscience, and can't be taught or coerced to put aside its destructive tendencies. The gnolls' frenzied bloodlust makes them an enemy to all, and when they lack a common foe, they fight among themselves. Even the most savage orcs avoid allying with gnolls."
+												"No goodness or compassion resides in the heart of a gnoll. Like a demon, it lacks anything resembling a conscience, and can't be taught or coerced to put aside its destructive tendencies. The gnolls' frenzied bloodlust makes them an enemy to all, and when they lack a common foe, they fight among themselves. Even the most savage orcs avoid allying with gnolls."
 											],
 											"type": "entries"
 										}
@@ -6815,7 +6849,7 @@
 										{
 											"name": "Demonic Origin",
 											"entries": [
-												" The origin of the gnolls traces back to a time when the demon lord Yeenoghu found his way to the Material Plane and ran amok. Packs of ordinary hyenas followed in his wake, scavenging the demon lord's kills. Those hyenas were transformed into the first gnolls, parading after Yeenoghu until he was banished back to the Abyss. The gnolls then scattered across the face of the world, a dire reminder of demonic power.",
+												"The origin of the gnolls traces back to a time when the demon lord Yeenoghu found his way to the Material Plane and ran amok. Packs of ordinary hyenas followed in his wake, scavenging the demon lord's kills. Those hyenas were transformed into the first gnolls, parading after Yeenoghu until he was banished back to the Abyss. The gnolls then scattered across the face of the world, a dire reminder of demonic power.",
 												"Gnolls rarely build permanent structures or craft anything of lasting value. They don't make weapons or armor, but scavenge such items from the corpses of their fallen victims, stringing ears, teeth, scalps, and other trophies from their foes onto their patchwork armor."
 											],
 											"type": "entries"
@@ -6823,14 +6857,14 @@
 										{
 											"name": "Nomadic Destroyers",
 											"entries": [
-												" Gnolls are dangerous because they strike at random. They emerge from the wilderness, plunder and slaughter, then move elsewhere. They attack like a plague of locusts, pillaging settlements and leaving little behind but razed buildings, gnawed corpses, and befouled land. Gnolls choose easy targets for their raids. Armored warriors holed up in a fortified castle will survive a rampaging gnoll horde unscathed, even as the towns, villages, and farms that surround the castle are ablaze, their people slaughtered and devoured."
+												"Gnolls are dangerous because they strike at random. They emerge from the wilderness, plunder and slaughter, then move elsewhere. They attack like a plague of locusts, pillaging settlements and leaving little behind but razed buildings, gnawed corpses, and befouled land. Gnolls choose easy targets for their raids. Armored warriors holed up in a fortified castle will survive a rampaging gnoll horde unscathed, even as the towns, villages, and farms that surround the castle are ablaze, their people slaughtered and devoured."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Thirst for Blood",
 											"entries": [
-												" No goodness or compassion resides in the heart of a gnoll. Like a demon, it lacks anything resembling a conscience, and can't be taught or coerced to put aside its destructive tendencies. The gnolls' frenzied bloodlust makes them an enemy to all, and when they lack a common foe, they fight among themselves. Even the most savage orcs avoid allying with gnolls."
+												"No goodness or compassion resides in the heart of a gnoll. Like a demon, it lacks anything resembling a conscience, and can't be taught or coerced to put aside its destructive tendencies. The gnolls' frenzied bloodlust makes them an enemy to all, and when they lack a common foe, they fight among themselves. Even the most savage orcs avoid allying with gnolls."
 											],
 											"type": "entries"
 										}
@@ -6870,7 +6904,7 @@
 										{
 											"name": "Demonic Origin",
 											"entries": [
-												" The origin of the gnolls traces back to a time when the demon lord Yeenoghu found his way to the Material Plane and ran amok. Packs of ordinary hyenas followed in his wake, scavenging the demon lord's kills. Those hyenas were transformed into the first gnolls, parading after Yeenoghu until he was banished back to the Abyss. The gnolls then scattered across the face of the world, a dire reminder of demonic power.",
+												"The origin of the gnolls traces back to a time when the demon lord Yeenoghu found his way to the Material Plane and ran amok. Packs of ordinary hyenas followed in his wake, scavenging the demon lord's kills. Those hyenas were transformed into the first gnolls, parading after Yeenoghu until he was banished back to the Abyss. The gnolls then scattered across the face of the world, a dire reminder of demonic power.",
 												"Gnolls rarely build permanent structures or craft anything of lasting value. They don't make weapons or armor, but scavenge such items from the corpses of their fallen victims, stringing ears, teeth, scalps, and other trophies from their foes onto their patchwork armor."
 											],
 											"type": "entries"
@@ -6878,14 +6912,14 @@
 										{
 											"name": "Nomadic Destroyers",
 											"entries": [
-												" Gnolls are dangerous because they strike at random. They emerge from the wilderness, plunder and slaughter, then move elsewhere. They attack like a plague of locusts, pillaging settlements and leaving little behind but razed buildings, gnawed corpses, and befouled land. Gnolls choose easy targets for their raids. Armored warriors holed up in a fortified castle will survive a rampaging gnoll horde unscathed, even as the towns, villages, and farms that surround the castle are ablaze, their people slaughtered and devoured."
+												"Gnolls are dangerous because they strike at random. They emerge from the wilderness, plunder and slaughter, then move elsewhere. They attack like a plague of locusts, pillaging settlements and leaving little behind but razed buildings, gnawed corpses, and befouled land. Gnolls choose easy targets for their raids. Armored warriors holed up in a fortified castle will survive a rampaging gnoll horde unscathed, even as the towns, villages, and farms that surround the castle are ablaze, their people slaughtered and devoured."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Thirst for Blood",
 											"entries": [
-												" No goodness or compassion resides in the heart of a gnoll. Like a demon, it lacks anything resembling a conscience, and can't be taught or coerced to put aside its destructive tendencies. The gnolls' frenzied bloodlust makes them an enemy to all, and when they lack a common foe, they fight among themselves. Even the most savage orcs avoid allying with gnolls."
+												"No goodness or compassion resides in the heart of a gnoll. Like a demon, it lacks anything resembling a conscience, and can't be taught or coerced to put aside its destructive tendencies. The gnolls' frenzied bloodlust makes them an enemy to all, and when they lack a common foe, they fight among themselves. Even the most savage orcs avoid allying with gnolls."
 											],
 											"type": "entries"
 										}
@@ -7142,7 +7176,7 @@
 										{
 											"name": "Slow Death",
 											"entries": [
-												" An ooze kills its prey slowly. Some varieties, such as black puddings and gelatinous cubes, engulf creatures to prevent escape. The only upside of this torturous death is that a victim's comrades can come to the rescue before it is too late.",
+												"An ooze kills its prey slowly. Some varieties, such as black puddings and gelatinous cubes, engulf creatures to prevent escape. The only upside of this torturous death is that a victim's comrades can come to the rescue before it is too late.",
 												"Since not every ooze digests every type of substance, some have coins, metal gear, bones, and other debris suspended within their quivering bodies. A slain ooze can be a rich source of treasure for its killers.",
 												"Whether this is true or not, the Faceless Lord is one of the few beings that can control oozes and imbue them with a modicum of intelligence. Most of the time, oozes have no sense of tactics or self-preservation. They are direct and predictable, attacking and eating without cunning. Under the control of Juiblex, they exhibit glimmers of sentience and malevolent intent."
 											],
@@ -7151,21 +7185,21 @@
 										{
 											"name": "Unwitting Servants",
 											"entries": [
-												" Although an ooze lacks the intelligence to ally itself with other creatures, others that understand an ooze's need to feed might lure it into a location where it can be of use to them. Clever monsters keep oozes around to defend passageways or consume refuse. Likewise, an ooze can be enticed into a pit trap, where its captors feed it often enough to prevent it from coming after them. Crafty creatures place torches and flaming braziers in strategic areas to dissuade an ooze from leaving a particular tunnel or room."
+												"Although an ooze lacks the intelligence to ally itself with other creatures, others that understand an ooze's need to feed might lure it into a location where it can be of use to them. Clever monsters keep oozes around to defend passageways or consume refuse. Likewise, an ooze can be enticed into a pit trap, where its captors feed it often enough to prevent it from coming after them. Crafty creatures place torches and flaming braziers in strategic areas to dissuade an ooze from leaving a particular tunnel or room."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Spawn of Juiblex",
 											"entries": [
-												" According to the Demonomicon of Iggwilv and other sources, oozes are scattered fragments or offspring of the demon lord Juiblex."
+												"According to the Demonomicon of Iggwilv and other sources, oozes are scattered fragments or offspring of the demon lord Juiblex."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Ooze Nature",
 											"entries": [
-												" An ooze doesn't require sleep."
+												"An ooze doesn't require sleep."
 											],
 											"type": "entries"
 										}
@@ -7627,21 +7661,21 @@
 										{
 											"name": "Benevolent Dictators and Brutal Tyrants",
 											"entries": [
-												" A naga rules its domain with absolute authority. Whether it rules with compassion or by terrorizing its subjects, the naga believes itself the master of all other creatures that inhabit its domain."
+												"A naga rules its domain with absolute authority. Whether it rules with compassion or by terrorizing its subjects, the naga believes itself the master of all other creatures that inhabit its domain."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Rivalry",
 											"entries": [
-												" Nagas have a long-standing enmity with the yuan-ti, with each race seeing itself as the epitome of serpentine evolution. Though cooperation between them is rare, nagas and yuan-ti sometimes set aside their differences to work toward common objectives. However, yuan-ti always chafe under a naga's authority."
+												"Nagas have a long-standing enmity with the yuan-ti, with each race seeing itself as the epitome of serpentine evolution. Though cooperation between them is rare, nagas and yuan-ti sometimes set aside their differences to work toward common objectives. However, yuan-ti always chafe under a naga's authority."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Immortal Nature",
 											"entries": [
-												" A naga doesn't require air, food, drink, or sleep."
+												"A naga doesn't require air, food, drink, or sleep."
 											],
 											"type": "entries"
 										}
@@ -7665,56 +7699,18 @@
 		{
 			"name": "Gynosphinx",
 			"source": "MM",
-			"entries": [
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								"A gynosphinx bears the head of a humanoid female. Many have the regal countenances of worldly queens, but some are marked with wild, leonine features. A gynosphinx's eyes see beyond the present time and place, and penetrate veils of invisibility and magic.",
-								"Supplicants who look deep into those eyes might find themselves magically displaced, banished to some far flung plane where a difficult trial awaits them.",
-								"Gynosphinxes are virtual libraries of knowledge and lore. They ask riddles and present puzzles to test the wit of supplicants that come to learn their secrets. Some are willing to bargain with such supplicants for treasure or service.",
-								{
-									"type": "entries",
-									"name": "Sphinxes",
-									"entries": [
-										"In sacred isolation, a sphinx guards the secrets and treasures of the gods. As it calmly regards each new party that comes before it, the bones of supplicants and quest seekers that failed to pass its tests lie scattered around its lair. Its great wings sweep along its flanks, its tawny leonine body rippling with muscle and possessed of forepaws powerful enough to tear a humanoid in half. Divine Guardians. Sphinxes test the worth of those who seek the treasures of the gods, whether forgotten secrets or mighty spells, artifacts or magical gateways. Creatures that choose to face a sphinx's test are bound to that test unto death, and only those worthy will survive it. The rest the sphinx destroys.",
-										"Some sphinxes are high priests of the gods that create them, but most are simply embodied spirits, brought into the mortal realm by devout prayer or direct intervention. A sphinx maintains its vigil tirelessly, not needing to sleep or eat. It rarely engages with others of its kind, knowing no other life except its sacred mission.",
-										{
-											"name": "Magical Tests",
-											"entries": [
-												" The secrets and treasures a sphinx guards remain under divine protection, so that when a creature fails a sphinx's test, the path to the object or knowledge it guards vanishes. Even if a sphinx is attacked and defeated, a quester will still fail to gain the secret it sought-and will make an enemy of the god that placed the sphinx as a guardian.",
-												"Benign deities sometimes grant a sphinx the power to remove supplicants that fail their tests, transporting them away and ensuring that they never encounter the sphinx again. However, those who fail a sphinx's test typically meet a gruesome end beneath its claws."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Extraplanar Beings",
-											"entries": [
-												" Mortals that encounter sphinxes do so most often in ancient tombs and ruins, but some sphinxes can access extraplanar realms. A conversation with a sphinx that begins between tumbled stone walls might suddenly shift to an alien locale, such as a life-sized game board or a daunting cliff that must be climbed in a howling storm. Sometimes a sphinx must be summoned from such an extradimensional space, with supplicants calling it from its empty lair. Only those the sphinx deems worthy gain admittance to its realm."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Fallen Sphinxes",
-											"entries": [
-												" Whether through the weariness of the ages, regret at the slaughter of innocents, or dreams of worship by supplicants that attempt to bargain their way to knowledge, some sphinxes break free of their divine command. However, even if a sphinx's alignment and loyalties drift in this way, it never leaves the place it guards or grants its secrets to any except creatures it deems worthy."
-											],
-											"type": "entries"
-										}
-									]
-								},
-								{
-									"type": "entries",
-									"name": "A Sphinx's Lair",
-									"entries": [
-										"A sphinx presides over an ancient temple, sepulcher, or vault, within which are hidden divine secrets and treasures beyond the reach of mortals."
-									]
-								}
-							]
-						}
-					]
+			"_copy": {
+				"name": "Sphinxes",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": [
+							"A gynosphinx bears the head of a humanoid female. Many have the regal countenances of worldly queens, but some are marked with wild, leonine features. A gynosphinx's eyes see beyond the present time and place, and penetrate veils of invisibility and magic.",
+							"Supplicants who look deep into those eyes might find themselves magically displaced, banished to some far flung plane where a difficult trial awaits them.",
+							"Gynosphinxes are virtual libraries of knowledge and lore. They ask riddles and present puzzles to test the wit of supplicants that come to learn their secrets. Some are willing to bargain with such supplicants for treasure or service."
+						]
+					}
 				}
 			],
 			"images": [
@@ -7844,7 +7840,7 @@
 										{
 											"name": "Furious Tempers",
 											"entries": [
-												" Ogres are notorious for their quick tempers, which flare at the smallest perceived offense. Insults and name-calling can rouse an ogre's wrath in an instant-as can stealing from it, bumping, jabbing, or prodding it, laughing, making faces, or simply looking at it the wrong way. When its rage is incited, an ogre lashes out in a frustrated tantrum until it runs out of objects or creatures to smash.",
+												"Ogres are notorious for their quick tempers, which flare at the smallest perceived offense. Insults and name-calling can rouse an ogre's wrath in an instant-as can stealing from it, bumping, jabbing, or prodding it, laughing, making faces, or simply looking at it the wrong way. When its rage is incited, an ogre lashes out in a frustrated tantrum until it runs out of objects or creatures to smash.",
 												"An ogre sleeps in caves, animal dens, or under trees until it finds a cabin or isolated farmhouse, whereupon it kills the inhabitants and lairs there. Whenever it is bored or hungry, an ogre ventures out from its lair, attacking anything that crosses its path. Only after an ogre has depleted an area of food does it move on.",
 												"Whenever possible, ogres gang up with other monsters to bully or prey on creatures weaker than themselves. They associate freely with goblinoids, orcs, and trolls, and practically worship giants. In the giants' complex social structure (known as the ordning), ogres rank beneath the lowest giants in status. As a result, an ogre will do nearly anything a giant asks."
 											],
@@ -7853,35 +7849,35 @@
 										{
 											"name": "Gruesome Gluttons",
 											"entries": [
-												" Ogres eat almost anything, but they especially enjoy the taste of dwarves, halflings, and elves. When they can, they combine dinner with pleasure, chasing scurrying victims around before eating them raw. If enough of its victim remains after the ogre has gorged itself, it might make a loincloth from its quarry's skin and a necklace from its leftover bones. This macabre crafting is the height of ogre culture."
+												"Ogres eat almost anything, but they especially enjoy the taste of dwarves, halflings, and elves. When they can, they combine dinner with pleasure, chasing scurrying victims around before eating them raw. If enough of its victim remains after the ogre has gorged itself, it might make a loincloth from its quarry's skin and a necklace from its leftover bones. This macabre crafting is the height of ogre culture."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Greedy Collectors",
 											"entries": [
-												" An ogre's eyes glitter with avarice when it sees the possessions of others. Ogres carry rough sacks on their raids, which they fill with fabulous \"treasure\" taken from their victims. This might include a collection of battered helmets, a moldy wheel of cheese, a rough patch of animal fur fastened like a cloak, or a squealing, mud-spattered pig. Ogres also delight in the gleam of gold and silver, and they will fight one another over small handfuls of coins. Smarter creatures can earn an ogre's trust by offering it gold or a weapon forged for a creature of its size."
+												"An ogre's eyes glitter with avarice when it sees the possessions of others. Ogres carry rough sacks on their raids, which they fill with fabulous \"treasure\" taken from their victims. This might include a collection of battered helmets, a moldy wheel of cheese, a rough patch of animal fur fastened like a cloak, or a squealing, mud-spattered pig. Ogres also delight in the gleam of gold and silver, and they will fight one another over small handfuls of coins. Smarter creatures can earn an ogre's trust by offering it gold or a weapon forged for a creature of its size."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Legendary Stupidity",
 											"entries": [
-												" Few ogres can count to ten, even with their fingers in front of them. Most speak only a rudimentary form of Giant and know a smattering of Common words. Ogres believe what they are told and are easy to fool or confuse, but they break things they don't understand. Silver-tongued tricksters who test their talents on these savages typically end up eating their eloquent words-and then being eaten in turn."
+												"Few ogres can count to ten, even with their fingers in front of them. Most speak only a rudimentary form of Giant and know a smattering of Common words. Ogres believe what they are told and are easy to fool or confuse, but they break things they don't understand. Silver-tongued tricksters who test their talents on these savages typically end up eating their eloquent words-and then being eaten in turn."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Primitive Wanderers",
 											"entries": [
-												" Ogres clothe themselves in animal pelts and uproot trees for use as crude tools and weapons. They create stone-tipped javelins for hunting. When they establish lairs, they settle near the rural edges of civilized lands, taking advantage of poorly protected livestock, undefended larders, and unwary farmers."
+												"Ogres clothe themselves in animal pelts and uproot trees for use as crude tools and weapons. They create stone-tipped javelins for hunting. When they establish lairs, they settle near the rural edges of civilized lands, taking advantage of poorly protected livestock, undefended larders, and unwary farmers."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Ogre Gangs",
 											"entries": [
-												" Ogres sometimes band together in small, nomadic groups, but they lack a true sense of tribalism. When bands of ogres meet, one might attempt to capture the members of the other group to increase its numbers. However, ogre bands are just as likely to trade members freely, especially if the welcoming band is temporarily flush with food and weapons."
+												"Ogres sometimes band together in small, nomadic groups, but they lack a true sense of tribalism. When bands of ogres meet, one might attempt to capture the members of the other group to increase its numbers. However, ogre bands are just as likely to trade members freely, especially if the welcoming band is temporarily flush with food and weapons."
 											],
 											"type": "entries"
 										}
@@ -8500,7 +8496,7 @@
 								{
 									"name": "Echoes in the Dark",
 									"entries": [
-										" Hook horrors communicate by striking their hooks against their exoskeletons or the stone surfaces around them. What sounds to others like random clacking noise is actually a complex language that only hook horrors understand, and which carries for miles through the echoing Underdark."
+										"Hook horrors communicate by striking their hooks against their exoskeletons or the stone surfaces around them. What sounds to others like random clacking noise is actually a complex language that only hook horrors understand, and which carries for miles through the echoing Underdark."
 									],
 									"type": "entries"
 								},
@@ -8671,7 +8667,7 @@
 													"name": "Ice Spear",
 													"type": "entries",
 													"entries": [
-														"Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 14 ({@damage 2d8 + 5}) piercing damage + 10 ({@damage 3d6}) cold damage. If the target is a creature, it must succeed on a DC 15 Constitution saving throw, or for 1 minute, its speed is reduced by 10 feet; it can take either an action or a bonus action on each of its turns, not both; and it can't take reactions. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+														"{@atk mw} {@hit +10} to hit, reach 10 ft., one target. {@h}14 ({@damage 2d8 + 5}) piercing damage + 10 ({@damage 3d6}) cold damage. If the target is a creature, it must succeed on a DC 15 Constitution saving throw, or for 1 minute, its speed is reduced by 10 feet; it can take either an action or a bonus action on each of its turns, not both; and it can't take reactions. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 													]
 												}
 											]
@@ -8886,59 +8882,19 @@
 		{
 			"name": "Iron Golem",
 			"source": "MM",
-			"entries": [
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								"The mightiest of the golems, the iron golem is a massive, towering giant wrought of heavy metal. An iron golem's shape can be worked into any form, though most are fashioned to look like giant suits of armor. Its fist can destroy creatures with a single blow, and its clanging steps shake the earth beneath its feet. Iron golems wield enormous blades to extend their reach, and all can belch clouds of deadly poison.",
-								"An iron golem's body is smelted with rare tinctures and admixtures. Though other golems bear weaknesses inherent in their materials or the power of the elemental spirit bound within them, iron golems were designed to be nearly invulnerable. Their iron bodies imprison the spirits that drive them, and are susceptible only to weapons imbued with magic or the strength of adamantine.",
-								{
-									"type": "entries",
-									"name": "Golems",
-									"entries": [
-										"Golems are made from humble materials-clay, flesh and bones, iron, or stone-but they possess astonishing power and durability. A golem has no ambitions, needs no sustenance, feels no pain, and knows no remorse. An unstoppable juggernaut, it exists to follow its creator's orders, and it protects or attacks as that creator demands.",
-										"To create a golem, one requires a manual of golems (see the Dungeon Master's Guide). The comprehensive illustrations and instructions in a manual detail the process for creating a golem of a particular type.",
-										{
-											"name": "Elemental Spirit in Material Form",
-											"entries": [
-												" The construction of a golem begins with the building of its body, requiring great command of the craft of sculpting, stonecutting, ironworking, or surgery. Sometimes a golem's creator is the master of the art, but often the individual who desires a golem must enlist master artisans to do the work.",
-												"After constructing the body from clay, flesh, iron, or stone, the golem's creator infuses it with a spirit from the Elemental Plane of Earth. This tiny spark of life has no memory, personality, or history. It is simply the impetus to move and obey. This process binds the spirit to the artificial body and subjects it to the will of the golem's creator.",
-												"A golem can be created with a special amulet or other item that allows the possessor of the item to control the golem. Golems whose creators are long dead can thus be harnessed to serve a new master.",
-												"A golem can't think or act for itself. Though it understands its commands perfectly, it has no grasp of language beyond that understanding, and can't be reasoned with or tricked with words."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Ageless Guardians",
-											"entries": [
-												" Golems can guard sacred sites, tombs, and treasure vaults long after the deaths of their creators, carrying out their appointed tasks for all eternity while brushing off physical damage and ignoring all but the most potent spells."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Blind Obedience",
-											"entries": [
-												" When its creator or possessor is on hand to command it, a golem performs flawlessly. If the golem is left without instructions or is {@condition incapacitated}, it continues to follow its last orders to the best of its ability. When it can't fulfill its orders, a golem might react violently-or stand and do nothing. A golem that has been given conflicting orders sometimes alternates between them."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Constructed Nature",
-											"entries": [
-												" A golem doesn't require air, food, drink, or sleep."
-											],
-											"type": "entries"
-										}
-									]
-								}
-							]
-						}
-					]
+			"_copy": {
+				"name": "Golems",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": [
+							"The mightiest of the golems, the iron golem is a massive, towering giant wrought of heavy metal. An iron golem's shape can be worked into any form, though most are fashioned to look like giant suits of armor. Its fist can destroy creatures with a single blow, and its clanging steps shake the earth beneath its feet. Iron golems wield enormous blades to extend their reach, and all can belch clouds of deadly poison.",
+							"An iron golem's body is smelted with rare tinctures and admixtures. Though other golems bear weaknesses inherent in their materials or the power of the elemental spirit bound within them, iron golems were designed to be nearly invulnerable. Their iron bodies imprison the spirits that drive them, and are susceptible only to weapons imbued with magic or the strength of adamantine."
+						]
+					}
 				}
-			],
+			},
 			"images": [
 				{
 					"type": "image",
@@ -9012,7 +8968,7 @@
 										{
 											"name": "Speech in Pantomime",
 											"entries": [
-												" Kenku can mimic the sound of anything they hear. A kenku asking for money might make the sound of coins clinking together, and a kenku referring to a busy marketplace can reproduce the cacophony of hawking vendors, barking dogs, bleating sheep, and the cries of street urchins. When mimicking voices, they can only repeat words and phrases they have heard, not create new sentences. To converse with a kenku is to witness a performance of imitated sounds and almost nonsensical verse.",
+												"Kenku can mimic the sound of anything they hear. A kenku asking for money might make the sound of coins clinking together, and a kenku referring to a busy marketplace can reproduce the cacophony of hawking vendors, barking dogs, bleating sheep, and the cries of street urchins. When mimicking voices, they can only repeat words and phrases they have heard, not create new sentences. To converse with a kenku is to witness a performance of imitated sounds and almost nonsensical verse.",
 												"Kenku speak to one another in much the same way. Because they are adept at interpreting one another's glances and gestures, the sounds they make to communicate complex ideas or emotions can be succinct. Groups of kenku also develop secret codes. For example, a cat's meow might be the secret code for \"Prepare to attack!\" or \"Flee for your lives!\" Their talent for mimicry extends to handwriting, and criminal organizations often employ kenku to forge documents. When a kenku commits a crime, it might forge evidence to implicate another creature."
 											],
 											"type": "entries"
@@ -9072,7 +9028,7 @@
 								{
 									"name": "Strength in Numbers",
 									"entries": [
-										" Kobolds are egg-laying creatures. They mature quickly and can live to be \"great wyrms\" more than a century old. However, many kobolds perish before they reach the end of their first decade. Physically weak, they are easy prey for predators. This vulnerability forces them to band together. Their superior numbers can win battles against powerful adversaries, but often with massive casualties on the kobold side."
+										"Kobolds are egg-laying creatures. They mature quickly and can live to be \"great wyrms\" more than a century old. However, many kobolds perish before they reach the end of their first decade. Physically weak, they are easy prey for predators. This vulnerability forces them to band together. Their superior numbers can win battles against powerful adversaries, but often with massive casualties on the kobold side."
 									],
 									"type": "entries"
 								},
@@ -9199,21 +9155,21 @@
 										{
 											"name": "Multiattack",
 											"entries": [
-												" The kuo-toa makes one bite attack and two unarmed strikes."
+												"The kuo-toa makes one bite attack and two unarmed strikes."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Bite",
 											"entries": [
-												" Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 4 ({@damage 1d4 + 2}) piercing damage."
+												"Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 4 ({@damage 1d4 + 2}) piercing damage."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Unarmed Strike",
 											"entries": [
-												" Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 5 ({@damage 1d6 + 2}) bludgeoning damage + 3 ({@damage 1d6}) lightning damage, and the target can't take reactions until the end of the kuo-toa's next turn."
+												"Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 5 ({@damage 1d6 + 2}) bludgeoning damage + 3 ({@damage 1d6}) lightning damage, and the target can't take reactions until the end of the kuo-toa's next turn."
 											],
 											"type": "entries"
 										}
@@ -9849,7 +9805,7 @@
 										{
 											"name": "Creatures of the Elements",
 											"entries": [
-												" A genie is born when the soul of a sentient living creature melds with the primordial matter of an elemental plane. Only under rare circumstances does such an elemental-infused soul coalesce into a manifest form and create a genie.",
+												"A genie is born when the soul of a sentient living creature melds with the primordial matter of an elemental plane. Only under rare circumstances does such an elemental-infused soul coalesce into a manifest form and create a genie.",
 												"A genie usually retains no connection to the soul that gave it form. That life force is a building block that determines the genie's form and apparent gender, as well as one or two key personality traits. Although they resemble humanoid beings, genies are elemental spirits given physical form. They don't mate with other genies or produce genie offspring, as all new genies are born out of the same mysterious fusion of spirit energy and elemental power. A genie with a stronger connection to its mortal soul might choose to sire a child with a mortal, although such offspring are rare.",
 												"When a genie perishes, it leaves nothing behind except what it was wearing or carrying, along with a small trace of its native element: a pile of dust, a gust of wind, a flash of fire and smoke, or a burst of water and foam.",
 												"In contrast to their love of slaves, most genies loathe being bound to service themselves. A genie obeys the will of another only when bribed or compelled by magic. All genies command the power of their native element, but a rare few also possess the power to grant wishes. For both these reasons, mortal mages often seek to bind genies into service.",
@@ -9861,21 +9817,21 @@
 										{
 											"name": "Rule or Be Ruled",
 											"entries": [
-												" Mortal slaves serve to validate a genie's power and high self-opinion. A hundred flattering voices are music to a genie's ears, while two hundred mortal slaves prostrated at its feet are proof that it is lord and master. Genies view slaves as living property, and a genie without property amounts to nothing among its own kind. As a result, many genies treasure their slaves, treating them as honored members of their households. Evil genies freely threaten and abuse their slaves, but never to the extent that the slaves are no longer of use."
+												"Mortal slaves serve to validate a genie's power and high self-opinion. A hundred flattering voices are music to a genie's ears, while two hundred mortal slaves prostrated at its feet are proof that it is lord and master. Genies view slaves as living property, and a genie without property amounts to nothing among its own kind. As a result, many genies treasure their slaves, treating them as honored members of their households. Evil genies freely threaten and abuse their slaves, but never to the extent that the slaves are no longer of use."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Decadent Nobility",
 											"entries": [
-												" Noble genies are the rarest of their kind. They are used to getting what they want, and have learned to trade their ability to grant wishes to attain the objects of their desire. This constant indulgence has made them decadent, while their supreme power over reality makes them haughty and arrogant. Their vast palaces overflow with wonders and sensory delights beyond imagination."
+												"Noble genies are the rarest of their kind. They are used to getting what they want, and have learned to trade their ability to grant wishes to attain the objects of their desire. This constant indulgence has made them decadent, while their supreme power over reality makes them haughty and arrogant. Their vast palaces overflow with wonders and sensory delights beyond imagination."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "The Power of Worship",
 											"entries": [
-												" Genies acknowledge the gods as powerful entities but have no desire to court or worship them. They find the endless fawning and mewling of religious devotees tiresome-except as it is directed toward them by their worshipful slaves."
+												"Genies acknowledge the gods as powerful entities but have no desire to court or worship them. They find the endless fawning and mewling of religious devotees tiresome-except as it is directed toward them by their worshipful slaves."
 											],
 											"type": "entries"
 										}
@@ -10397,7 +10353,7 @@
 										{
 											"name": "Absolute Law and Order",
 											"entries": [
-												" Under the direction of their leader, Primus, modrons increase order in the multiverse in accordance with laws beyond the comprehension of mortal minds. Their own minds are networked in a hierarchal pyramid, in which each modron receives commands from superiors and delegates orders to underlings. A modron carries out commands with total obedience, utmost efficiency, and an absence of morality or ego. Modrons have no sense of self beyond what is necessary to fulfill their duties. They exist as a unified collective, divided by ranks, yet they always refer to themselves collectively. To a modron, there is no \"I,\" but only \"we\" or \"us.\"",
+												"Under the direction of their leader, Primus, modrons increase order in the multiverse in accordance with laws beyond the comprehension of mortal minds. Their own minds are networked in a hierarchal pyramid, in which each modron receives commands from superiors and delegates orders to underlings. A modron carries out commands with total obedience, utmost efficiency, and an absence of morality or ego. Modrons have no sense of self beyond what is necessary to fulfill their duties. They exist as a unified collective, divided by ranks, yet they always refer to themselves collectively. To a modron, there is no \"I,\" but only \"we\" or \"us.\"",
 												{
 													"type": "inset",
 													"name": "Variant: Rogue Modrons",
@@ -10412,21 +10368,21 @@
 										{
 											"name": "Absolute Hierarchy",
 											"entries": [
-												" Modrons communicate only with their own rank and the ranks immediately above and below them. Modrons more than one rank away are either too advanced or too simple to understand."
+												"Modrons communicate only with their own rank and the ranks immediately above and below them. Modrons more than one rank away are either too advanced or too simple to understand."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Cogs of the Great Machine",
 											"entries": [
-												" If a modron is destroyed, its remains disintegrate. A replacement from the next lowest rank then transforms in a flash of light, gaining the physical form of its new rank. The promoted modron is replaced by one of its underlings in the same manner, all the way to the lowest levels of the hierarchy. There, a new modron is created by Primus, with a steady stream of monodrones leaving the Great Modron Cathedral on Mechanus as a result."
+												"If a modron is destroyed, its remains disintegrate. A replacement from the next lowest rank then transforms in a flash of light, gaining the physical form of its new rank. The promoted modron is replaced by one of its underlings in the same manner, all the way to the lowest levels of the hierarchy. There, a new modron is created by Primus, with a steady stream of monodrones leaving the Great Modron Cathedral on Mechanus as a result."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "The Great Modron March",
 											"entries": [
-												" When the gears of Mechanus complete seventeen cycles once every 289 years, Primus sends a vast army of modrons across the Outer Planes, ostensibly on a reconnaissance mission. The march is long and dangerous, and only a small number of modrons returns to Mechanus."
+												"When the gears of Mechanus complete seventeen cycles once every 289 years, Primus sends a vast army of modrons across the Outer Planes, ostensibly on a reconnaissance mission. The march is long and dangerous, and only a small number of modrons returns to Mechanus."
 											],
 											"type": "entries"
 										}
@@ -10594,7 +10550,7 @@
 										{
 											"name": "Preserved Wrath",
 											"entries": [
-												" The long burial rituals that accompany a mummy's entombment help protect its body from rot. In the embalming process, the newly dead creature's organs are removed and placed in special jars, and its corpse is treated with preserving oils, herbs, and wrappings. After the body has been prepared, the corpse is typically wrapped in linen bandages.",
+												"The long burial rituals that accompany a mummy's entombment help protect its body from rot. In the embalming process, the newly dead creature's organs are removed and placed in special jars, and its corpse is treated with preserving oils, herbs, and wrappings. After the body has been prepared, the corpse is typically wrapped in linen bandages.",
 												"More ephemeral or permanent offenses, such as revealing a secret the mummy wished kept or killing an individual the mummy loved, can't be so easily remedied. In such cases, a mummy might slaughter all the creatures responsible and still not sate its wrath."
 											],
 											"type": "entries"
@@ -10602,42 +10558,42 @@
 										{
 											"name": "The Will of Dark Gods",
 											"entries": [
-												" An undead mummy is created when the priest of a death god or other dark deity ritually imbues a prepared corpse with necromantic magic. The mummy's linen wrappings are inscribed with necromantic markings before the burial ritual concludes with an invocation to darkness. As a mummy endures in undeath, it animates in response to conditions specified by the ritual. Most commonly, a transgression against its tomb, treasures, lands, or former loved ones will cause a mummy to rise."
+												"An undead mummy is created when the priest of a death god or other dark deity ritually imbues a prepared corpse with necromantic magic. The mummy's linen wrappings are inscribed with necromantic markings before the burial ritual concludes with an invocation to darkness. As a mummy endures in undeath, it animates in response to conditions specified by the ritual. Most commonly, a transgression against its tomb, treasures, lands, or former loved ones will cause a mummy to rise."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "The Punished",
 											"entries": [
-												" Once deceased, an individual has no say in whether or not its body is made into a mummy. Some mummies were powerful individuals who displeased a high priest or pharaoh, or who committed crimes of treason, adultery, or murder. As punishment, they were cursed with eternal undeath, embalmed, mummified, and sealed away. Other times, mummies acting as tomb guardians are created from slaves put to death specifically to serve a greater purpose."
+												"Once deceased, an individual has no say in whether or not its body is made into a mummy. Some mummies were powerful individuals who displeased a high priest or pharaoh, or who committed crimes of treason, adultery, or murder. As punishment, they were cursed with eternal undeath, embalmed, mummified, and sealed away. Other times, mummies acting as tomb guardians are created from slaves put to death specifically to serve a greater purpose."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Creature of Ritual",
 											"entries": [
-												" A mummy obeys the conditions and parameters laid down by the rituals that created it, driven only to punish transgressors. The overwhelming terror that foreshadows a mummy's attack can leave the intended victim paralyzed with fright. In the days following a mummy's touch, a victim's body rots from the outside in, until nothing but dust remains."
+												"A mummy obeys the conditions and parameters laid down by the rituals that created it, driven only to punish transgressors. The overwhelming terror that foreshadows a mummy's attack can leave the intended victim paralyzed with fright. In the days following a mummy's touch, a victim's body rots from the outside in, until nothing but dust remains."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Ending a Mummy's Curse",
 											"entries": [
-												" Rare magic can undo or dispel the ritual that gave rise to a mummy, allowing it to truly die. More commonly, a mummy can be sent back to its endless rest by undoing the transgression that caused it to rise. A sacred idol might be replaced in its niche, a stolen treasure could be returned to its tomb, or a temple might be purified of despoiling bloodshed."
+												"Rare magic can undo or dispel the ritual that gave rise to a mummy, allowing it to truly die. More commonly, a mummy can be sent back to its endless rest by undoing the transgression that caused it to rise. A sacred idol might be replaced in its niche, a stolen treasure could be returned to its tomb, or a temple might be purified of despoiling bloodshed."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Undead Archives",
 											"entries": [
-												" Though they seldom bother to do so, mummies can speak. As a result, some serve as undead repositories of lost lore, and can be consulted by the descendants of those who created them. Powerful individuals sometimes intentionally sequester mummies away for occasional consultation."
+												"Though they seldom bother to do so, mummies can speak. As a result, some serve as undead repositories of lost lore, and can be consulted by the descendants of those who created them. Powerful individuals sometimes intentionally sequester mummies away for occasional consultation."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Undead Nature",
 											"entries": [
-												" A mummy doesn't require air, food, drink, or sleep."
+												"A mummy doesn't require air, food, drink, or sleep."
 											],
 											"type": "entries"
 										}
@@ -10776,7 +10732,7 @@
 										{
 											"name": "Controlled by Evil",
 											"entries": [
-												" Blights are independent creatures, but most act under a Gulthias tree's control, often displaying the habits and traits of the life force or spirit that spawned them. By attacking their progenitor's old foes or seeking out treasures valuable to it, they carry on the legacy of long-lost evil."
+												"Blights are independent creatures, but most act under a Gulthias tree's control, often displaying the habits and traits of the life force or spirit that spawned them. By attacking their progenitor's old foes or seeking out treasures valuable to it, they carry on the legacy of long-lost evil."
 											],
 											"type": "entries"
 										}
@@ -10968,7 +10924,7 @@
 										{
 											"name": "Lurkers in Magical Places",
 											"entries": [
-												" Nothics are notorious for infiltrating arcane academies and other places rich in magical learning. They are driven by the vague knowledge that there exists a method to reverse their condition. This isn't a clear sense of purpose, but rather an obsessive tug at the end of the mind. Some nothics are clever enough to realize that this is merely part of the strange lesson for their folly, a false hope to drive them to seek out more arcane secrets."
+												"Nothics are notorious for infiltrating arcane academies and other places rich in magical learning. They are driven by the vague knowledge that there exists a method to reverse their condition. This isn't a clear sense of purpose, but rather an obsessive tug at the end of the mind. Some nothics are clever enough to realize that this is merely part of the strange lesson for their folly, a false hope to drive them to seek out more arcane secrets."
 											],
 											"type": "entries"
 										}
@@ -11045,7 +11001,7 @@
 										{
 											"name": "Slow Death",
 											"entries": [
-												" An ooze kills its prey slowly. Some varieties, such as black puddings and gelatinous cubes, engulf creatures to prevent escape. The only upside of this torturous death is that a victim's comrades can come to the rescue before it is too late.",
+												"An ooze kills its prey slowly. Some varieties, such as black puddings and gelatinous cubes, engulf creatures to prevent escape. The only upside of this torturous death is that a victim's comrades can come to the rescue before it is too late.",
 												"Since not every ooze digests every type of substance, some have coins, metal gear, bones, and other debris suspended within their quivering bodies. A slain ooze can be a rich source of treasure for its killers.",
 												"Whether this is true or not, the Faceless Lord is one of the few beings that can control oozes and imbue them with a modicum of intelligence. Most of the time, oozes have no sense of tactics or self-preservation. They are direct and predictable, attacking and eating without cunning. Under the control of Juiblex, they exhibit glimmers of sentience and malevolent intent."
 											],
@@ -11054,21 +11010,21 @@
 										{
 											"name": "Unwitting Servants",
 											"entries": [
-												" Although an ooze lacks the intelligence to ally itself with other creatures, others that understand an ooze's need to feed might lure it into a location where it can be of use to them. Clever monsters keep oozes around to defend passageways or consume refuse. Likewise, an ooze can be enticed into a pit trap, where its captors feed it often enough to prevent it from coming after them. Crafty creatures place torches and flaming braziers in strategic areas to dissuade an ooze from leaving a particular tunnel or room."
+												"Although an ooze lacks the intelligence to ally itself with other creatures, others that understand an ooze's need to feed might lure it into a location where it can be of use to them. Clever monsters keep oozes around to defend passageways or consume refuse. Likewise, an ooze can be enticed into a pit trap, where its captors feed it often enough to prevent it from coming after them. Crafty creatures place torches and flaming braziers in strategic areas to dissuade an ooze from leaving a particular tunnel or room."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Spawn of Juiblex",
 											"entries": [
-												" According to the Demonomicon of Iggwilv and other sources, oozes are scattered fragments or offspring of the demon lord Juiblex."
+												"According to the Demonomicon of Iggwilv and other sources, oozes are scattered fragments or offspring of the demon lord Juiblex."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Ooze Nature",
 											"entries": [
-												" An ooze doesn't require sleep."
+												"An ooze doesn't require sleep."
 											],
 											"type": "entries"
 										}
@@ -11243,7 +11199,7 @@
 								{
 									"name": "Gruumsh One-Eye",
 									"entries": [
-										" Orcs worship Gruumsh, the mightiest of the orc deities and their creator. The orcs believe that in ancient days, the gods gathered to divide the world among their followers. When Gruumsh claimed the mountains, he learned they had been taken by the dwarves. He laid claim to the forests, but those had been settled by the elves. Each place that Gruumsh wanted had already been claimed. The other gods laughed at Gruumsh, but he responded with a furious bellow. Grasping his mighty spear, he laid waste to the mountains, set the forests aflame, and carved great furrows in the fields. Such was the role of the orcs, he proclaimed, to take and destroy all that the other races would deny them. To this day, the orcs wage an endless war on humans, elves, dwarves, and other folk.",
+										"Orcs worship Gruumsh, the mightiest of the orc deities and their creator. The orcs believe that in ancient days, the gods gathered to divide the world among their followers. When Gruumsh claimed the mountains, he learned they had been taken by the dwarves. He laid claim to the forests, but those had been settled by the elves. Each place that Gruumsh wanted had already been claimed. The other gods laughed at Gruumsh, but he responded with a furious bellow. Grasping his mighty spear, he laid waste to the mountains, set the forests aflame, and carved great furrows in the fields. Such was the role of the orcs, he proclaimed, to take and destroy all that the other races would deny them. To this day, the orcs wage an endless war on humans, elves, dwarves, and other folk.",
 										"Orcs hold a particular hatred for elves. The elven god Corellon Larethian half-blinded Gruumsh with a well-placed arrow to the orc god's eye. Since then, the orcs have taken particular joy in slaughtering elves. Turning his injury into a baleful gift, Gruumsh grants divine might to any champion who willingly plucks out one of its eyes in his honor."
 									],
 									"type": "entries"
@@ -11314,7 +11270,7 @@
 										{
 											"name": "Gruumsh One-Eye",
 											"entries": [
-												" Orcs worship Gruumsh, the mightiest of the orc deities and their creator. The orcs believe that in ancient days, the gods gathered to divide the world among their followers. When Gruumsh claimed the mountains, he learned they had been taken by the dwarves. He laid claim to the forests, but those had been settled by the elves. Each place that Gruumsh wanted had already been claimed. The other gods laughed at Gruumsh, but he responded with a furious bellow. Grasping his mighty spear, he laid waste to the mountains, set the forests aflame, and carved great furrows in the fields. Such was the role of the orcs, he proclaimed, to take and destroy all that the other races would deny them. To this day, the orcs wage an endless war on humans, elves, dwarves, and other folk.",
+												"Orcs worship Gruumsh, the mightiest of the orc deities and their creator. The orcs believe that in ancient days, the gods gathered to divide the world among their followers. When Gruumsh claimed the mountains, he learned they had been taken by the dwarves. He laid claim to the forests, but those had been settled by the elves. Each place that Gruumsh wanted had already been claimed. The other gods laughed at Gruumsh, but he responded with a furious bellow. Grasping his mighty spear, he laid waste to the mountains, set the forests aflame, and carved great furrows in the fields. Such was the role of the orcs, he proclaimed, to take and destroy all that the other races would deny them. To this day, the orcs wage an endless war on humans, elves, dwarves, and other folk.",
 												"Orcs hold a particular hatred for elves. The elven god Corellon Larethian half-blinded Gruumsh with a well-placed arrow to the orc god's eye. Since then, the orcs have taken particular joy in slaughtering elves. Turning his injury into a baleful gift, Gruumsh grants divine might to any champion who willingly plucks out one of its eyes in his honor.",
 												{
 													"type": "entries",
@@ -11332,21 +11288,21 @@
 										{
 											"name": "Ranging Scavengers",
 											"entries": [
-												" Their lust for slaughter demands that orcs dwell always within striking distance of new targets. As such, they seldom settle permanently, instead converting ruins, cavern complexes, and defeated foes' villages into fortified camps and strongholds. Orcs build only for defense, making no innovation or improvement to their lairs beyond mounting the severed body parts of their victims on spiked stockade walls or pikes jutting up from moats and trenches."
+												"Their lust for slaughter demands that orcs dwell always within striking distance of new targets. As such, they seldom settle permanently, instead converting ruins, cavern complexes, and defeated foes' villages into fortified camps and strongholds. Orcs build only for defense, making no innovation or improvement to their lairs beyond mounting the severed body parts of their victims on spiked stockade walls or pikes jutting up from moats and trenches."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Leadership and Might",
 											"entries": [
-												" Orc tribes are mostly patriarchal, flaunting such vivid or grotesque titles as Many-Arrows, Screaming Eye, and Elf Ripper. Occasionally, a powerful war chief unites scattered orc tribes into a single rampaging horde, which runs roughshod over other orc tribes and humanoid settlements from a position of overwhelming strength."
+												"Orc tribes are mostly patriarchal, flaunting such vivid or grotesque titles as Many-Arrows, Screaming Eye, and Elf Ripper. Occasionally, a powerful war chief unites scattered orc tribes into a single rampaging horde, which runs roughshod over other orc tribes and humanoid settlements from a position of overwhelming strength."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Orc Crossbreeds",
 											"entries": [
-												" Luthic, the orc goddess of fertility and wife of Gruumsh, demands that orcs procreate often and indiscriminately so that orc hordes swell generation after generation. The orcs' drive to reproduce runs stronger than any other humanoid race, and they readily crossbreed with other races. When an orc procreates with a non-orc humanoid of similar size and stature (such as a human or a dwarf), the resulting child is either an orc or a half-orc. When an orc produces young with an ogre, the child is a half-ogre of intimidating strength and brutish features called an ogrillon."
+												"Luthic, the orc goddess of fertility and wife of Gruumsh, demands that orcs procreate often and indiscriminately so that orc hordes swell generation after generation. The orcs' drive to reproduce runs stronger than any other humanoid race, and they readily crossbreed with other races. When an orc procreates with a non-orc humanoid of similar size and stature (such as a human or a dwarf), the resulting child is either an orc or a half-orc. When an orc produces young with an ogre, the child is a half-ogre of intimidating strength and brutish features called an ogrillon."
 											],
 											"type": "entries"
 										}
@@ -11391,7 +11347,7 @@
 										{
 											"name": "Gruumsh One-Eye",
 											"entries": [
-												" Orcs worship Gruumsh, the mightiest of the orc deities and their creator. The orcs believe that in ancient days, the gods gathered to divide the world among their followers. When Gruumsh claimed the mountains, he learned they had been taken by the dwarves. He laid claim to the forests, but those had been settled by the elves. Each place that Gruumsh wanted had already been claimed. The other gods laughed at Gruumsh, but he responded with a furious bellow. Grasping his mighty spear, he laid waste to the mountains, set the forests aflame, and carved great furrows in the fields. Such was the role of the orcs, he proclaimed, to take and destroy all that the other races would deny them. To this day, the orcs wage an endless war on humans, elves, dwarves, and other folk.",
+												"Orcs worship Gruumsh, the mightiest of the orc deities and their creator. The orcs believe that in ancient days, the gods gathered to divide the world among their followers. When Gruumsh claimed the mountains, he learned they had been taken by the dwarves. He laid claim to the forests, but those had been settled by the elves. Each place that Gruumsh wanted had already been claimed. The other gods laughed at Gruumsh, but he responded with a furious bellow. Grasping his mighty spear, he laid waste to the mountains, set the forests aflame, and carved great furrows in the fields. Such was the role of the orcs, he proclaimed, to take and destroy all that the other races would deny them. To this day, the orcs wage an endless war on humans, elves, dwarves, and other folk.",
 												"Orcs hold a particular hatred for elves. The elven god Corellon Larethian half-blinded Gruumsh with a well-placed arrow to the orc god's eye. Since then, the orcs have taken particular joy in slaughtering elves. Turning his injury into a baleful gift, Gruumsh grants divine might to any champion who willingly plucks out one of its eyes in his honor.",
 												{
 													"type": "entries",
@@ -11409,21 +11365,21 @@
 										{
 											"name": "Ranging Scavengers",
 											"entries": [
-												" Their lust for slaughter demands that orcs dwell always within striking distance of new targets. As such, they seldom settle permanently, instead converting ruins, cavern complexes, and defeated foes' villages into fortified camps and strongholds. Orcs build only for defense, making no innovation or improvement to their lairs beyond mounting the severed body parts of their victims on spiked stockade walls or pikes jutting up from moats and trenches."
+												"Their lust for slaughter demands that orcs dwell always within striking distance of new targets. As such, they seldom settle permanently, instead converting ruins, cavern complexes, and defeated foes' villages into fortified camps and strongholds. Orcs build only for defense, making no innovation or improvement to their lairs beyond mounting the severed body parts of their victims on spiked stockade walls or pikes jutting up from moats and trenches."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Leadership and Might",
 											"entries": [
-												" Orc tribes are mostly patriarchal, flaunting such vivid or grotesque titles as Many-Arrows, Screaming Eye, and Elf Ripper. Occasionally, a powerful war chief unites scattered orc tribes into a single rampaging horde, which runs roughshod over other orc tribes and humanoid settlements from a position of overwhelming strength."
+												"Orc tribes are mostly patriarchal, flaunting such vivid or grotesque titles as Many-Arrows, Screaming Eye, and Elf Ripper. Occasionally, a powerful war chief unites scattered orc tribes into a single rampaging horde, which runs roughshod over other orc tribes and humanoid settlements from a position of overwhelming strength."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Orc Crossbreeds",
 											"entries": [
-												" Luthic, the orc goddess of fertility and wife of Gruumsh, demands that orcs procreate often and indiscriminately so that orc hordes swell generation after generation. The orcs' drive to reproduce runs stronger than any other humanoid race, and they readily crossbreed with other races. When an orc procreates with a non-orc humanoid of similar size and stature (such as a human or a dwarf), the resulting child is either an orc or a half-orc. When an orc produces young with an ogre, the child is a half-ogre of intimidating strength and brutish features called an ogrillon."
+												"Luthic, the orc goddess of fertility and wife of Gruumsh, demands that orcs procreate often and indiscriminately so that orc hordes swell generation after generation. The orcs' drive to reproduce runs stronger than any other humanoid race, and they readily crossbreed with other races. When an orc procreates with a non-orc humanoid of similar size and stature (such as a human or a dwarf), the resulting child is either an orc or a half-orc. When an orc produces young with an ogre, the child is a half-ogre of intimidating strength and brutish features called an ogrillon."
 											],
 											"type": "entries"
 										}
@@ -11486,7 +11442,7 @@
 										{
 											"name": "Gruumsh One-Eye",
 											"entries": [
-												" Orcs worship Gruumsh, the mightiest of the orc deities and their creator. The orcs believe that in ancient days, the gods gathered to divide the world among their followers. When Gruumsh claimed the mountains, he learned they had been taken by the dwarves. He laid claim to the forests, but those had been settled by the elves. Each place that Gruumsh wanted had already been claimed. The other gods laughed at Gruumsh, but he responded with a furious bellow. Grasping his mighty spear, he laid waste to the mountains, set the forests aflame, and carved great furrows in the fields. Such was the role of the orcs, he proclaimed, to take and destroy all that the other races would deny them. To this day, the orcs wage an endless war on humans, elves, dwarves, and other folk.",
+												"Orcs worship Gruumsh, the mightiest of the orc deities and their creator. The orcs believe that in ancient days, the gods gathered to divide the world among their followers. When Gruumsh claimed the mountains, he learned they had been taken by the dwarves. He laid claim to the forests, but those had been settled by the elves. Each place that Gruumsh wanted had already been claimed. The other gods laughed at Gruumsh, but he responded with a furious bellow. Grasping his mighty spear, he laid waste to the mountains, set the forests aflame, and carved great furrows in the fields. Such was the role of the orcs, he proclaimed, to take and destroy all that the other races would deny them. To this day, the orcs wage an endless war on humans, elves, dwarves, and other folk.",
 												"Orcs hold a particular hatred for elves. The elven god Corellon Larethian half-blinded Gruumsh with a well-placed arrow to the orc god's eye. Since then, the orcs have taken particular joy in slaughtering elves. Turning his injury into a baleful gift, Gruumsh grants divine might to any champion who willingly plucks out one of its eyes in his honor.",
 												{
 													"type": "entries",
@@ -11504,21 +11460,21 @@
 										{
 											"name": "Ranging Scavengers",
 											"entries": [
-												" Their lust for slaughter demands that orcs dwell always within striking distance of new targets. As such, they seldom settle permanently, instead converting ruins, cavern complexes, and defeated foes' villages into fortified camps and strongholds. Orcs build only for defense, making no innovation or improvement to their lairs beyond mounting the severed body parts of their victims on spiked stockade walls or pikes jutting up from moats and trenches."
+												"Their lust for slaughter demands that orcs dwell always within striking distance of new targets. As such, they seldom settle permanently, instead converting ruins, cavern complexes, and defeated foes' villages into fortified camps and strongholds. Orcs build only for defense, making no innovation or improvement to their lairs beyond mounting the severed body parts of their victims on spiked stockade walls or pikes jutting up from moats and trenches."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Leadership and Might",
 											"entries": [
-												" Orc tribes are mostly patriarchal, flaunting such vivid or grotesque titles as Many-Arrows, Screaming Eye, and Elf Ripper. Occasionally, a powerful war chief unites scattered orc tribes into a single rampaging horde, which runs roughshod over other orc tribes and humanoid settlements from a position of overwhelming strength."
+												"Orc tribes are mostly patriarchal, flaunting such vivid or grotesque titles as Many-Arrows, Screaming Eye, and Elf Ripper. Occasionally, a powerful war chief unites scattered orc tribes into a single rampaging horde, which runs roughshod over other orc tribes and humanoid settlements from a position of overwhelming strength."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Orc Crossbreeds",
 											"entries": [
-												" Luthic, the orc goddess of fertility and wife of Gruumsh, demands that orcs procreate often and indiscriminately so that orc hordes swell generation after generation. The orcs' drive to reproduce runs stronger than any other humanoid race, and they readily crossbreed with other races. When an orc procreates with a non-orc humanoid of similar size and stature (such as a human or a dwarf), the resulting child is either an orc or a half-orc. When an orc produces young with an ogre, the child is a half-ogre of intimidating strength and brutish features called an ogrillon."
+												"Luthic, the orc goddess of fertility and wife of Gruumsh, demands that orcs procreate often and indiscriminately so that orc hordes swell generation after generation. The orcs' drive to reproduce runs stronger than any other humanoid race, and they readily crossbreed with other races. When an orc procreates with a non-orc humanoid of similar size and stature (such as a human or a dwarf), the resulting child is either an orc or a half-orc. When an orc produces young with an ogre, the child is a half-ogre of intimidating strength and brutish features called an ogrillon."
 											],
 											"type": "entries"
 										}
@@ -11555,7 +11511,7 @@
 								{
 									"name": "Dwellers in Darkness",
 									"entries": [
-										" Otyughs tolerate bright light only when considerable stores of carrion or garbage lie within reach. In the wilderness, they dwell in stagnant swamps, scum-filled ponds, and damp forest dells. The scent of graveyards, city sewers, village middens, and manure-filled animal pens attracts them to civilized areas.",
+										"Otyughs tolerate bright light only when considerable stores of carrion or garbage lie within reach. In the wilderness, they dwell in stagnant swamps, scum-filled ponds, and damp forest dells. The scent of graveyards, city sewers, village middens, and manure-filled animal pens attracts them to civilized areas.",
 										"Since otyughs lack concern for anything but food, their nests sometimes accumulate a variety of treasures shed from their victims and mixed among the junk."
 									],
 									"type": "entries"
@@ -11705,7 +11661,7 @@
 										{
 											"name": "Absolute Law and Order",
 											"entries": [
-												" Under the direction of their leader, Primus, modrons increase order in the multiverse in accordance with laws beyond the comprehension of mortal minds. Their own minds are networked in a hierarchal pyramid, in which each modron receives commands from superiors and delegates orders to underlings. A modron carries out commands with total obedience, utmost efficiency, and an absence of morality or ego. Modrons have no sense of self beyond what is necessary to fulfill their duties. They exist as a unified collective, divided by ranks, yet they always refer to themselves collectively. To a modron, there is no \"I,\" but only \"we\" or \"us.\"",
+												"Under the direction of their leader, Primus, modrons increase order in the multiverse in accordance with laws beyond the comprehension of mortal minds. Their own minds are networked in a hierarchal pyramid, in which each modron receives commands from superiors and delegates orders to underlings. A modron carries out commands with total obedience, utmost efficiency, and an absence of morality or ego. Modrons have no sense of self beyond what is necessary to fulfill their duties. They exist as a unified collective, divided by ranks, yet they always refer to themselves collectively. To a modron, there is no \"I,\" but only \"we\" or \"us.\"",
 												{
 													"type": "inset",
 													"name": "Variant: Rogue Modrons",
@@ -11720,21 +11676,21 @@
 										{
 											"name": "Absolute Hierarchy",
 											"entries": [
-												" Modrons communicate only with their own rank and the ranks immediately above and below them. Modrons more than one rank away are either too advanced or too simple to understand."
+												"Modrons communicate only with their own rank and the ranks immediately above and below them. Modrons more than one rank away are either too advanced or too simple to understand."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Cogs of the Great Machine",
 											"entries": [
-												" If a modron is destroyed, its remains disintegrate. A replacement from the next lowest rank then transforms in a flash of light, gaining the physical form of its new rank. The promoted modron is replaced by one of its underlings in the same manner, all the way to the lowest levels of the hierarchy. There, a new modron is created by Primus, with a steady stream of monodrones leaving the Great Modron Cathedral on Mechanus as a result."
+												"If a modron is destroyed, its remains disintegrate. A replacement from the next lowest rank then transforms in a flash of light, gaining the physical form of its new rank. The promoted modron is replaced by one of its underlings in the same manner, all the way to the lowest levels of the hierarchy. There, a new modron is created by Primus, with a steady stream of monodrones leaving the Great Modron Cathedral on Mechanus as a result."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "The Great Modron March",
 											"entries": [
-												" When the gears of Mechanus complete seventeen cycles once every 289 years, Primus sends a vast army of modrons across the Outer Planes, ostensibly on a reconnaissance mission. The march is long and dangerous, and only a small number of modrons returns to Mechanus."
+												"When the gears of Mechanus complete seventeen cycles once every 289 years, Primus sends a vast army of modrons across the Outer Planes, ostensibly on a reconnaissance mission. The march is long and dangerous, and only a small number of modrons returns to Mechanus."
 											],
 											"type": "entries"
 										}
@@ -12235,7 +12191,7 @@
 										{
 											"name": "Absolute Law and Order",
 											"entries": [
-												" Under the direction of their leader, Primus, modrons increase order in the multiverse in accordance with laws beyond the comprehension of mortal minds. Their own minds are networked in a hierarchal pyramid, in which each modron receives commands from superiors and delegates orders to underlings. A modron carries out commands with total obedience, utmost efficiency, and an absence of morality or ego. Modrons have no sense of self beyond what is necessary to fulfill their duties. They exist as a unified collective, divided by ranks, yet they always refer to themselves collectively. To a modron, there is no \"I,\" but only \"we\" or \"us.\"",
+												"Under the direction of their leader, Primus, modrons increase order in the multiverse in accordance with laws beyond the comprehension of mortal minds. Their own minds are networked in a hierarchal pyramid, in which each modron receives commands from superiors and delegates orders to underlings. A modron carries out commands with total obedience, utmost efficiency, and an absence of morality or ego. Modrons have no sense of self beyond what is necessary to fulfill their duties. They exist as a unified collective, divided by ranks, yet they always refer to themselves collectively. To a modron, there is no \"I,\" but only \"we\" or \"us.\"",
 												{
 													"type": "inset",
 													"name": "Variant: Rogue Modrons",
@@ -12250,21 +12206,21 @@
 										{
 											"name": "Absolute Hierarchy",
 											"entries": [
-												" Modrons communicate only with their own rank and the ranks immediately above and below them. Modrons more than one rank away are either too advanced or too simple to understand."
+												"Modrons communicate only with their own rank and the ranks immediately above and below them. Modrons more than one rank away are either too advanced or too simple to understand."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Cogs of the Great Machine",
 											"entries": [
-												" If a modron is destroyed, its remains disintegrate. A replacement from the next lowest rank then transforms in a flash of light, gaining the physical form of its new rank. The promoted modron is replaced by one of its underlings in the same manner, all the way to the lowest levels of the hierarchy. There, a new modron is created by Primus, with a steady stream of monodrones leaving the Great Modron Cathedral on Mechanus as a result."
+												"If a modron is destroyed, its remains disintegrate. A replacement from the next lowest rank then transforms in a flash of light, gaining the physical form of its new rank. The promoted modron is replaced by one of its underlings in the same manner, all the way to the lowest levels of the hierarchy. There, a new modron is created by Primus, with a steady stream of monodrones leaving the Great Modron Cathedral on Mechanus as a result."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "The Great Modron March",
 											"entries": [
-												" When the gears of Mechanus complete seventeen cycles once every 289 years, Primus sends a vast army of modrons across the Outer Planes, ostensibly on a reconnaissance mission. The march is long and dangerous, and only a small number of modrons returns to Mechanus."
+												"When the gears of Mechanus complete seventeen cycles once every 289 years, Primus sends a vast army of modrons across the Outer Planes, ostensibly on a reconnaissance mission. The march is long and dangerous, and only a small number of modrons returns to Mechanus."
 											],
 											"type": "entries"
 										}
@@ -12512,7 +12468,7 @@
 								{
 									"name": "Evil Spirits in Mortal Flesh",
 									"entries": [
-										" Rakshasas originated long ago in the Nine Hells, when powerful devils created a dark ritual to free their essence from their fiendish bodies in order to escape the Lower Planes. A rakshasa enters the Material Plane to feed its appetite for humanoid flesh and evil schemes. It selects its prey with care, taking pains to keep its presence in the world a secret."
+										"Rakshasas originated long ago in the Nine Hells, when powerful devils created a dark ritual to free their essence from their fiendish bodies in order to escape the Lower Planes. A rakshasa enters the Material Plane to feed its appetite for humanoid flesh and evil schemes. It selects its prey with care, taking pains to keep its presence in the world a secret."
 									],
 									"type": "entries"
 								},
@@ -12905,7 +12861,7 @@
 										{
 											"name": "Constructed Nature",
 											"entries": [
-												" An animated object doesn't require air, food, drink, or sleep. The magic that animates an object is dispelled when the construct drops to 0 hit points. An animated object reduced to 0 hit points becomes inanimate and is too damaged to be of much use or value to anyone."
+												"An animated object doesn't require air, food, drink, or sleep. The magic that animates an object is dispelled when the construct drops to 0 hit points. An animated object reduced to 0 hit points becomes inanimate and is too damaged to be of much use or value to anyone."
 											],
 											"type": "entries"
 										}
@@ -13153,7 +13109,7 @@
 								{
 									"name": "Spirit-Powered Constructs",
 									"entries": [
-										" A scarecrow is animated by the bound spirit of a slain evil creature, granting it purpose and mobility. It is this uncanny presence from beyond death that allows a scarecrow to inspire fear in those it gazes upon. Hags and witches often bind scarecrows with the spirits of demons, but any evil spirit will do. Although aspects of the spirit's personality might surface, a scarecrow's spirit doesn't recall the memories it had as a creature, and its will is focused solely on serving its creator. If its creator dies, the spirit inhabiting a scarecrow either continues to follow its last commands, seeks revenge for its creator's death, or destroys itself."
+										"A scarecrow is animated by the bound spirit of a slain evil creature, granting it purpose and mobility. It is this uncanny presence from beyond death that allows a scarecrow to inspire fear in those it gazes upon. Hags and witches often bind scarecrows with the spirits of demons, but any evil spirit will do. Although aspects of the spirit's personality might surface, a scarecrow's spirit doesn't recall the memories it had as a creature, and its will is focused solely on serving its creator. If its creator dies, the spirit inhabiting a scarecrow either continues to follow its last commands, seeks revenge for its creator's death, or destroys itself."
 									],
 									"type": "entries"
 								}
@@ -13453,7 +13409,7 @@
 								{
 									"name": "All-Consuming Devourers",
 									"entries": [
-										" A shambling mound feeds on any organic material, tirelessly consuming plants as it moves and devouring animals that can't escape it. Only the shambling mounds' rarity and plodding speed prevent them from overwhelming entire ecosystems. Even so, their presence leeches natural environments of plant and animal life, and an unsettling quiet pervades the swamps and woods haunted by these ever-hungry horrors."
+										"A shambling mound feeds on any organic material, tirelessly consuming plants as it moves and devouring animals that can't escape it. Only the shambling mounds' rarity and plodding speed prevent them from overwhelming entire ecosystems. Even so, their presence leeches natural environments of plant and animal life, and an unsettling quiet pervades the swamps and woods haunted by these ever-hungry horrors."
 									],
 									"type": "entries"
 								},
@@ -13465,7 +13421,7 @@
 										{
 											"name": "Spawned by Lightning",
 											"entries": [
-												" A shambling mound results from a phenomenon in which lightning or fey magic invigorates an otherwise ordinary swamp plant. As the plant is reborn into its second life, it chokes the life from plants and animals around it, mulching their corpses in a heap around its roots. Those roots eventually give up their reliance on the soil, directing the shambling mound to seek out new sources of food."
+												"A shambling mound results from a phenomenon in which lightning or fey magic invigorates an otherwise ordinary swamp plant. As the plant is reborn into its second life, it chokes the life from plants and animals around it, mulching their corpses in a heap around its roots. Those roots eventually give up their reliance on the soil, directing the shambling mound to seek out new sources of food."
 											],
 											"type": "entries"
 										}
@@ -13481,7 +13437,7 @@
 										{
 											"name": "A Resurgent Menace",
 											"entries": [
-												" If a shambling mound faces defeat before an overwhelming foe, the root-stem can feign death, collapsing the remains of its mound. If not subsequently killed, the root-stem beds down in the shambler's remains to slowly regrow its full body, then once again sets out to consume all it can. In this way, shambling mound infestations long thought destroyed can recur time and again."
+												"If a shambling mound faces defeat before an overwhelming foe, the root-stem can feign death, collapsing the remains of its mound. If not subsequently killed, the root-stem beds down in the shambler's remains to slowly regrow its full body, then once again sets out to consume all it can. In this way, shambling mound infestations long thought destroyed can recur time and again."
 											],
 											"type": "entries"
 										}
@@ -13619,7 +13575,7 @@
 												{
 													"name": "Respect for Humanity",
 													"entries": [
-														" Silver dragons befriend humanoids of all races, but shorter-lived races such as humans spark their curiosity in a way the longer-lived elves and dwarves don't. Humans have a drive and zest for life that silver dragons find fascinating."
+														"Silver dragons befriend humanoids of all races, but shorter-lived races such as humans spark their curiosity in a way the longer-lived elves and dwarves don't. Humans have a drive and zest for life that silver dragons find fascinating."
 													],
 													"type": "entries"
 												}
@@ -13753,44 +13709,55 @@
 					"entries": [
 						"In the Ever-Changing Chaos of Limbo, bits of forest and meadow, ruined castles, and isolated islands drift through a tumult of fire, water, earth, and wind. The foremost inhabitants of this inhospitable plane are the toad-like slaadi. Slaadi are undisciplined and have no formal hierarchy, although weaker slaadi obey stronger ones under threat of annihilation.",
 						{
+							"type": "entries",
 							"name": "The Spawning Stone",
 							"entries": [
-								" Long ago, Primus, overlord of the modrons, created a gigantic, geometrically complex stone imbued with the power of law. He then cast it adrift in Limbo, believing that the stone would bring order to the chaos of that plane and halt the spread of chaos to other planes. As the stone's power grew, it became possible for creatures with ordered minds, such as modrons and githzerai, to create enclaves in Limbo. However, Primus's creation had an unforeseen side effect: the chaotic energy absorbed by the stone spawned the horrors that came to be known as slaadi. Sages refer to Primus's massive creation as the Spawning Stone for this reason.",
-								"The slaadi wiped out every last modron enclave in Limbo. As creatures of utter chaos, slaadi loathe modrons and attack them on sight. Nonetheless, Primus stands by his creation and either doesn't perceive the slaadi as threats or chooses to ignore them.",
-								{
-									"type": "inset",
-									"name": "Variant: Slaad Control Gems",
-									"entries": [
-										"As a slaad emerges from the Spawning Stone, the stone magically implants a fragment of itself in the slaad's brain. This fragment takes the form of a magic gem roughly the size and shape of a human child's fist. The gem is the same color as the slaad. Another creature can use magic to draw forth a slaad's gem and use it to subjugate the slaad. The slaad must obey whoever possesses its gem. If a slaad's gem is destroyed, the slaad can no longer be controlled in this way.",
-										"A slaad born from something other than the Spawning Stone has no gem in its brain, but it gains one if it ever comes into contact with the Spawning Stone. Slaadi on Limbo are attracted to the Spawning Stone, so most end up with a gem. A slaad with a control gem in its brain has the following additional trait.",
-										{
-											"type": "entries",
-											"name": "Control Gem",
-											"entries": [
-												"Implanted in the slaad's brain is a magic control gem. The slaad must obey whoever possesses the gem and is immune to being {@condition charmed} while so controlled.",
-												"Certain spells can be used to acquire the gem. If the slaad fails its saving throw against imprisonment, the spell can transfer the gem to the spellcaster's open hand, instead of imprisoning the slaad. A {@spell wish} spell, if cast in the slaad's presence, can be worded to acquire the gem.",
-												"A {@spell greater restoration} spell cast on the slaad destroys the gem without harming the slaad.",
-												"Someone who is proficient in Wisdom ({@skill Medicine}) can remove the gem from an {@condition incapacitated} slaad. Each try requires 1 minute of uninterrupted work and a successful DC 20 Wisdom ({@skill Medicine}) check. Each failed attempt deals 22 ({@damage 4d10}) psychic damage to the slaad."
-											]
-										}
-									]
-								}
-							],
-							"type": "entries"
+								"Long ago, Primus, overlord of the modrons, created a gigantic, geometrically complex stone imbued with the power of law. He then cast it adrift in Limbo, believing that the stone would bring order to the chaos of that plane and halt the spread of chaos to other planes. As the stone's power grew, it became possible for creatures with ordered minds, such as modrons and githzerai, to create enclaves in Limbo. However, Primus's creation had an unforeseen side effect: the chaotic energy absorbed by the stone spawned the horrors that came to be known as slaadi. Sages refer to Primus's massive creation as the Spawning Stone for this reason.",
+								"The slaadi wiped out every last modron enclave in Limbo. As creatures of utter chaos, slaadi loathe modrons and attack them on sight. Nonetheless, Primus stands by his creation and either doesn't perceive the slaadi as threats or chooses to ignore them."
+							]
 						},
 						{
 							"name": "Birth and Transformation",
 							"entries": [
-								" Slaadi have horrific cycles of reproduction. Slaadi reproduce either by implanting humanoid hosts with eggs or by infecting them with a transformative disease called chaos phage. Each color of slaad reproduces or transforms in a different way, with red slaadi spawning blue and green slaadi, and blue slaadi spawning red and green. Each green slaad undergoes a lifelong cycle of transformation into the more powerful gray and death slaadi. With each transformation, the slaad retains its memories."
+								"Slaadi have horrific cycles of reproduction. Slaadi reproduce either by implanting humanoid hosts with eggs or by infecting them with a transformative disease called chaos phage. Each color of slaad reproduces or transforms in a different way, with red slaadi spawning blue and green slaadi, and blue slaadi spawning red and green. Each green slaad undergoes a lifelong cycle of transformation into the more powerful gray and death slaadi. With each transformation, the slaad retains its memories."
 							],
 							"type": "entries"
 						},
 						{
 							"name": "Shapechangers",
 							"entries": [
-								" Some slaadi can transform into the humanoid creatures from which they were originally spawned. These slaadi return to the Material Plane to sow discord in the guise of their former selves."
+								"Some slaadi can transform into the humanoid creatures from which they were originally spawned. These slaadi return to the Material Plane to sow discord in the guise of their former selves."
 							],
 							"type": "entries"
+						},
+						{
+							"type": "inset",
+							"name": "Variant: Slaad Control Gems",
+							"entries": [
+								"As a slaad emerges from the Spawning Stone, the stone magically implants a fragment of itself in the slaad's brain. This fragment takes the form of a magic gem roughly the size and shape of a human child's fist. The gem is the same color as the slaad. Another creature can use magic to draw forth a slaad's gem and use it to subjugate the slaad. The slaad must obey whoever possesses its gem. If a slaad's gem is destroyed, the slaad can no longer be controlled in this way.",
+								"A slaad born from something other than the Spawning Stone has no gem in its brain, but it gains one if it ever comes into contact with the Spawning Stone. Slaadi on Limbo are attracted to the Spawning Stone, so most end up with a gem. A slaad with a control gem in its brain has the following additional trait.",
+								{
+									"type": "entries",
+									"name": "Control Gem",
+									"entries": [
+										"Implanted in the slaad's brain is a magic control gem. The slaad must obey whoever possesses the gem and is immune to being {@condition charmed} while so controlled.",
+										"Certain spells can be used to acquire the gem. If the slaad fails its saving throw against imprisonment, the spell can transfer the gem to the spellcaster's open hand, instead of imprisoning the slaad. A {@spell wish} spell, if cast in the slaad's presence, can be worded to acquire the gem.",
+										"A {@spell greater restoration} spell cast on the slaad destroys the gem without harming the slaad.",
+										"Someone who is proficient in Wisdom ({@skill Medicine}) can remove the gem from an {@condition incapacitated} slaad. Each try requires 1 minute of uninterrupted work and a successful DC 20 Wisdom ({@skill Medicine}) check. Each failed attempt deals 22 ({@damage 4d10}) psychic damage to the slaad."
+									]
+								}
+							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"Embedded in a slaad's brain is a magic gem. Acquire it, and the slaad is yours to command."
+									]
+								}
+							]
 						}
 					]
 				}
@@ -13963,7 +13930,7 @@
 										{
 											"name": "Dwellers in Darkness",
 											"entries": [
-												" Sunlight represents a source of life that no specter can ever hope to douse, and it pains them. When night falls, they leave their final resting places in search of living creatures to slay, knowing that few weapons can harm them in return.",
+												"Sunlight represents a source of life that no specter can ever hope to douse, and it pains them. When night falls, they leave their final resting places in search of living creatures to slay, knowing that few weapons can harm them in return.",
 												"At the first light of dawn, they retreat back into the darkness, where they remain until night falls again."
 											],
 											"type": "entries"
@@ -14061,21 +14028,21 @@
 										{
 											"name": "Benevolent Dictators and Brutal Tyrants",
 											"entries": [
-												" A naga rules its domain with absolute authority. Whether it rules with compassion or by terrorizing its subjects, the naga believes itself the master of all other creatures that inhabit its domain."
+												"A naga rules its domain with absolute authority. Whether it rules with compassion or by terrorizing its subjects, the naga believes itself the master of all other creatures that inhabit its domain."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Rivalry",
 											"entries": [
-												" Nagas have a long-standing enmity with the yuan-ti, with each race seeing itself as the epitome of serpentine evolution. Though cooperation between them is rare, nagas and yuan-ti sometimes set aside their differences to work toward common objectives. However, yuan-ti always chafe under a naga's authority."
+												"Nagas have a long-standing enmity with the yuan-ti, with each race seeing itself as the epitome of serpentine evolution. Though cooperation between them is rare, nagas and yuan-ti sometimes set aside their differences to work toward common objectives. However, yuan-ti always chafe under a naga's authority."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Immortal Nature",
 											"entries": [
-												" A naga doesn't require air, food, drink, or sleep."
+												"A naga doesn't require air, food, drink, or sleep."
 											],
 											"type": "entries"
 										}
@@ -14129,12 +14096,24 @@
 										{
 											"name": "Good-Hearted",
 											"entries": [
-												" Because they are judges of the heart and favor good creatures, sprites oppose the will of evil fey and pledge to thwart evil archfey at every turn. If they encounter adventurers on a quest to rid their forest of an evil fey creature or goblinoid menace, they will pledge their support and even come to their aid when the adventurers least expect it.",
+												"Because they are judges of the heart and favor good creatures, sprites oppose the will of evil fey and pledge to thwart evil archfey at every turn. If they encounter adventurers on a quest to rid their forest of an evil fey creature or goblinoid menace, they will pledge their support and even come to their aid when the adventurers least expect it.",
 												"Unlike pixies, sprites rarely indulge in frivolous merriment and fun. They are firm warriors, protectors, and judges, and their stern bent causes other fey to consider them overly dour and serious. However, fey that respect the sprites' territory find them staunch allies in times of trouble."
 											],
 											"type": "entries"
 										}
 									]
+								}
+							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"The tree had a wee village nestled in its boughs, I swear. Next thing I knew, I was lyin' face-down in the dirt. My head was full of stars. An' when I stood up an' looked around, both the tree an' the wee village were gone."
+									],
+									"by": "Tale of a half-orc ranger"
 								}
 							]
 						}
@@ -14305,59 +14284,19 @@
 		{
 			"name": "Stone Golem",
 			"source": "MM",
-			"entries": [
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								"Stone golems display great variety in shape and form, cut and chiseled from stone to appear as tall, impressive statues. Though most bear humanoid features, stone golems can be carved in any form the sculptor can imagine. Ancient stone golems found in sealed tombs or flanking the gates of lost cities sometimes take the forms of giant beasts.",
-								"Like other golems, stone golems are nearly impervious to spells and ordinary weapons. Creatures that fight a stone golem can feel the ebb and flow of time slow down around them, almost as though they were made of stone themselves.",
-								{
-									"type": "entries",
-									"name": "Golems",
-									"entries": [
-										"Golems are made from humble materials-clay, flesh and bones, iron, or stone-but they possess astonishing power and durability. A golem has no ambitions, needs no sustenance, feels no pain, and knows no remorse. An unstoppable juggernaut, it exists to follow its creator's orders, and it protects or attacks as that creator demands.",
-										"To create a golem, one requires a manual of golems (see the Dungeon Master's Guide). The comprehensive illustrations and instructions in a manual detail the process for creating a golem of a particular type.",
-										{
-											"name": "Elemental Spirit in Material Form",
-											"entries": [
-												" The construction of a golem begins with the building of its body, requiring great command of the craft of sculpting, stonecutting, ironworking, or surgery. Sometimes a golem's creator is the master of the art, but often the individual who desires a golem must enlist master artisans to do the work.",
-												"After constructing the body from clay, flesh, iron, or stone, the golem's creator infuses it with a spirit from the Elemental Plane of Earth. This tiny spark of life has no memory, personality, or history. It is simply the impetus to move and obey. This process binds the spirit to the artificial body and subjects it to the will of the golem's creator.",
-												"A golem can be created with a special amulet or other item that allows the possessor of the item to control the golem. Golems whose creators are long dead can thus be harnessed to serve a new master.",
-												"A golem can't think or act for itself. Though it understands its commands perfectly, it has no grasp of language beyond that understanding, and can't be reasoned with or tricked with words."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Ageless Guardians",
-											"entries": [
-												" Golems can guard sacred sites, tombs, and treasure vaults long after the deaths of their creators, carrying out their appointed tasks for all eternity while brushing off physical damage and ignoring all but the most potent spells."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Blind Obedience",
-											"entries": [
-												"When its creator or possessor is on hand to command it, a golem performs flawlessly. If the golem is left without instructions or is {@condition incapacitated}, it continues to follow its last orders to the best of its ability. When it can't fulfill its orders, a golem might react violently-or stand and do nothing. A golem that has been given conflicting orders sometimes alternates between them."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Constructed Nature",
-											"entries": [
-												" A golem doesn't require air, food, drink, or sleep."
-											],
-											"type": "entries"
-										}
-									]
-								}
-							]
-						}
-					]
+			"_copy": {
+				"name": "Golems",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": [
+							"Stone golems display great variety in shape and form, cut and chiseled from stone to appear as tall, impressive statues. Though most bear humanoid features, stone golems can be carved in any form the sculptor can imagine. Ancient stone golems found in sealed tombs or flanking the gates of lost cities sometimes take the forms of giant beasts.",
+							"Like other golems, stone golems are nearly impervious to spells and ordinary weapons. Creatures that fight a stone golem can feel the ebb and flow of time slow down around them, almost as though they were made of stone themselves."
+						]
+					}
 				}
-			],
+			},
 			"images": [
 				{
 					"type": "image",
@@ -14651,7 +14590,7 @@
 								{
 									"name": "Thri-Kreen Communication",
 									"entries": [
-										" Thri-kreen employ a language without words. To show emotion and reaction, a thri-kreen clacks its mandibles and waves its antennae, giving other thri-kreen a sense of what it is thinking and feeling. Other creatures find this manner of communication difficult to interpret and impossible to duplicate.",
+										"Thri-kreen employ a language without words. To show emotion and reaction, a thri-kreen clacks its mandibles and waves its antennae, giving other thri-kreen a sense of what it is thinking and feeling. Other creatures find this manner of communication difficult to interpret and impossible to duplicate.",
 										"When forced to interact with creatures of other intelligent species, thri-kreen employ alternative methods of communication, such as drawing pictures in sand or making pictures out of twigs or blades of grass."
 									],
 									"type": "entries"
@@ -14836,28 +14775,28 @@
 										{
 											"name": "Absolute Law and Order",
 											"entries": [
-												" Under the direction of their leader, Primus, modrons increase order in the multiverse in accordance with laws beyond the comprehension of mortal minds. Their own minds are networked in a hierarchal pyramid, in which each modron receives commands from superiors and delegates orders to underlings. A modron carries out commands with total obedience, utmost efficiency, and an absence of morality or ego. Modrons have no sense of self beyond what is necessary to fulfill their duties. They exist as a unified collective, divided by ranks, yet they always refer to themselves collectively. To a modron, there is no \"I,\" but only \"we\" or \"us.\""
+												"Under the direction of their leader, Primus, modrons increase order in the multiverse in accordance with laws beyond the comprehension of mortal minds. Their own minds are networked in a hierarchal pyramid, in which each modron receives commands from superiors and delegates orders to underlings. A modron carries out commands with total obedience, utmost efficiency, and an absence of morality or ego. Modrons have no sense of self beyond what is necessary to fulfill their duties. They exist as a unified collective, divided by ranks, yet they always refer to themselves collectively. To a modron, there is no \"I,\" but only \"we\" or \"us.\""
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Absolute Hierarchy",
 											"entries": [
-												" Modrons communicate only with their own rank and the ranks immediately above and below them. Modrons more than one rank away are either too advanced or too simple to understand."
+												"Modrons communicate only with their own rank and the ranks immediately above and below them. Modrons more than one rank away are either too advanced or too simple to understand."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Cogs of the Great Machine",
 											"entries": [
-												" If a modron is destroyed, its remains disintegrate. A replacement from the next lowest rank then transforms in a flash of light, gaining the physical form of its new rank. The promoted modron is replaced by one of its underlings in the same manner, all the way to the lowest levels of the hierarchy. There, a new modron is created by Primus, with a steady stream of monodrones leaving the Great Modron Cathedral on Mechanus as a result."
+												"If a modron is destroyed, its remains disintegrate. A replacement from the next lowest rank then transforms in a flash of light, gaining the physical form of its new rank. The promoted modron is replaced by one of its underlings in the same manner, all the way to the lowest levels of the hierarchy. There, a new modron is created by Primus, with a steady stream of monodrones leaving the Great Modron Cathedral on Mechanus as a result."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "The Great Modron March",
 											"entries": [
-												" When the gears of Mechanus complete seventeen cycles once every 289 years, Primus sends a vast army of modrons across the Outer Planes, ostensibly on a reconnaissance mission. The march is long and dangerous, and only a small number of modrons returns to Mechanus."
+												"When the gears of Mechanus complete seventeen cycles once every 289 years, Primus sends a vast army of modrons across the Outer Planes, ostensibly on a reconnaissance mission. The march is long and dangerous, and only a small number of modrons returns to Mechanus."
 											],
 											"type": "entries"
 										}
@@ -14904,6 +14843,18 @@
 									"entries": [
 										"Some troglodytes venerate Laogzed, a demonic, monstrously fat toad-lizard that slumbers in the Abyss. Laogzed offers the troglodytes nothing in return except aspiration, for it is the dream of his troglodyte worshipers to become as fat, well-fed, and wearily content as he seems to be."
 									]
+								}
+							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"Smells liek an orc's loincloth in here!"
+									],
+									"by": "Last words of Arlack Hammermantle, dwarf spelunker"
 								}
 							]
 						}
@@ -14987,7 +14938,7 @@
 										{
 											"name": "Controlled by Evil",
 											"entries": [
-												" Blights are independent creatures, but most act under a Gulthias tree's control, often displaying the habits and traits of the life force or spirit that spawned them. By attacking their progenitor's old foes or seeking out treasures valuable to it, they carry on the legacy of long-lost evil."
+												"Blights are independent creatures, but most act under a Gulthias tree's control, often displaying the habits and traits of the life force or spirit that spawned them. By attacking their progenitor's old foes or seeking out treasures valuable to it, they carry on the legacy of long-lost evil."
 											],
 											"type": "entries"
 										}
@@ -15112,6 +15063,18 @@
 									"entries": [
 										"Many survivors of an umber hulk encounter recollect little about the attack, because the monster's confusing gaze scrambles their memory of the event. Those who have fought and killed umber hulks recognize the signs. For other denizens of the Underdark, grisly tales of vanished explorers and wanton destruction speak of an unknown foe. Umber hulks take on supernatural status in these harrowing stories, many of which convey the same warning: once an umber hulk has been spotted, it is already too late to escape it."
 									]
+								}
+							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"The wall caved in. That's the last thing I remember."
+									],
+									"by": "A survivor's account of an umber hulk attack"
 								}
 							]
 						}
@@ -15260,6 +15223,18 @@
 										"In a desperate attempt to win Tatyana's heart, Strahd forged a pact with dark powers that made him immortal. At the wedding of Sergei and Tatyana, he confronted his brother and killed him. Tatyana fled and flung herself from Ravenloft's walls. Strahd's guards, seeing him for a monster, shot him with arrows. But he did not die. He became a vampire-the first vampire, according to many sages.",
 										"In the centuries since his transformation, Strahd's lust for life and youth have only grown. He broods in his dark castle, cursing the living for stealing away what he lost, and never admitting his hand in the tragedy he created."
 									]
+								},
+								{
+									"type": "insetReadaloud",
+									"entries": [
+										{
+											"type": "quote",
+											"entries": [
+												"I am The Ancient, I am The Land. My beginnings are lost in the darkness of the past. I was the warrior, I was good and just. I thundered across the land like the wrath of a just god, but the war years and the killing years wore down my soul as the wind wears down stone into sand."
+											],
+											"by": "Count Strahd von Zarovich"
+										}
+									]
 								}
 							]
 						}
@@ -15353,7 +15328,7 @@
 										{
 											"name": "Controlled by Evil",
 											"entries": [
-												" Blights are independent creatures, but most act under a Gulthias tree's control, often displaying the habits and traits of the life force or spirit that spawned them. By attacking their progenitor's old foes or seeking out treasures valuable to it, they carry on the legacy of long-lost evil."
+												"Blights are independent creatures, but most act under a Gulthias tree's control, often displaying the habits and traits of the life force or spirit that spawned them. By attacking their progenitor's old foes or seeking out treasures valuable to it, they carry on the legacy of long-lost evil."
 											],
 											"type": "entries"
 										}
@@ -15521,6 +15496,18 @@
 									"entries": [
 										"A water weird doesn't require air, food, drink, or sleep."
 									]
+								}
+							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"Before you drink from a fountain or pool, toss a copper coin into it. It's a small price to pay for your life."
+									],
+									"by": "X the Mystic's 2nd rule of dungeon survival"
 								}
 							]
 						}
@@ -15864,7 +15851,7 @@
 										{
 											"name": "Consumed by Despair",
 											"entries": [
-												" Will-o'-wisps are the souls of evil beings that perished in anguish or misery as they wandered forsaken lands permeated with powerful magic. They thrive in swampy bogs and bone-strewn battlefields where the oppressive weight of sorrow stoops even heavier than the low-hanging mist and fog. Trapped in these desolate places of lost hope and memory, will-o'-wisps lure other creatures toward dismal fates and feed on their misery."
+												"Will-o'-wisps are the souls of evil beings that perished in anguish or misery as they wandered forsaken lands permeated with powerful magic. They thrive in swampy bogs and bone-strewn battlefields where the oppressive weight of sorrow stoops even heavier than the low-hanging mist and fog. Trapped in these desolate places of lost hope and memory, will-o'-wisps lure other creatures toward dismal fates and feed on their misery."
 											],
 											"type": "entries"
 										}
@@ -16097,6 +16084,18 @@
 									]
 								}
 							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"Keep a few gems in your pocket. A hungry xorn is a helpful xorn."
+									],
+									"by": "X the Mystic's 6th rule of dungeon survival"
+								}
+							]
 						}
 					]
 				}
@@ -16151,6 +16150,18 @@
 									"entries": [
 										"An abominable yeti is larger than a normal yeti, standing three times as tall as a human. It typically lives and hunts alone, though a pair of abominable yetis might live together long enough to raise young. These towering yetis are highly territorial and savage, attacking and devouring any warm-blooded creatures they encounter, then scattering the bones across the ice and snow."
 									]
+								}
+							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"On your guard! That's not the wind howling!"
+									],
+									"by": "Kelesta Hawke of the Emerald Enclave"
 								}
 							]
 						}
@@ -16308,25 +16319,24 @@
 			}
 		},
 		{
-			"name": "Yuan-ti Abomination",
+			"name": "Yuan-ti",
 			"source": "MM",
 			"entries": [
 				{
-					"type": "entries",
+					"type": "section",
+					"name": "Yuan-ti",
 					"entries": [
+						"Yuan-ti are devious serpent folk devoid of compassion. From remote temples in jungles, swamps, and deserts, the yuan-ti plot to supplant and dominate all other races and to make themselves gods.",
 						{
 							"type": "entries",
 							"entries": [
-								"Monstrous serpents with burly humanoid torsos and arms, abominations form the highest caste of yuan-ti society, and they most closely resemble the race as the serpent gods intended it. They mastermind elaborate schemes and perform dark rites in the hope of one day ruling the world.",
 								{
 									"type": "entries",
-									"name": "Yuan-ti",
 									"entries": [
-										"Yuan-ti are devious serpent folk devoid of compassion. From remote temples in jungles, swamps, and deserts, the yuan-ti plot to supplant and dominate all other races and to make themselves gods.",
 										{
 											"name": "Forsaken Humanity",
 											"entries": [
-												" The yuan-ti were once humans who thrived in the earliest days of civilization and worshiped serpents as totem animals. They lauded the serpent's sinuous flexibility, its calculated poise, and its deadly strike. Their advanced philosophy taught the virtue of detachment from emotion and of clear, focused thought.",
+												"The yuan-ti were once humans who thrived in the earliest days of civilization and worshiped serpents as totem animals. They lauded the serpent's sinuous flexibility, its calculated poise, and its deadly strike. Their advanced philosophy taught the virtue of detachment from emotion and of clear, focused thought.",
 												"Yuan-ti culture was among the richest in the mortal world. Their warriors were legendary, their empires always expanding. Yuan-ti temples stood at the centers of ancient metropolises, reaching ever higher in prayer to the gods they longed to emulate. In time, the serpent gods heard those prayers, their sibilant voices responding from the darkness as they told the yuan-ti what they must do. The yuan-ti religion grew more fanatical in its devotion. Cults bound themselves to the worship of the serpent gods and imitated their ways, indulging in cannibalism and humanoid sacrifice. Through foul sorcery, the yuan-ti bred with snakes, utterly sacrificing their humanity to become like the serpent gods in form, as well as in thought and emotion.",
 												"Yuan-ti know that the world they hope to rule can't be bound for long by brute force, and that many creatures will refuse to serve. As a result, yuan-ti first influence other creatures with the promise of wealth and power. Time and again, humanoid cultures make the fatal mistake of trusting the yuan-ti. They forget that a yuan-ti that acts honorably or lends aid in a time of trouble does so only as part of a grander design.",
 												"Yuan-ti leaders are cunning and ruthless tacticians who readily sacrifice lesser yuan-ti if potential victory justifies such losses. They have no sense of honorable combat and strike first in decisive ambush if they can."
@@ -16336,59 +16346,85 @@
 										{
 											"name": "Serpent Kings of Fallen Empires",
 											"entries": [
-												" The yuan-ti view their physical transformation as a transcendent moment for their race, allowing them to shed their frail humanity like dead skin. Those that did not transform eventually became slaves or food for the blessed of the serpent gods. The yuan-ti empires withered or were defeated by those who fought against their cannibalism and slavery, and the serpent folk were left in the ruins of their great capitals, far removed from other races."
+												"The yuan-ti view their physical transformation as a transcendent moment for their race, allowing them to shed their frail humanity like dead skin. Those that did not transform eventually became slaves or food for the blessed of the serpent gods. The yuan-ti empires withered or were defeated by those who fought against their cannibalism and slavery, and the serpent folk were left in the ruins of their great capitals, far removed from other races."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Cold of Heart",
 											"entries": [
-												" Humanoid emotions are foreign to most yuan-ti, which understand sentiment only as unexploitable weakness. A yuan-ti views the world and the events of its own life with such extreme pragmatism that it is nearly impossible to manipulate, influence, or control by nonmagical means, even as it seeks to control other creatures through terror, pleasure, and awe."
+												"Humanoid emotions are foreign to most yuan-ti, which understand sentiment only as unexploitable weakness. A yuan-ti views the world and the events of its own life with such extreme pragmatism that it is nearly impossible to manipulate, influence, or control by nonmagical means, even as it seeks to control other creatures through terror, pleasure, and awe."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "False Worship",
 											"entries": [
-												" Yuan-ti life revolves around their temples, yet yuan-ti don't love the gods they worship. Instead, they see worship as a means to attain power. A yuan-ti believes an individual who attains enough power can devour and replace one of the yuan-ti gods. The yuan-ti strive for ascension and are willing to commit the darkest atrocities to achieve it."
+												"Yuan-ti life revolves around their temples, yet yuan-ti don't love the gods they worship. Instead, they see worship as a means to attain power. A yuan-ti believes an individual who attains enough power can devour and replace one of the yuan-ti gods. The yuan-ti strive for ascension and are willing to commit the darkest atrocities to achieve it."
 											],
 											"type": "entries"
 										}
 									]
 								},
 								{
-									"type": "entries",
+									"type": "inset",
 									"name": "Serpent Gods",
 									"entries": [
 										"The yuan-ti revere a number of powerful entities as gods, including the following.",
 										{
 											"name": "Dendar, the Night Serpent",
 											"entries": [
-												" Dendar's followers say that one day she will grow so large from feasting on the fears and nightmares of the world that she will devour it whole. Yuan-ti that serve Dendar terrorize other creatures in any way they can, growing and nurturing the fears of humanoids to feed the Night Serpent."
+												"{@deity Dendar|yuan-ti|VGM|Dendar's} followers say that one day she will grow so large from feasting on the fears and nightmares of the world that she will devour it whole. Yuan-ti that serve Dendar terrorize other creatures in any way they can, growing and nurturing the fears of humanoids to feed the Night Serpent."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Merrshaulk, Master of the Pit",
 											"entries": [
-												" Merrshaulk is the long slumbering chief deity of the yuan-ti. As worship of Merrshaulk waned, he went into slumber. Merrshaulk's priests are yuan-ti abominations that maintain traditions of living sacrifice and cause suffering in the god's name. With enough vile acts, the abominations believe that Merrshaulk will reawaken and restore the yuan-ti to their rightful place."
+												"{@deity Merrshaulk|yuan-ti|VGM} is the long slumbering chief deity of the yuan-ti. As worship of Merrshaulk waned, he went into slumber. Merrshaulk's priests are yuan-ti abominations that maintain traditions of living sacrifice and cause suffering in the god's name. With enough vile acts, the abominations believe that Merrshaulk will reawaken and restore the yuan-ti to their rightful place."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Sseth, the Sibilant Death",
 											"entries": [
-												" Sseth appeared to the yuan-ti of antiquity in the form of a winged yuan-ti claiming to be an avatar of Merrshaulk. Speaking with Merrshaulk's voice, Sseth vowed to pull the yuan-ti out of decline and build a new empire. Many of Merrshaulk's devout turned to the worship of Sseth. Some yuan-ti have long suspected Sseth as an usurper taking advantage of Merrshaulk's slumber to make himself a god. They believe that Sseth might even have devoured Merrshaulk, and now answers the prayers of Merrshaulk's followers, as his priests convert or consume Merrshaulk's more stubborn adherents."
+												"{@deity Sseth|yuan-ti|VGM} appeared to the yuan-ti of antiquity in the form of a winged yuan-ti claiming to be an avatar of Merrshaulk. Speaking with Merrshaulk's voice, Sseth vowed to pull the yuan-ti out of decline and build a new empire. Many of Merrshaulk's devout turned to the worship of Sseth. Some yuan-ti have long suspected Sseth as an usurper taking advantage of Merrshaulk's slumber to make himself a god. They believe that Sseth might even have devoured Merrshaulk, and now answers the prayers of Merrshaulk's followers, as his priests convert or consume Merrshaulk's more stubborn adherents."
 											],
 											"type": "entries"
 										}
 									]
 								}
 							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"The yuan-ti cast off their humanity long ago, and with it, their sanity."
+									],
+									"by": "From {@style Masters of the Forbidden City|small-caps} by Codo Vidak"
+								}
+							]
 						}
 					]
 				}
-			],
+			]
+		},
+		{
+			"name": "Yuan-ti Abomination",
+			"source": "MM",
+			"_copy": {
+				"name": "Yuan-ti",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": "Monstrous serpents with burly humanoid torsos and arms, abominations form the highest caste of yuan-ti society, and they most closely resemble the race as the serpent gods intended it. They mastermind elaborate schemes and perform dark rites in the hope of one day ruling the world."
+					}
+				}
+			},
 			"images": [
 				{
 					"type": "image",
@@ -16402,85 +16438,16 @@
 		{
 			"name": "Yuan-ti Malison",
 			"source": "MM",
-			"entries": [
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								"A malison is a hideous blend of human and serpentine features. Three different types of malisons are known to exist, and other types are possible. Malisons form the middle caste of yuan-ti society and hunt with arrows tipped with their own venom. They use their magical powers of suggestion to force their enemies' surrender.",
-								{
-									"type": "entries",
-									"name": "Yuan-ti",
-									"entries": [
-										"Yuan-ti are devious serpent folk devoid of compassion. From remote temples in jungles, swamps, and deserts, the yuan-ti plot to supplant and dominate all other races and to make themselves gods.",
-										{
-											"name": "Forsaken Humanity",
-											"entries": [
-												" The yuan-ti were once humans who thrived in the earliest days of civilization and worshiped serpents as totem animals. They lauded the serpent's sinuous flexibility, its calculated poise, and its deadly strike. Their advanced philosophy taught the virtue of detachment from emotion and of clear, focused thought.",
-												"Yuan-ti culture was among the richest in the mortal world. Their warriors were legendary, their empires always expanding. Yuan-ti temples stood at the centers of ancient metropolises, reaching ever higher in prayer to the gods they longed to emulate. In time, the serpent gods heard those prayers, their sibilant voices responding from the darkness as they told the yuan-ti what they must do. The yuan-ti religion grew more fanatical in its devotion. Cults bound themselves to the worship of the serpent gods and imitated their ways, indulging in cannibalism and humanoid sacrifice. Through foul sorcery, the yuan-ti bred with snakes, utterly sacrificing their humanity to become like the serpent gods in form, as well as in thought and emotion.",
-												"Yuan-ti know that the world they hope to rule can't be bound for long by brute force, and that many creatures will refuse to serve. As a result, yuan-ti first influence other creatures with the promise of wealth and power. Time and again, humanoid cultures make the fatal mistake of trusting the yuan-ti. They forget that a yuan-ti that acts honorably or lends aid in a time of trouble does so only as part of a grander design.",
-												"Yuan-ti leaders are cunning and ruthless tacticians who readily sacrifice lesser yuan-ti if potential victory justifies such losses. They have no sense of honorable combat and strike first in decisive ambush if they can."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Serpent Kings of Fallen Empires",
-											"entries": [
-												" The yuan-ti view their physical transformation as a transcendent moment for their race, allowing them to shed their frail humanity like dead skin. Those that did not transform eventually became slaves or food for the blessed of the serpent gods. The yuan-ti empires withered or were defeated by those who fought against their cannibalism and slavery, and the serpent folk were left in the ruins of their great capitals, far removed from other races."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Cold of Heart",
-											"entries": [
-												" Humanoid emotions are foreign to most yuan-ti, which understand sentiment only as an exploitable weakness. A yuan-ti views the world and the events of its own life with such extreme pragmatism that it is nearly impossible to manipulate, influence, or control by nonmagical means, even as it seeks to control other creatures through terror, pleasure, and awe."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "False Worship",
-											"entries": [
-												" Yuan-ti life revolves around their temples, yet yuan-ti don't love the gods they worship. Instead, they see worship as a means to attain power. A yuan-ti believes an individual who attains enough power can devour and replace one of the yuan-ti gods. The yuan-ti strive for ascension and are willing to commit the darkest atrocities to achieve it."
-											],
-											"type": "entries"
-										}
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Serpent Gods",
-									"entries": [
-										"The yuan-ti revere a number of powerful entities as gods, including the following.",
-										{
-											"name": "Dendar, the Night Serpent",
-											"entries": [
-												" Dendar's followers say that one day she will grow so large from feasting on the fears and nightmares of the world that she will devour it whole. Yuan-ti that serve Dendar terrorize other creatures in any way they can, growing and nurturing the fears of humanoids to feed the Night Serpent."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Merrshaulk, Master of the Pit",
-											"entries": [
-												" Merrshaulk is the long slumbering chief deity of the yuan-ti. As worship of Merrshaulk waned, he went into slumber. Merrshaulk's priests are yuan-ti abominations that maintain traditions of living sacrifice and cause suffering in the god's name. With enough vile acts, the abominations believe that Merrshaulk will reawaken and restore the yuan-ti to their rightful place."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Sseth, the Sibilant Death",
-											"entries": [
-												" Sseth appeared to the yuan-ti of antiquity in the form of a winged yuan-ti claiming to be an avatar of Merrshaulk. Speaking with Merrshaulk's voice, Sseth vowed to pull the yuan-ti out of decline and build a new empire. Many of Merrshaulk's devout turned to the worship of Sseth. Some yuan-ti have long suspected Sseth as an usurper taking advantage of Merrshaulk's slumber to make himself a god. They believe that Sseth might even have devoured Merrshaulk, and now answers the prayers of Merrshaulk's followers, as his priests convert or consume Merrshaulk's more stubborn adherents."
-											],
-											"type": "entries"
-										}
-									]
-								}
-							]
-						}
-					]
+			"_copy": {
+				"name": "Yuan-ti",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": "A malison is a hideous blend of human and serpentine features. Three different types of malisons are known to exist, and other types are possible. Malisons form the middle caste of yuan-ti society and hunt with arrows tipped with their own venom. They use their magical powers of suggestion to force their enemies' surrender."
+					}
 				}
-			],
+			},
 			"images": [
 				{
 					"type": "image",
@@ -16518,85 +16485,16 @@
 		{
 			"name": "Yuan-ti Pureblood",
 			"source": "MM",
-			"entries": [
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								"Purebloods form the lowest caste of yuan-ti society. They closely resemble humans, yet a pureblood can't pass for human under close scrutiny because there's always some hint of its true nature, such as scaly patches of skin, serpentine eyes, pointed teeth, or a forked tongue. Wearing cloaks and cowls, they masquerade as humans and infiltrate civilized lands to gather information, kidnap prisoners for interrogation and sacrifice, and trade with anyone who has something that can further their myriad plots.",
-								{
-									"type": "entries",
-									"name": "Yuan-ti",
-									"entries": [
-										"Yuan-ti are devious serpent folk devoid of compassion. From remote temples in jungles, swamps, and deserts, the yuan-ti plot to supplant and dominate all other races and to make themselves gods.",
-										{
-											"name": "Forsaken Humanity",
-											"entries": [
-												" The yuan-ti were once humans who thrived in the earliest days of civilization and worshiped serpents as totem animals. They lauded the serpent's sinuous flexibility, its calculated poise, and its deadly strike. Their advanced philosophy taught the virtue of detachment from emotion and of clear, focused thought.",
-												"Yuan-ti culture was among the richest in the mortal world. Their warriors were legendary, their empires always expanding. Yuan-ti temples stood at the centers of ancient metropolises, reaching ever higher in prayer to the gods they longed to emulate. In time, the serpent gods heard those prayers, their sibilant voices responding from the darkness as they told the yuan-ti what they must do. The yuan-ti religion grew more fanatical in its devotion. Cults bound themselves to the worship of the serpent gods and imitated their ways, indulging in cannibalism and humanoid sacrifice. Through foul sorcery, the yuan-ti bred with snakes, utterly sacrificing their humanity to become like the serpent gods in form, as well as in thought and emotion.",
-												"Yuan-ti know that the world they hope to rule can't be bound for long by brute force, and that many creatures will refuse to serve. As a result, yuan-ti first influence other creatures with the promise of wealth and power. Time and again, humanoid cultures make the fatal mistake of trusting the yuan-ti. They forget that a yuan-ti that acts honorably or lends aid in a time of trouble does so only as part of a grander design.",
-												"Yuan-ti leaders are cunning and ruthless tacticians who readily sacrifice lesser yuan-ti if potential victory justifies such losses. They have no sense of honorable combat and strike first in decisive ambush if they can."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Serpent Kings of Fallen Empires",
-											"entries": [
-												" The yuan-ti view their physical transformation as a transcendent moment for their race, allowing them to shed their frail humanity like dead skin. Those that did not transform eventually became slaves or food for the blessed of the serpent gods. The yuan-ti empires withered or were defeated by those who fought against their cannibalism and slavery, and the serpent folk were left in the ruins of their great capitals, far removed from other races."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Cold of Heart",
-											"entries": [
-												" Humanoid emotions are foreign to most yuan-ti, which understand sentiment only as an exploitable weakness. A yuan-ti views the world and the events of its own life with such extreme pragmatism that it is nearly impossible to manipulate, influence, or control by nonmagical means, even as it seeks to control other creatures through terror, pleasure, and awe."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "False Worship",
-											"entries": [
-												" Yuan-ti life revolves around their temples, yet yuan-ti don't love the gods they worship. Instead, they see worship as a means to attain power. A yuan-ti believes an individual who attains enough power can devour and replace one of the yuan-ti gods. The yuan-ti strive for ascension and are willing to commit the darkest atrocities to achieve it."
-											],
-											"type": "entries"
-										}
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Serpent Gods",
-									"entries": [
-										"The yuan-ti revere a number of powerful entities as gods, including the following.",
-										{
-											"name": "Dendar, the Night Serpent",
-											"entries": [
-												" Dendar's followers say that one day she will grow so large from feasting on the fears and nightmares of the world that she will devour it whole. Yuan-ti that serve Dendar terrorize other creatures in any way they can, growing and nurturing the fears of humanoids to feed the Night Serpent."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Merrshaulk, Master of the Pit",
-											"entries": [
-												" Merrshaulk is the long slumbering chief deity of the yuan-ti. As worship of Merrshaulk waned, he went into slumber. Merrshaulk's priests are yuan-ti abominations that maintain traditions of living sacrifice and cause suffering in the god's name. With enough vile acts, the abominations believe that Merrshaulk will reawaken and restore the yuan-ti to their rightful place."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Sseth, the Sibilant Death",
-											"entries": [
-												" Sseth appeared to the yuan-ti of antiquity in the form of a winged yuan-ti claiming to be an avatar of Merrshaulk. Speaking with Merrshaulk's voice, Sseth vowed to pull the yuan-ti out of decline and build a new empire. Many of Merrshaulk's devout turned to the worship of Sseth. Some yuan-ti have long suspected Sseth as an usurper taking advantage of Merrshaulk's slumber to make himself a god. They believe that Sseth might even have devoured Merrshaulk, and now answers the prayers of Merrshaulk's followers, as his priests convert or consume Merrshaulk's more stubborn adherents."
-											],
-											"type": "entries"
-										}
-									]
-								}
-							]
-						}
-					]
+			"_copy": {
+				"name": "Yuan-ti",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": "Purebloods form the lowest caste of yuan-ti society. They closely resemble humans, yet a pureblood can't pass for human under close scrutiny because there's always some hint of its true nature, such as scaly patches of skin, serpentine eyes, pointed teeth, or a forked tongue. Wearing cloaks and cowls, they masquerade as humans and infiltrate civilized lands to gather information, kidnap prisoners for interrogation and sacrifice, and trade with anyone who has something that can further their myriad plots."
+					}
 				}
-			],
+			},
 			"images": [
 				{
 					"type": "image",
@@ -16611,51 +16509,94 @@
 			"name": "Yugoloths",
 			"source": "MM",
 			"entries": [
-				"Yugoloths are fickle fiends that inhabit the planes of Acheron, Gehenna, Hades, and Carceri. They act as mercenaries and are notorious for their shifting loyalties. They are the embodiments of avarice. Before serving under anyone's banner, a yugoloth asks the only question on its mind: What's in it for me?",
 				{
-					"type": "entries",
+					"type": "section",
+					"name": "Yugoloths",
 					"entries": [
+						"Yugoloths are fickle fiends that inhabit the planes of Acheron, Gehenna, Hades, and Carceri. They act as mercenaries and are notorious for their shifting loyalties. They are the embodiments of avarice. Before serving under anyone's banner, a yugoloth asks the only question on its mind: {@i What's in it for me?}",
 						{
 							"type": "entries",
 							"entries": [
 								{
 									"type": "entries",
-									"name": "Spawn of Gehenna",
 									"entries": [
-										"The first yugoloths were created by a sisterhood of night hags on Gehenna. It is widely believed that Asmodeus, Lord of the Nine Hells, commissioned the work, in the hope of creating an army of fiends that were not bound to the Nine Hells. In the course of making this new army, the hags crafted four magic tomes and recorded the true names of every yugoloth they created, save one, the General of Gehenna. These tomes were called the Books of Keeping. Since knowing a fiend's true name grants power over it, the hags used the books to ensure the yugoloths' loyalty. They also used the books to capture the true names of other fiends that crossed them. It is rumored that the Books of Keeping contain the true names of a few demon lords and archdevils as well.",
-										"Petty jealousies and endless bickering caused the sisterhood to dissolve, and in the ensuing power grab, the Books of Keeping were lost or stolen. No longer indentured to anyone, the yugoloths gained independence, and they now offer their services to the highest bidder."
+										{
+											"type": "entries",
+											"name": "Spawn of Gehenna",
+											"entries": [
+												"The first yugoloths were created by a sisterhood of night hags on Gehenna. It is widely believed that Asmodeus, Lord of the Nine Hells, commissioned the work, in the hope of creating an army of fiends that were not bound to the Nine Hells. In the course of making this new army, the hags crafted four magic tomes and recorded the true names of every yugoloth they created, save one, the General of Gehenna. These tomes were called the Books of Keeping. Since knowing a fiend's true name grants power over it, the hags used the books to ensure the yugoloths' loyalty. They also used the books to capture the true names of other fiends that crossed them. It is rumored that the Books of Keeping contain the true names of a few demon lords and archdevils as well.",
+												"Petty jealousies and endless bickering caused the sisterhood to dissolve, and in the ensuing power grab, the Books of Keeping were lost or stolen. No longer indentured to anyone, the yugoloths gained independence, and they now offer their services to the highest bidder."
+											]
+										},
+										{
+											"type": "entries",
+											"name": "Fiendish Mercenaries",
+											"entries": [
+												"Summoned yugoloths demand much for their time and loyalty. Whatever promises a yugoloth makes are quickly broken when a better opportunity presents itself. Unlike demons, yugoloths can be reasoned with, but unlike devils, they are rarely true to their word.",
+												"Yugoloths can be found anywhere, but the high cost of maintaining a yugoloth army's loyalty typically exceeds what any warlord on the Material Plane can pay. Being self-serving creatures, yugoloths quarrel among themselves constantly. A yugoloth army is more organized than a ravening horde of demons, but far less orderly and regimented than a legion of devils. Without a powerful leader to keep them in line, yugoloths fight simply to indulge their violent predilections, and only as long as it benefits them to do so."
+											]
+										},
+										{
+											"type": "entries",
+											"name": "Back to Gehenna",
+											"entries": [
+												"When a yugoloth dies, it dissolves into a pool of ichor and reforms at full strength on the Bleak Eternity of Gehenna. Only on its native plane can a yugoloth be destroyed permanently. A yugoloth knows this and acts accordingly. When summoned to other planes, a yugoloth fights without concern for its own well-being. On Gehenna, it is more apt to retreat or plead for mercy if its demise seems imminent.",
+												"When a yugoloth is permanently destroyed, its name vanishes from every Book of Keeping. If a yugoloth is re-created by way of an unholy ritual requiring the expenditure of souls, its name reappears in the books."
+											]
+										},
+										{
+											"type": "entries",
+											"name": "The Books of Keeping",
+											"entries": [
+												"When all four copies of the Books of Keeping disappeared, Asmodeus and the night hags lost control of their yugoloth creations. Each Book of Keeping still exists, drifting from plane to plane, where the brave and the foolish occasionally stumble upon them. A yugoloth summoned using its true name, as inscribed in the Books of Keeping, is forced to serve its summoner obediently. The yugoloth hates being controlled in this manner and isn't shy about making its displeasure known. Like a petulant child, it will follow its instructions to the letter while looking for opportunities to misinterpret them."
+											]
+										},
+										{
+											"type": "entries",
+											"name": "The General of Gehenna",
+											"entries": [
+												"Somewhere in the brimstone wastes of Gehenna, there roams an ultroloth so strong that none contests his power: the General of Gehenna. Many yugoloths search for this great general in the hope of serving with him. They believe that service with the General of Gehenna grants power and prestige among lower planar entities.",
+												"Whatever the case, no fiend finds the General unless the General desires it. His personal name is unknown, and even the Books of Keeping contain no mention of this powerful, thoroughly evil entity."
+											]
+										}
 									]
-								},
+								}
+							]
+						},
+						{
+							"type": "inset",
+							"name": "Variant: Yugoloth Summoning",
+							"entries": [
+								"Some yugoloths can have an action option that allows them to summon other yugoloths.",
 								{
 									"type": "entries",
-									"name": "Fiendish Mercenaries",
+									"name": "Summon Yugoloth (1/Day)",
 									"entries": [
-										"Summoned yugoloths demand much for their time and loyalty. Whatever promises a yugoloth makes are quickly broken when a better opportunity presents itself. Unlike demons, yugoloths can be reasoned with, but unlike devils, they are rarely true to their word.",
-										"Yugoloths can be found anywhere, but the high cost of maintaining a yugoloth army's loyalty typically exceeds what any warlord on the Material Plane can pay. Being self-serving creatures, yugoloths quarrel among themselves constantly. A yugoloth army is more organized than a ravening horde of demons, but far less orderly and regimented than a legion of devils. Without a powerful leader to keep them in line, yugoloths fight simply to indulge their violent predilections, and only as long as it benefits them to do so."
+										"The yugoloth chooses what to summon and attempts a magical summoning.",
+										{
+											"type": "list",
+											"items": [
+												"An arcanaloth has a {@chance 40} chance of summoning one arcanaloth.",
+												"A mezzoloth has a {@chance 30} chance of summoning one mezzoloth.",
+												"A nycaloth has a {@chance 50} chance of summoning {@dice 1d4} mezzoloths or one nycaloth.",
+												"An ultroloth has a {@chance 50} chance of summoning {@dice 1d6} mezzoloths, {@dice 1d4} nycaloths, or one ultroloth."
+											]
+										},
+										"A summoned yugoloth appears in an unoccupied space within 60 feet of its summoner, does as it pleases (unless its summoner is an ultroloth, in which case it acts as an ally of its summoner), and can't summon other yugoloths. The summoned yugoloth remains for l minute, until it or its summoner dies, or until its summoner takes a bonus action to dismiss it"
 									]
-								},
+								}
+							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
 								{
-									"type": "entries",
-									"name": "Back to Gehenna",
+									"type": "quote",
 									"entries": [
-										"When a yugoloth dies, it dissolves into a pool of ichor and reforms at full strength on the Bleak Eternity of Gehenna. Only on its native plane can a yugoloth be destroyed permanently. A yugoloth knows this and acts accordingly. When summoned to other planes, a yugoloth fights without concern for its own well-being. On Gehenna, it is more apt to retreat or plead for mercy if its demise seems imminent.",
-										"When a yugoloth is permanently destroyed, its name vanishes from every Book of Keeping. If a yugoloth is re-created by way of an unholy ritual requiring the expenditure of souls, its name reappears in the books."
-									]
-								},
-								{
-									"type": "entries",
-									"name": "The Books of Keeping",
-									"entries": [
-										"When all four copies of the Books of Keeping disappeared, Asmodeus and the night hags lost control of their yugoloth creations. Each Book of Keeping still exists, drifting from plane to plane, where the brave and the foolish occasionally stumble upon them. A yugoloth summoned using its true name, as inscribed in the Books of Keeping, is forced to serve its summoner obediently. The yugoloth hates being controlled in this manner and isn't shy about making its displeasure known. Like a petulant child, it will follow its instructions to the letter while looking for opportunities to misinterpret them."
-									]
-								},
-								{
-									"type": "entries",
-									"name": "The General of Gehenna",
-									"entries": [
-										"Somewhere in the brimstone wastes of Gehenna, there roams an ultroloth so strong that none contests his power: the General of Gehenna. Many yugoloths search for this great general in the hope of serving with him. They believe that service with the General of Gehenna grants power and prestige among lower planar entities.",
-										"Whatever the case, no fiend finds the General unless the General desires it. His personal name is unknown, and even the Books of Keeping contain no mention of this powerful, thoroughly evil entity."
-									]
+										"Power. We all crave it, but only a select few of us deserve it."
+									],
+									"by": "Shemeshka the Marauder",
+									"from": "arcanaloth in Sigil"
 								}
 							]
 						}
@@ -16704,6 +16645,19 @@
 									"entries": [
 										"A zombie doesn't require air, food, drink, or sleep."
 									]
+								}
+							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"After Beek died, we cast an {@spell animate dead} spell on his corpse. It was fun for a while, but the zombie started to smell real bad, so we doused it in oil and set it on fire. Beek would've found that hilarious."
+									],
+									"by": "Fonkin Hoodypeak",
+									"from": "on friendship"
 								}
 							]
 						}

--- a/data/bestiary/fluff-bestiary-mm.json
+++ b/data/bestiary/fluff-bestiary-mm.json
@@ -566,7 +566,7 @@
 						]
 					}
 				}
-			],
+			},
 			"images": [
 				{
 					"type": "image",
@@ -1428,23 +1428,21 @@
 			]
 		},
 		{
-			"name": "Black Pudding",
+			"name": "Oozes",
 			"source": "MM",
 			"entries": [
 				{
-					"type": "entries",
+					"type": "section",
+					"name": "Oozes",
 					"entries": [
+						"Oozes thrive in the dark, shunning areas of bright light and extreme temperatures. They flow through the damp underground, feeding on any creature or object that can be dissolved, slinking along the ground, dripping from walls and ceilings, spreading across the edges of underground pools, and squeezing through cracks.",
+						"The first warning an adventurer receives of an ooze's presence is often the searing pain of its acidic touch. Oozes are drawn to movement and warmth. Organic material nourishes them, and when prey is scarce they feed on grime, fungus, and offal. Veteran explorers know that an immaculately clean passageway is a likely sign that an ooze lairs nearby.",
 						{
 							"type": "entries",
 							"entries": [
-								"A black pudding resembles a heaving mound of sticky black sludge. In dim passageways, the pudding appears to be little more than a blot of shadow.",
-								"Flesh, wood, metal, and bone dissolve when the pudding ebbs over them. Stone remains behind, wiped clean.",
 								{
 									"type": "entries",
-									"name": "Oozes",
 									"entries": [
-										"Oozes thrive in the dark, shunning areas of bright light and extreme temperatures. They flow through the damp underground, feeding on any creature or object that can be dissolved, slinking along the ground, dripping from walls and ceilings, spreading across the edges of underground pools, and squeezing through cracks.",
-										"The first warning an adventurer receives of an ooze's presence is often the searing pain of its acidic touch. Oozes are drawn to movement and warmth. Organic material nourishes them, and when prey is scarce they feed on grime, fungus, and offal. Veteran explorers know that an immaculately clean passageway is a likely sign that an ooze lairs nearby.",
 										{
 											"name": "Slow Death",
 											"entries": [
@@ -1481,7 +1479,24 @@
 						}
 					]
 				}
-			],
+			]
+		},
+		{
+			"name": "Black Pudding",
+			"source": "MM",
+			"_copy": {
+				"name": "Oozes",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": [
+							"A black pudding resembles a heaving mound of sticky black sludge. In dim passageways, the pudding appears to be little more than a blot of shadow.",
+							"Flesh, wood, metal, and bone dissolve when the pudding ebbs over them. Stone remains behind, wiped clean."
+						]
+					}
+				}
+			},
 			"images": [
 				{
 					"type": "image",
@@ -1701,49 +1716,16 @@
 		{
 			"name": "Bone Naga",
 			"source": "MM",
-			"entries": [
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								"In response to the long history of conflict between the yuan-ti and the nagas, yuan-ti created a necromantic ritual that could halt a naga's resurrection by transforming the living naga into a skeletal undead servitor. A bone naga retains only a few of the spells it knew in life.",
-								{
-									"type": "entries",
-									"name": "Nagas",
-									"entries": [
-										"Nagas are intelligent serpents that inhabit the ruins of the past, amassing arcane treasures and knowledge.",
-										"The first nagas were created as immortal guardians by a humanoid race long lost to history. When this race died out, the nagas deemed themselves the rightful inheritors of their masters' treasures and magical lore. Industrious and driven, nagas occasionally venture out from their lairs to track down magic items or rare spellbooks.",
-										"Nagas never feel the ravages of time or succumb to sickness. Even if it is struck down, a naga's immortal spirit reforms in a new body in a matter of days, ready to continue its eternal work.",
-										{
-											"name": "Benevolent Dictators and Brutal Tyrants",
-											"entries": [
-												"A naga rules its domain with absolute authority. Whether it rules with compassion or by terrorizing its subjects, the naga believes itself the master of all other creatures that inhabit its domain."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Rivalry",
-											"entries": [
-												"Nagas have a long-standing enmity with the yuan-ti, with each race seeing itself as the epitome of serpentine evolution. Though cooperation between them is rare, nagas and yuan-ti sometimes set aside their differences to work toward common objectives. However, yuan-ti always chafe under a naga's authority."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Immortal Nature",
-											"entries": [
-												"A naga doesn't require air, food, drink, or sleep."
-											],
-											"type": "entries"
-										}
-									]
-								}
-							]
-						}
-					]
+			"_copy": {
+				"name": "Nagas",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": "In response to the long history of conflict between the yuan-ti and the nagas, yuan-ti created a necromantic ritual that could halt a naga's resurrection by transforming the living naga into a skeletal undead servitor. A bone naga retains only a few of the spells it knew in life."
+					}
 				}
-			],
+			},
 			"images": [
 				{
 					"type": "image",
@@ -2497,7 +2479,19 @@
 						"mode": "prependArr",
 						"items": [
 							"Sculpted from clay, this bulky golem stands head and shoulders taller than most human-sized creatures. It is human shaped, but its proportions are off.",
-							"Clay golems are often divinely endowed with purpose by priests of great faith. However, clay is a weak vessel for life force. If the golem is damaged, the elemental spirit bound into it can break free. Such a golem runs amok, smashing everything around it until it is destroyed or completely repaired."
+							"Clay golems are often divinely endowed with purpose by priests of great faith. However, clay is a weak vessel for life force. If the golem is damaged, the elemental spirit bound into it can break free. Such a golem runs amok, smashing everything around it until it is destroyed or completely repaired.",
+							{
+								"type": "insetReadaloud",
+								"entries": [
+									{
+										"type": "quote",
+										"entries": [
+											"The more rigid its physical form, the less likely the golem is to lose its sense of purpose. The clay ones can be a bit twitchy."
+										],
+										"by": "Words of warning in the {@style Manual of Clay Golems|small-caps}"
+									}
+								]
+							}
 						]
 					}
 				}
@@ -2960,81 +2954,49 @@
 		{
 			"name": "Dao",
 			"source": "MM",
-			"entries": [
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								"Dao are greedy, malicious genies from the Elemental Plane of Earth. They adorn themselves with jewelry crafted from precious gems and rare metals, and when they fly, their lower bodies become columns of swirling sand. A dao isn't happy unless it is the envy of other dao.",
-								{
-									"name": "All That Glitters",
-									"type": "entries",
-									"entries": [
-										"The dao dwell in complexes of twisting tunnels and glittering ore-veined caverns on the Elemental Plane of Earth. These maze works are continually expanding as the dao delve into and reshape the rock around them. Dao care nothing for the poverty or misfortune of others. A dao might grind powdered gems and gold dust over its food to heighten the experience of eating, devouring its wealth as mortals consume a precious spice."
-									]
-								},
-								{
-									"name": "Lords of the Earth",
-									"type": "entries",
-									"entries": [
-										"A dao never assists a mortal unless the genie has something to gain, preferably treasure. Among the genies, dao are on speaking and trading terms with the efreet, but they have nothing but scorn for djinn and marids. Other races native to the Elemental Plane of Earth avoid the dao, which are always seeking new slaves to mine the maze works of their floating earth islands."
-									]
-								},
-								{
-									"name": "Proud Slavers",
-									"type": "entries",
-									"entries": [
-										"The dao trade for the finest slaves that money can buy, forcing them to work in dangerous subterranean realms that rumble with earthquakes. As much as they enjoy enslaving others, the dao hate being enslaved. Powerful wizards have been known to lure dao to the Material Plane and trap them in the confines of magic gemstones or iron flasks. Unfortunately for the dao, their greed makes it relatively easy for mages to cozen them into service."
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Genies",
-									"entries": [
-										"Genies are rare elemental creatures out of story and legend. Only a few can be found on the Material Plane. The rest reside on the Elemental Planes, where they rule from lavish palaces and are attended by worshipful slaves.",
-										"Genies are as brilliant as they are mighty, as proud as they are majestic. Haughty and decadent, they have a profound sense of entitlement that stems from the knowledge that few creatures except the gods and other genies can challenge their power.",
-										{
-											"name": "Creatures of the Elements",
-											"entries": [
-												"A genie is born when the soul of a sentient living creature melds with the primordial matter of an elemental plane. Only under rare circumstances does such an elemental-infused soul coalesce into a manifest form and create a genie.",
-												"A genie usually retains no connection to the soul that gave it form. That life force is a building block that determines the genie's form and apparent gender, as well as one or two key personality traits. Although they resemble humanoid beings, genies are elemental spirits given physical form. They don't mate with other genies or produce genie offspring, as all new genies are born out of the same mysterious fusion of spirit energy and elemental power. A genie with a stronger connection to its mortal soul might choose to sire a child with a mortal, although such offspring are rare.",
-												"When a genie perishes, it leaves nothing behind except what it was wearing or carrying, along with a small trace of its native element: a pile of dust, a gust of wind, a flash of fire and smoke, or a burst of water and foam.",
-												"In contrast to their love of slaves, most genies loathe being bound to service themselves. A genie obeys the will of another only when bribed or compelled by magic. All genies command the power of their native element, but a rare few also possess the power to grant wishes. For both these reasons, mortal mages often seek to bind genies into service.",
-												"Noble genies cultivate the jealousy and envy of other genies, asserting their superiority at every opportunity. Other genies respect the influence of the noble genies, knowing how unwise it is to defy a creature that can alter reality at a whim. A genie isn't beholden to any noble genie, however, and will sometimes choose to defy a noble genie's will and risk the consequences.",
-												"Their miraculous powers, the grandeur of their abodes, and the numbers of their slaves allow some genies to deceive themselves into believing they are as powerful as the gods. Some go so far as to demand that mortals of other realms-even whole continents or worlds-bow down before them."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Rule or Be Ruled",
-											"entries": [
-												"Mortal slaves serve to validate a genie's power and high self-opinion. A hundred flattering voices are music to a genie's ears, while two hundred mortal slaves prostrated at its feet are proof that it is lord and master. Genies view slaves as living property, and a genie without property amounts to nothing among its own kind. As a result, many genies treasure their slaves, treating them as honored members of their households. Evil genies freely threaten and abuse their slaves, but never to the extent that the slaves are no longer of use."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Decadent Nobility",
-											"entries": [
-												"Noble genies are the rarest of their kind. They are used to getting what they want, and have learned to trade their ability to grant wishes to attain the objects of their desire. This constant indulgence has made them decadent, while their supreme power over reality makes them haughty and arrogant. Their vast palaces overflow with wonders and sensory delights beyond imagination."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "The Power of Worship",
-											"entries": [
-												"Genies acknowledge the gods as powerful entities but have no desire to court or worship them. They find the endless fawning and mewling of religious devotees tiresome-except as it is directed toward them by their worshipful slaves."
-											],
-											"type": "entries"
-										}
-									]
-								}
-							]
-						}
-					]
+			"_copy": {
+				"name": "Genies",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": [
+							"Dao are greedy, malicious genies from the Elemental Plane of Earth. They adorn themselves with jewelry crafted from precious gems and rare metals, and when they fly, their lower bodies become columns of swirling sand. A dao isn't happy unless it is the envy of other dao.",
+							{
+								"type": "entries",
+								"entries": [
+									{
+										"type": "entries",
+										"entries": [
+											{
+												"name": "All That Glitters",
+												"type": "entries",
+												"entries": [
+													"The dao dwell in complexes of twisting tunnels and glittering ore-veined caverns on the Elemental Plane of Earth. These maze works are continually expanding as the dao delve into and reshape the rock around them. Dao care nothing for the poverty or misfortune of others. A dao might grind powdered gems and gold dust over its food to heighten the experience of eating, devouring its wealth as mortals consume a precious spice."
+												]
+											},
+											{
+												"name": "Lords of the Earth",
+												"type": "entries",
+												"entries": [
+													"A dao never assists a mortal unless the genie has something to gain, preferably treasure. Among the genies, dao are on speaking and trading terms with the efreet, but they have nothing but scorn for djinn and marids. Other races native to the Elemental Plane of Earth avoid the dao, which are always seeking new slaves to mine the maze works of their floating earth islands."
+												]
+											},
+											{
+												"name": "Proud Slavers",
+												"type": "entries",
+												"entries": [
+													"The dao trade for the finest slaves that money can buy, forcing them to work in dangerous subterranean realms that rumble with earthquakes. As much as they enjoy enslaving others, the dao hate being enslaved. Powerful wizards have been known to lure dao to the Material Plane and trap them in the confines of magic gemstones or iron flasks. Unfortunately for the dao, their greed makes it relatively easy for mages to cozen them into service."
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
 				}
-			],
+			},
 			"images": [
 				{
 					"type": "image",
@@ -4126,43 +4088,77 @@
 		{
 			"name": "Djinni",
 			"source": "MM",
+			"_copy": {
+				"name": "Genies",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": [
+							"Proud, sensuous genies from the Elemental Plane of Air, the djinn are attractive, tall, well-muscled humanoids with blue skin and dark eyes. They dress in airy, shimmering silks, designed as much for comfort as to flaunt their musculature.",
+							{
+								"type": "entries",
+								"entries": [
+									{
+										"type": "entries",
+										"entries": [
+											{
+												"name": "Airy Aesthetes",
+												"type": "entries",
+												"entries": [
+													"Djinn rule floating islands of cloud stuff covered with enormous pavilions, or topped with wondrous buildings, courtyards, fountains, and gardens. Creatures of comfort and ease, djinn enjoy succulent fruits, pungent wines, fine perfumes, and beautiful music.",
+													"Djinn are known for their sense of mischief and their favorable attitude toward mortals. Among genies, djinn deal coolly with efreet and marids, whom they view as haughty. They openly despise dao and strike against them with little provocation."
+												]
+											},
+											{
+												"name": "Masters of the Wind",
+												"type": "entries",
+												"entries": [
+													"Masters of the air, the djinn ride powerful whirlwinds that they create and direct on a whim, and which can even carry passengers. Creatures that stand against a djinni are assaulted by wind and thunder, even as the djinni spins away on that wind if outmatched in combat. When a djinni flies, its lower body transforms into a column of swirling air."
+												]
+											},
+											{
+												"name": "Accepting Servitors",
+												"type": "entries",
+												"entries": [
+													"The djinn believe that servitude is a matter of fate, and that no being can contest the hand of fate. As a result, of all the genies, djinn are the ones most amenable to servitude, though they never enjoy it. Djinn treat their slaves more like servants deserving of kindness and protection, and they part with them reluctantly.",
+													"A mortal who desires the brief service of a djinni can entreat it with fine gifts, or use flattery to bribe it into compliance. Powerful wizards are able to forgo such niceties, however, if they can summon, bind into service, or imprison a djinni using magic. Long-term service displeases a djinni, and imprisonment is inexcusable. Djinn resent the cruel wizards that have imprisoned their kind in bottles, iron flasks, and wind instruments throughout the ages. Betrayal, particularly by a mortal whom a djinni trusted, is a vile deed that only deadly vengeance can amend."
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				}
+			},
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "internal",
+						"path": "bestiary/MM/Djinni.jpg"
+					}
+				}
+			]
+		},
+		{
+			"name": "Genies",
+			"source": "MM",
 			"entries": [
 				{
-					"type": "entries",
+					"type": "section",
+					"name": "Genies",
 					"entries": [
+						"Genies are rare elemental creatures out of story and legend. Only a few can be found on the Material Plane. The rest reside on the Elemental Planes, where they rule from lavish palaces and are attended by worshipful slaves.",
+						"Genies are as brilliant as they are mighty, as proud as they are majestic. Haughty and decadent, they have a profound sense of entitlement that stems from the knowledge that few creatures except the gods and other genies can challenge their power.",
 						{
 							"type": "entries",
 							"entries": [
-								"Proud, sensuous genies from the Elemental Plane of Air, the djinn are attractive, tall, well-muscled humanoids with blue skin and dark eyes. They dress in airy, shimmering silks, designed as much for comfort as to flaunt their musculature.",
-								{
-									"name": "Airy Aesthetes",
-									"type": "entries",
-									"entries": [
-										"Djinn rule floating islands of cloud stuff covered with enormous pavilions, or topped with wondrous buildings, courtyards, fountains, and gardens. Creatures of comfort and ease, djinn enjoy succulent fruits, pungent wines, fine perfumes, and beautiful music.",
-										"Djinn are known for their sense of mischief and their favorable attitude toward mortals. Among genies, djinn deal coolly with efreet and marids, whom they view as haughty. They openly despise dao and strike against them with little provocation."
-									]
-								},
-								{
-									"name": "Masters of the Wind",
-									"type": "entries",
-									"entries": [
-										"Masters of the air, the djinn ride powerful whirlwinds that they create and direct on a whim, and which can even carry passengers. Creatures that stand against a djinni are assaulted by wind and thunder, even as the djinni spins away on that wind if outmatched in combat. When a djinni flies, its lower body transforms into a column of swirling air."
-									]
-								},
-								{
-									"name": "Accepting Servitors",
-									"type": "entries",
-									"entries": [
-										"The djinn believe that servitude is a matter of fate, and that no being can contest the hand of fate. As a result, of all the genies, djinn are the ones most amenable to servitude, though they never enjoy it. Djinn treat their slaves more like servants deserving of kindness and protection, and they part with them reluctantly.",
-										"A mortal who desires the brief service of a djinni can entreat it with fine gifts, or use flattery to bribe it into compliance. Powerful wizards are able to forgo such niceties, however, if they can summon, bind into service, or imprison a djinni using magic. Long-term service displeases a djinni, and imprisonment is inexcusable. Djinn resent the cruel wizards that have imprisoned their kind in bottles, iron flasks, and wind instruments throughout the ages. Betrayal, particularly by a mortal whom a djinni trusted, is a vile deed that only deadly vengeance can amend."
-									]
-								},
 								{
 									"type": "entries",
-									"name": "Genies",
 									"entries": [
-										"Genies are rare elemental creatures out of story and legend. Only a few can be found on the Material Plane. The rest reside on the Elemental Planes, where they rule from lavish palaces and are attended by worshipful slaves.",
-										"Genies are as brilliant as they are mighty, as proud as they are majestic. Haughty and decadent, they have a profound sense of entitlement that stems from the knowledge that few creatures except the gods and other genies can challenge their power.",
 										{
 											"name": "Creatures of the Elements",
 											"entries": [
@@ -4201,15 +4197,6 @@
 							]
 						}
 					]
-				}
-			],
-			"images": [
-				{
-					"type": "image",
-					"href": {
-						"type": "internal",
-						"path": "bestiary/MM/Djinni.jpg"
-					}
 				}
 			]
 		},
@@ -4722,62 +4709,16 @@
 		{
 			"name": "Duodrone",
 			"source": "MM",
-			"entries": [
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								"The blocky duodrones supervise units of monodrones and can perform up to two tasks at a time.",
-								{
-									"type": "entries",
-									"name": "Modrons",
-									"entries": [
-										"Modrons are beings of absolute law that adhere to a hive-like hierarchy. They inhabit the plane of Mechanus and tend its eternally revolving gears, their existence a clockwork routine of perfect order.",
-										{
-											"name": "Absolute Law and Order",
-											"entries": [
-												"Under the direction of their leader, Primus, modrons increase order in the multiverse in accordance with laws beyond the comprehension of mortal minds. Their own minds are networked in a hierarchal pyramid, in which each modron receives commands from superiors and delegates orders to underlings. A modron carries out commands with total obedience, utmost efficiency, and an absence of morality or ego. Modrons have no sense of self beyond what is necessary to fulfill their duties. They exist as a unified collective, divided by ranks, yet they always refer to themselves collectively. To a modron, there is no \"I,\" but only \"we\" or \"us.\"",
-												{
-													"type": "inset",
-													"name": "Variant: Rogue Modrons",
-													"entries": [
-														"A modron unit sometimes becomes defective, either through natural decay or exposure to chaotic forces. Rogue modrons don't act in accordance with Primus's wishes and directives, breaking laws, disobeying orders, and even engaging in violence. Other modrons hunt down such rogues.",
-														"A rogue modron loses the Axiomatic Mind trait and can have any alignment other than lawful neutral. Otherwise, it has the same statistics as a regular modron of its rank."
-													]
-												}
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Absolute Hierarchy",
-											"entries": [
-												"Modrons communicate only with their own rank and the ranks immediately above and below them. Modrons more than one rank away are either too advanced or too simple to understand."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Cogs of the Great Machine",
-											"entries": [
-												"If a modron is destroyed, its remains disintegrate. A replacement from the next lowest rank then transforms in a flash of light, gaining the physical form of its new rank. The promoted modron is replaced by one of its underlings in the same manner, all the way to the lowest levels of the hierarchy. There, a new modron is created by Primus, with a steady stream of monodrones leaving the Great Modron Cathedral on Mechanus as a result."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "The Great Modron March",
-											"entries": [
-												"When the gears of Mechanus complete seventeen cycles once every 289 years, Primus sends a vast army of modrons across the Outer Planes, ostensibly on a reconnaissance mission. The march is long and dangerous, and only a small number of modrons returns to Mechanus."
-											],
-											"type": "entries"
-										}
-									]
-								}
-							]
-						}
-					]
+			"_copy": {
+				"name": "Modrons",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": "The blocky duodrones supervise units of monodrones and can perform up to two tasks at a time."
+					}
 				}
-			],
+			},
 			"images": [
 				{
 					"type": "image",
@@ -4874,82 +4815,62 @@
 		{
 			"name": "Efreeti",
 			"source": "MM",
-			"entries": [
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								"Hulking genies of the Elemental Plane of Fire, the efreet are masters of flame, immune to fire and able to create it on a whim. Fine silk caftans and damask robes drape their magma-red or coal-black skin, and they bedeck themselves in brass and gold torcs, chains, and rings, all glittering with jewels. When an efreeti flies, its lower body transforms into a column of smoke and embers.",
-								{
-									"name": "Haughty and Cruel",
-									"type": "entries",
-									"entries": [
-										"The efreet are deceptive, cunning, and cruel to the point of ruthlessness. They despise being forced into servitude and are relentless in pursuit of vengeance against creatures that have wronged them. Efreet don't see themselves in this light, naturally, and regard their race as fair and orderly, even as they admit to an enlightened sense of self-interest."
-									]
-								},
-								{
-									"name": "Spiteful Slavers",
-									"type": "entries",
-									"entries": [
-										"Efreet view all other creatures as enemies or potential serfs. They raid the Material Plane and the elemental planes for slaves, which they capture and bring back to their homes on the Elemental Plane of Fire. The efreet rule as oppressive tyrants, promoting only the cruelest among their slaves. Those overseers are given whips to help keep the rank-and-file slaves in line."
-									]
-								},
-								{
-									"name": "Planar Raiders",
-									"type": "entries",
-									"entries": [
-										"Most efreet reside on the Elemental Plane of Fire, either in great domed fortresses of black glass and basalt surrounded by churning lakes of fire, or in the fabled City of Brass. Additionally, efreet military outposts thronging with their minions and slaves can be found scattered throughout the planes.",
-										"On the Material Plane, efreet dwell in fiery regions such as volcanoes and the burning expanses of the world's deserts. Their love of the desert brings them into conflict with the djinn that ride the desert whirlwinds, and with the earthbound dao. Efreet utterly despise marids, with whom they have maintained a passionate conflict throughout the history of both races."
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Genies",
-									"entries": [
-										"Genies are rare elemental creatures out of story and legend. Only a few can be found on the Material Plane. The rest reside on the Elemental Planes, where they rule from lavish palaces and are attended by worshipful slaves.",
-										"Genies are as brilliant as they are mighty, as proud as they are majestic. Haughty and decadent, they have a profound sense of entitlement that stems from the knowledge that few creatures except the gods and other genies can challenge their power.",
-										{
-											"name": "Creatures of the Elements",
-											"entries": [
-												"A genie is born when the soul of a sentient living creature melds with the primordial matter of an elemental plane. Only under rare circumstances does such an elemental-infused soul coalesce into a manifest form and create a genie.",
-												"A genie usually retains no connection to the soul that gave it form. That life force is a building block that determines the genie's form and apparent gender, as well as one or two key personality traits. Although they resemble humanoid beings, genies are elemental spirits given physical form. They don't mate with other genies or produce genie offspring, as all new genies are born out of the same mysterious fusion of spirit energy and elemental power. A genie with a stronger connection to its mortal soul might choose to sire a child with a mortal, although such offspring are rare.",
-												"When a genie perishes, it leaves nothing behind except what it was wearing or carrying, along with a small trace of its native element: a pile of dust, a gust of wind, a flash of fire and smoke, or a burst of water and foam.",
-												"In contrast to their love of slaves, most genies loathe being bound to service themselves. A genie obeys the will of another only when bribed or compelled by magic. All genies command the power of their native element, but a rare few also possess the power to grant wishes. For both these reasons, mortal mages often seek to bind genies into service.",
-												"Noble genies cultivate the jealousy and envy of other genies, asserting their superiority at every opportunity. Other genies respect the influence of the noble genies, knowing how unwise it is to defy a creature that can alter reality at a whim. A genie isn't beholden to any noble genie, however, and will sometimes choose to defy a noble genie's will and risk the consequences.",
-												"Their miraculous powers, the grandeur of their abodes, and the numbers of their slaves allow some genies to deceive themselves into believing they are as powerful as the gods. Some go so far as to demand that mortals of other realms-even whole continents or worlds-bow down before them."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Rule or Be Ruled",
-											"entries": [
-												"Mortal slaves serve to validate a genie's power and high self-opinion. A hundred flattering voices are music to a genie's ears, while two hundred mortal slaves prostrated at its feet are proof that it is lord and master. Genies view slaves as living property, and a genie without property amounts to nothing among its own kind. As a result, many genies treasure their slaves, treating them as honored members of their households. Evil genies freely threaten and abuse their slaves, but never to the extent that the slaves are no longer of use."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Decadent Nobility",
-											"entries": [
-												"Noble genies are the rarest of their kind. They are used to getting what they want, and have learned to trade their ability to grant wishes to attain the objects of their desire. This constant indulgence has made them decadent, while their supreme power over reality makes them haughty and arrogant. Their vast palaces overflow with wonders and sensory delights beyond imagination."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "The Power of Worship",
-											"entries": [
-												"Genies acknowledge the gods as powerful entities but have no desire to court or worship them. They find the endless fawning and mewling of religious devotees tiresome-except as it is directed toward them by their worshipful slaves."
-											],
-											"type": "entries"
-										}
-									]
-								}
-							]
-						}
-					]
+			"_copy": {
+				"name": "Genies",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": [
+							"Hulking genies of the Elemental Plane of Fire, the efreet are masters of flame, immune to fire and able to create it on a whim. Fine silk caftans and damask robes drape their magma-red or coal-black skin, and they bedeck themselves in brass and gold torcs, chains, and rings, all glittering with jewels. When an efreeti flies, its lower body transforms into a column of smoke and embers.",
+							{
+								"type": "entries",
+								"entries": [
+									{
+										"type": "entries",
+										"entries": [
+											{
+												"name": "Haughty and Cruel",
+												"type": "entries",
+												"entries": [
+													"The efreet are deceptive, cunning, and cruel to the point of ruthlessness. They despise being forced into servitude and are relentless in pursuit of vengeance against creatures that have wronged them. Efreet don't see themselves in this light, naturally, and regard their race as fair and orderly, even as they admit to an enlightened sense of self-interest."
+												]
+											},
+											{
+												"name": "Spiteful Slavers",
+												"type": "entries",
+												"entries": [
+													"Efreet view all other creatures as enemies or potential serfs. They raid the Material Plane and the elemental planes for slaves, which they capture and bring back to their homes on the Elemental Plane of Fire. The efreet rule as oppressive tyrants, promoting only the cruelest among their slaves. Those overseers are given whips to help keep the rank-and-file slaves in line."
+												]
+											},
+											{
+												"name": "Planar Raiders",
+												"type": "entries",
+												"entries": [
+													"Most efreet reside on the Elemental Plane of Fire, either in great domed fortresses of black glass and basalt surrounded by churning lakes of fire, or in the fabled City of Brass. Additionally, efreet military outposts thronging with their minions and slaves can be found scattered throughout the planes.",
+													"On the Material Plane, efreet dwell in fiery regions such as volcanoes and the burning expanses of the world's deserts. Their love of the desert brings them into conflict with the djinn that ride the desert whirlwinds, and with the earthbound dao. Efreet utterly despise marids, with whom they have maintained a passionate conflict throughout the history of both races."
+												]
+											}
+										]
+									}
+								]
+							},
+							{
+								"type": "insetReadaloud",
+								"entries": [
+									{
+										"type": "quote",
+										"entries": [
+											"The armies of the Grand Sultan are bolstered by legions of devils, his palace warded by spells of a thousand archmagi. No one has plundered the efreeti's fabled vaults and lived to tell the tale. By the grace of a thousand winds, you could be the first."
+										],
+										"by": "A djinni enticing adventurers to free her caliph from a magic lamp in the Charcoal Palace of the City of Brass"
+									}
+								]
+							}
+						]
+					}
 				}
-			],
+			},
 			"images": [
 				{
 					"type": "image",
@@ -5537,7 +5458,19 @@
 						"mode": "prependArr",
 						"items": [
 							"A flesh golem is a grisly assortment of humanoid body parts stitched and bolted together into a muscled brute imbued with formidable strength. Its brain is capable of simple reason, though its thoughts are no more sophisticated than those of a young child. The golem's muscle tissue responds to the power of lightning, invigorating the creature with vitality and strength. Powerful enchantments protect the golem's skin, deflecting spells and all but the most potent weapons.",
-							"A flesh golem lurches with a stiff-jointed gait, as if not in complete control of its body. Its dead flesh isn't an ideal container for an elemental spirit, which sometimes howls incoherently to vent its outrage. If the spirit breaks free of its creator's will, the golem goes berserk until calmed, or until its shell of flesh is destroyed or completely healed."
+							"A flesh golem lurches with a stiff-jointed gait, as if not in complete control of its body. Its dead flesh isn't an ideal container for an elemental spirit, which sometimes howls incoherently to vent its outrage. If the spirit breaks free of its creator's will, the golem goes berserk until calmed, or until its shell of flesh is destroyed or completely healed.",
+							{
+								"type": "insetReadaloud",
+								"entries": [
+									{
+										"type": "quote",
+										"entries": [
+											"Two of my gravediggers were caught and hanged yesterday. The other two are understandably reluctant to meet a similar fate, but I shan't let their concerns stall my progress. I need fresh corpses, and if those bumpkins can't get them for me, I'll use theirs instead."
+										],
+										"by": "From the diary of Evangeliza Lavain, necromancer"
+									}
+								]
+							}
 						]
 					}
 				}
@@ -5896,7 +5829,7 @@
 									]
 								},
 								{
-									"type": "entries",
+									"type": "inset",
 									"name": "Shards of Elemental Evil",
 									"entries": [
 										"As Ogrémoch, the evil Prince of Elemental Earth, treads his stony realm, it leaves shards of broken rock in his wake. Imbued with slivers of sentience, these shards thrum with the essence of the elemental prince, growing over long years into vaguely humanoid rock formations that resolve at last into the hard, cruel shapes of gargoyles.",
@@ -5920,51 +5853,66 @@
 			]
 		},
 		{
-			"name": "Gas Spore",
+			"name": "Fungi",
 			"source": "MM",
 			"entries": [
 				{
-					"type": "entries",
+					"type": "section",
+					"name": "Fungi",
 					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								"The first gas spores are thought to have been spawned from dead beholders, whose moldering corpses fed a parasitic fungus with aberrant magic. Having long since adapted into a unique plant creature, a gas spore grows quickly and purposefully out of any corpse, creating a malevolent-looking mockery of the most feared denizen of the Underdark.",
-								{
-									"type": "entries",
-									"name": "Fungi",
-									"entries": [
-										"With its sky of jagged stone and perpetual night, the Underdark is home to all manner of fungi. Taking the place of plants in the subterranean realm, fungi are vital to the survival of many underground species, providing nourishment and shelter in the unforgiving darkness.",
-										"Fungi spawn in organic matter, then break that matter down to consume it, feeding on filth and corpses. As they mature, fungi eject spores that drift on the lightest breeze to spawn new fungi.",
-										"Not needing sunlight or warmth to grow, fungi thrive in every corner and crevice of the Underdark. Transformed by the magic that permeates that underground realm, Underdark fungi often develop potent defensive mechanisms or abilities of mimicry and attack. The largest specimens can spread to create vast subterranean forests in which countless creatures live and feed."
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Eye Tyrant's Form",
-									"entries": [
-										"A gas spore is a spherical, balloon-like fungus that resembles a beholder from a distance, though its true nature becomes increasingly obvious as one approaches it. The monster possesses a blind central \"eye\" and rhizome growths sprouting from its upper surface, superficially resembling a beholder's eyestalks."
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Death Burst",
-									"entries": [
-										"A gas spore is a hollow shell filled with a lighter-than-air gas that enables it to float as a beholder does. Piercing the shell with even the weakest attack causes the creature to burst apart, releasing a cloud of deadly spores. A creature that inhales the spores becomes host to them, and is often dead within a day. Its corpse then becomes the spawning ground from which new gas spores arise."
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Beholder Memories",
-									"entries": [
-										"A gas spore that sprouts from a beholder's corpse sometimes carries within it memories of its deceased parent. When the gas spore explodes, its deadly spores cast those memories adrift. Any creature that inhales the spores and survives inherits one or more of the beholder's fragmented memories, and might gain useful information about the beholder's former lair and other nearby places and creatures of interest."
-									]
-								}
-							]
-						}
+						"With its sky of jagged stone and perpetual night, the Underdark is home to all manner of fungi. Taking the place of plants in the subterranean realm, fungi are vital to the survival of many underground species, providing nourishment and shelter in the unforgiving darkness.",
+						"Fungi spawn in organic matter, then break that matter down to consume it, feeding on filth and corpses. As they mature, fungi eject spores that drift on the lightest breeze to spawn new fungi.",
+						"Not needing sunlight or warmth to grow, fungi thrive in every corner and crevice of the Underdark. Transformed by the magic that permeates that underground realm, Underdark fungi often develop potent defensive mechanisms or abilities of mimicry and attack. The largest specimens can spread to create vast subterranean forests in which countless creatures live and feed."
 					]
 				}
-			],
+			]
+		},
+		{
+			"name": "Gas Spore",
+			"source": "MM",
+			"_copy": {
+				"name": "Fungi",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": [
+							"The first gas spores are thought to have been spawned from dead beholders, whose moldering corpses fed a parasitic fungus with aberrant magic. Having long since adapted into a unique plant creature, a gas spore grows quickly and purposefully out of any corpse, creating a malevolent-looking mockery of the most feared denizen of the Underdark.",
+							{
+								"type": "entries",
+								"entries": [
+									{
+										"type": "entries",
+										"entries": [
+											{
+												"type": "entries",
+												"name": "Eye Tyrant's Form",
+												"entries": [
+													"A gas spore is a spherical, balloon-like fungus that resembles a beholder from a distance, though its true nature becomes increasingly obvious as one approaches it. The monster possesses a blind central \"eye\" and rhizome growths sprouting from its upper surface, superficially resembling a beholder's eyestalks."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Death Burst",
+												"entries": [
+													"A gas spore is a hollow shell filled with a lighter-than-air gas that enables it to float as a beholder does. Piercing the shell with even the weakest attack causes the creature to burst apart, releasing a cloud of deadly spores. A creature that inhales the spores becomes host to them, and is often dead within a day. Its corpse then becomes the spawning ground from which new gas spores arise."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Beholder Memories",
+												"entries": [
+													"A gas spore that sprouts from a beholder's corpse sometimes carries within it memories of its deceased parent. When the gas spore explodes, its deadly spores cast those memories adrift. Any creature that inhales the spores and survives inherits one or more of the beholder's fragmented memories, and might gain useful information about the beholder's former lair and other nearby places and creatures of interest."
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				}
+			},
 			"images": [
 				{
 					"type": "image",
@@ -5979,53 +5927,17 @@
 			"name": "Gelatinous Cube",
 			"source": "MM",
 			"entries": [
+				"Gelatinous cubes scour dungeon passages in silent, predictable patterns, leaving perfectly clean paths in their wake. They consume living tissue while leaving bones and other materials undissolved.",
+				"A gelatinous cube is all but transparent, making it hard to spot until it attacks. A cube that is well fed can be easier to spot, since its victims' bones, coins, and other objects can be seen suspended inside the creature.",
 				{
-					"type": "entries",
+					"type": "insetReadaloud",
 					"entries": [
 						{
-							"type": "entries",
+							"type": "quote",
 							"entries": [
-								"Gelatinous cubes scour dungeon passages in silent, predictable patterns, leaving perfectly clean paths in their wake. They consume living tissue while leaving bones and other materials undissolved.",
-								"A gelatinous cube is all but transparent, making it hard to spot until it attacks. A cube that is well fed can be easier to spot, since its victims' bones, coins, and other objects can be seen suspended inside the creature.",
-								{
-									"type": "entries",
-									"name": "Oozes",
-									"entries": [
-										"Oozes thrive in the dark, shunning areas of bright light and extreme temperatures. They flow through the damp underground, feeding on any creature or object that can be dissolved, slinking along the ground, dripping from walls and ceilings, spreading across the edges of underground pools, and squeezing through cracks.",
-										"The first warning an adventurer receives of an ooze's presence is often the searing pain of its acidic touch. Oozes are drawn to movement and warmth. Organic material nourishes them, and when prey is scarce they feed on grime, fungus, and offal. Veteran explorers know that an immaculately clean passageway is a likely sign that an ooze lairs nearby.",
-										{
-											"name": "Slow Death",
-											"entries": [
-												"An ooze kills its prey slowly. Some varieties, such as black puddings and gelatinous cubes, engulf creatures to prevent escape. The only upside of this torturous death is that a victim's comrades can come to the rescue before it is too late.",
-												"Since not every ooze digests every type of substance, some have coins, metal gear, bones, and other debris suspended within their quivering bodies. A slain ooze can be a rich source of treasure for its killers.",
-												"Whether this is true or not, the Faceless Lord is one of the few beings that can control oozes and imbue them with a modicum of intelligence. Most of the time, oozes have no sense of tactics or self-preservation. They are direct and predictable, attacking and eating without cunning. Under the control of Juiblex, they exhibit glimmers of sentience and malevolent intent."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Unwitting Servants",
-											"entries": [
-												"Although an ooze lacks the intelligence to ally itself with other creatures, others that understand an ooze's need to feed might lure it into a location where it can be of use to them. Clever monsters keep oozes around to defend passageways or consume refuse. Likewise, an ooze can be enticed into a pit trap, where its captors feed it often enough to prevent it from coming after them. Crafty creatures place torches and flaming braziers in strategic areas to dissuade an ooze from leaving a particular tunnel or room."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Spawn of Juiblex",
-											"entries": [
-												"According to the Demonomicon of Iggwilv and other sources, oozes are scattered fragments or offspring of the demon lord Juiblex."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Ooze Nature",
-											"entries": [
-												"An ooze doesn't require sleep."
-											],
-											"type": "entries"
-										}
-									]
-								}
-							]
+								"The dungeon's floors were spotless. That should have been our first clue."
+							],
+							"by": "From the journal of Jaster Hollowquill, on his first exploration of Undermountain"
 						}
 					]
 				}
@@ -6045,20 +5957,10 @@
 			"source": "MM",
 			"entries": [
 				{
-					"type": "entries",
+					"type": "inset",
+					"name": "The Nature of Swarms",
 					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "inset",
-									"name": "The Nature of Swarms",
-									"entries": [
-										"The swarms presented here aren't ordinary or benign assemblies of little creatures. They form as a result of some sinister or unwholesome influence. A vampire can summon swarms of bats and rats from the darkest corners of the night, while the very presence of a mummy lord can cause scarab beetles to boil up from the sand-filled depths of its tomb. A hag might have the power to turn swarms of ravens against her enemies, while a {@creature yuan-ti abomination} might have {@creature swarm of poisonous snakes||swarms of poisonous snakes} slithering in its wake. Even druids can't charm these swarms, and their aggressiveness is borderline unnatural."
-									]
-								}
-							]
-						}
+						"The swarms presented here aren't ordinary or benign assemblies of little creatures. They form as a result of some sinister or unwholesome influence. A vampire can summon swarms of bats and rats from the darkest corners of the night, while the very presence of a mummy lord can cause scarab beetles to boil up from the sand-filled depths of its tomb. A hag might have the power to turn swarms of ravens against her enemies, while a {@creature yuan-ti abomination} might have {@creature swarm of poisonous snakes||swarms of poisonous snakes} slithering in its wake. Even druids can't charm these swarms, and their aggressiveness is borderline unnatural."
 					]
 				}
 			]
@@ -6489,6 +6391,30 @@
 								"Chief among these gods are the children of Annam, whose sons represent each type of giant: Stronmaus for storm giants, Memnor for cloud giants, Skoraeus Stonebones for stone giants, Thrym for frost giants, Surtur for fire giants, and Grolantor for hill giants. Not all giants automatically revere their kind's primary deity, however. Many good cloud giants refuse to worship the deceitful Memnor, and a storm giant dwelling in the icy mountains of the north might pay more homage to Thrym than Stronmaus. Other giants feel a stronger connection to Annam's daughters, who include Hiatea, the huntress and home warden; Iallanis, goddess of love and peace; and Diancastra, an impetuous and arrogant trickster.",
 								"Some giants abandon their own gods and fall prey to demon cults, paying homage to Baphomet or Kostchtchie. To worship them or any other non-giant deity is a great sin against the ordning, and almost certain to make a giant an outcast."
 							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"Boulders assailed our walls and cast them down, leavin' gaps through which the giants strode, weapons in hand."
+									],
+									"by": "Captain Dwern Addlestone's partial account of the Siege of Sterngate"
+								}
+							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"And here is where Angerroth the barbarian fell against the giant horde. His bones are under that boulder over there."
+									],
+									"by": "Elder Zelane of Istivin, recounting the Giant Wars"
+								}
+							]
 						}
 					]
 				}
@@ -6553,7 +6479,19 @@
 						"The warlike githyanki and the contemplative githzerai are a sundered people-two cultures that utterly despise one another. Before there were githyanki or githzerai, these creatures were a single race enslaved by the {@creature mind flayer||mind flayers}. Although they attempted to overthrow their masters many times, their rebellions were repeatedly crushed until a great leader named Gith arose.",
 						"After much bloodshed, Gith and her followers threw off the yoke of their illithid masters, but another leader named Zerthimon emerged in the aftermath of battle.",
 						"Zerthimon challenged Gith's motives, claiming that her strict martial leadership and desire for vengeance amounted to little more than another form of slavery for her people. A rift erupted between followers of each leader, and they eventually became the two races whose enmity endures to this day.",
-						"Whether these tall, gaunt creatures were peaceful or savage, cultured or primitive before the {@creature mind flayer||mind flayers} enslaved and changed them, none can say. Not even the original name of their race remains from that distant time."
+						"Whether these tall, gaunt creatures were peaceful or savage, cultured or primitive before the {@creature mind flayer||mind flayers} enslaved and changed them, none can say. Not even the original name of their race remains from that distant time.",
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"The githyanki and the githzerai were so profoundly scarred by their enslavement to the mind flayers that they forget they were one race, united. Having won their freedom, they wage war against each other with a hatred none can fully comprehend."
+									],
+									"by": "Aristul the Yellow, master of planar lore"
+								}
+							]
+						}
 					]
 				}
 			]
@@ -6987,6 +6925,30 @@
 									]
 								}
 							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"If you want soldiers or thugs, hire hobgoblins. If you want someone clubbed to death in their sleep, hire bugbears. If you want mean little fools, hire goblins."
+									],
+									"by": "Stalman Kilm, Slave Lord"
+								}
+							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"{@b {@style Bree-Yark!|small-caps}}"
+									],
+									"by": "Goblin for \"We surrender!\" (or so they say)"
+								}
+							]
 						}
 					]
 				}
@@ -7159,57 +7121,16 @@
 		{
 			"name": "Gray Ooze",
 			"source": "MM",
-			"entries": [
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								"A gray ooze is stone turned to liquid by chaos. When it moves, it slithers like a liquid snake, rising to strike.",
-								{
-									"type": "entries",
-									"name": "Oozes",
-									"entries": [
-										"Oozes thrive in the dark, shunning areas of bright light and extreme temperatures. They flow through the damp underground, feeding on any creature or object that can be dissolved, slinking along the ground, dripping from walls and ceilings, spreading across the edges of underground pools, and squeezing through cracks.",
-										"The first warning an adventurer receives of an ooze's presence is often the searing pain of its acidic touch. Oozes are drawn to movement and warmth. Organic material nourishes them, and when prey is scarce they feed on grime, fungus, and offal. Veteran explorers know that an immaculately clean passageway is a likely sign that an ooze lairs nearby.",
-										{
-											"name": "Slow Death",
-											"entries": [
-												"An ooze kills its prey slowly. Some varieties, such as black puddings and gelatinous cubes, engulf creatures to prevent escape. The only upside of this torturous death is that a victim's comrades can come to the rescue before it is too late.",
-												"Since not every ooze digests every type of substance, some have coins, metal gear, bones, and other debris suspended within their quivering bodies. A slain ooze can be a rich source of treasure for its killers.",
-												"Whether this is true or not, the Faceless Lord is one of the few beings that can control oozes and imbue them with a modicum of intelligence. Most of the time, oozes have no sense of tactics or self-preservation. They are direct and predictable, attacking and eating without cunning. Under the control of Juiblex, they exhibit glimmers of sentience and malevolent intent."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Unwitting Servants",
-											"entries": [
-												"Although an ooze lacks the intelligence to ally itself with other creatures, others that understand an ooze's need to feed might lure it into a location where it can be of use to them. Clever monsters keep oozes around to defend passageways or consume refuse. Likewise, an ooze can be enticed into a pit trap, where its captors feed it often enough to prevent it from coming after them. Crafty creatures place torches and flaming braziers in strategic areas to dissuade an ooze from leaving a particular tunnel or room."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Spawn of Juiblex",
-											"entries": [
-												"According to the Demonomicon of Iggwilv and other sources, oozes are scattered fragments or offspring of the demon lord Juiblex."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Ooze Nature",
-											"entries": [
-												"An ooze doesn't require sleep."
-											],
-											"type": "entries"
-										}
-									]
-								}
-							]
-						}
-					]
+			"_copy": {
+				"name": "Oozes",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": "A gray ooze is stone turned to liquid by chaos. When it moves, it slithers like a liquid snake, rising to strike."
+					}
 				}
-			],
+			},
 			"images": [
 				{
 					"type": "image",
@@ -7453,6 +7374,18 @@
 									]
 								}
 							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"Our intrepid rogue climbed up the shaft to secure a rope. There was a gasp, and the rope fell. We never saw her again."
+									],
+									"by": "An adventurer's account of a grell attack in Khyber, published in {@style The Korranberg Chronicle|small-caps}"
+								}
+							]
 						}
 					]
 				}
@@ -7642,50 +7575,19 @@
 		{
 			"name": "Guardian Naga",
 			"source": "MM",
-			"entries": [
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								"Wise and good, the beautiful guardian nagas protect sacred places and items of magical power from falling into evil hands. In their hidden redoubts, they research spells and hatch convoluted plots to thwart the evil designs of their enemies.",
-								"A guardian naga doesn't seek out violence, warning off intruders rather than attacking. Only if its foes persist does the naga attack, accosting enemies with its spells and poisonous spittle.",
-								{
-									"type": "entries",
-									"name": "Nagas",
-									"entries": [
-										"Nagas are intelligent serpents that inhabit the ruins of the past, amassing arcane treasures and knowledge.",
-										"The first nagas were created as immortal guardians by a humanoid race long lost to history. When this race died out, the nagas deemed themselves the rightful inheritors of their masters' treasures and magical lore. Industrious and driven, nagas occasionally venture out from their lairs to track down magic items or rare spellbooks.",
-										"Nagas never feel the ravages of time or succumb to sickness. Even if it is struck down, a naga's immortal spirit reforms in a new body in a matter of days, ready to continue its eternal work.",
-										{
-											"name": "Benevolent Dictators and Brutal Tyrants",
-											"entries": [
-												"A naga rules its domain with absolute authority. Whether it rules with compassion or by terrorizing its subjects, the naga believes itself the master of all other creatures that inhabit its domain."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Rivalry",
-											"entries": [
-												"Nagas have a long-standing enmity with the yuan-ti, with each race seeing itself as the epitome of serpentine evolution. Though cooperation between them is rare, nagas and yuan-ti sometimes set aside their differences to work toward common objectives. However, yuan-ti always chafe under a naga's authority."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Immortal Nature",
-											"entries": [
-												"A naga doesn't require air, food, drink, or sleep."
-											],
-											"type": "entries"
-										}
-									]
-								}
-							]
-						}
-					]
+			"_copy": {
+				"name": "Nagas",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": [
+							"Wise and good, the beautiful guardian nagas protect sacred places and items of magical power from falling into evil hands. In their hidden redoubts, they research spells and hatch convoluted plots to thwart the evil designs of their enemies.",
+							"A guardian naga doesn't seek out violence, warning off intruders rather than attacking. Only if its foes persist does the naga attack, accosting enemies with its spells and poisonous spittle."
+						]
+					}
 				}
-			],
+			},
 			"images": [
 				{
 					"type": "image",
@@ -7712,7 +7614,7 @@
 						]
 					}
 				}
-			],
+			},
 			"images": [
 				{
 					"type": "image",
@@ -7823,71 +7725,23 @@
 		{
 			"name": "Half-Ogre (Ogrillon)",
 			"source": "MM",
-			"entries": [
-				{
-					"type": "entries",
-					"entries": [
-						{
+			"_copy": {
+				"name": "Ogre",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "appendArr",
+						"items": {
 							"type": "entries",
+							"name": "Half-Ogre (Ogrillon)",
 							"entries": [
 								"When an ogre mates with a human, hobgoblin, bugbear, or orc, the result is always a half-ogre. (Ogres don't mate with dwarves, halflings, or elves. They eat them.) Human mothers rarely survive the birth of a half-ogre offspring.",
-								"The half-ogre offspring of an ogre and an orc is also called an ogrillon. An adult half-ogre or ogrillon stands 8 feet tall and weighs 450 pounds on average.",
-								{
-									"type": "entries",
-									"name": "Ogres",
-									"entries": [
-										"Ogres are as lazy of mind as they are strong of body. They live by raiding, scavenging, and killing for food and pleasure. The average adult specimen stands between 9 and 10 feet tall and weighs close to a thousand pounds.",
-										{
-											"name": "Furious Tempers",
-											"entries": [
-												"Ogres are notorious for their quick tempers, which flare at the smallest perceived offense. Insults and name-calling can rouse an ogre's wrath in an instant-as can stealing from it, bumping, jabbing, or prodding it, laughing, making faces, or simply looking at it the wrong way. When its rage is incited, an ogre lashes out in a frustrated tantrum until it runs out of objects or creatures to smash.",
-												"An ogre sleeps in caves, animal dens, or under trees until it finds a cabin or isolated farmhouse, whereupon it kills the inhabitants and lairs there. Whenever it is bored or hungry, an ogre ventures out from its lair, attacking anything that crosses its path. Only after an ogre has depleted an area of food does it move on.",
-												"Whenever possible, ogres gang up with other monsters to bully or prey on creatures weaker than themselves. They associate freely with goblinoids, orcs, and trolls, and practically worship giants. In the giants' complex social structure (known as the ordning), ogres rank beneath the lowest giants in status. As a result, an ogre will do nearly anything a giant asks."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Gruesome Gluttons",
-											"entries": [
-												"Ogres eat almost anything, but they especially enjoy the taste of dwarves, halflings, and elves. When they can, they combine dinner with pleasure, chasing scurrying victims around before eating them raw. If enough of its victim remains after the ogre has gorged itself, it might make a loincloth from its quarry's skin and a necklace from its leftover bones. This macabre crafting is the height of ogre culture."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Greedy Collectors",
-											"entries": [
-												"An ogre's eyes glitter with avarice when it sees the possessions of others. Ogres carry rough sacks on their raids, which they fill with fabulous \"treasure\" taken from their victims. This might include a collection of battered helmets, a moldy wheel of cheese, a rough patch of animal fur fastened like a cloak, or a squealing, mud-spattered pig. Ogres also delight in the gleam of gold and silver, and they will fight one another over small handfuls of coins. Smarter creatures can earn an ogre's trust by offering it gold or a weapon forged for a creature of its size."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Legendary Stupidity",
-											"entries": [
-												"Few ogres can count to ten, even with their fingers in front of them. Most speak only a rudimentary form of Giant and know a smattering of Common words. Ogres believe what they are told and are easy to fool or confuse, but they break things they don't understand. Silver-tongued tricksters who test their talents on these savages typically end up eating their eloquent words-and then being eaten in turn."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Primitive Wanderers",
-											"entries": [
-												"Ogres clothe themselves in animal pelts and uproot trees for use as crude tools and weapons. They create stone-tipped javelins for hunting. When they establish lairs, they settle near the rural edges of civilized lands, taking advantage of poorly protected livestock, undefended larders, and unwary farmers."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Ogre Gangs",
-											"entries": [
-												"Ogres sometimes band together in small, nomadic groups, but they lack a true sense of tribalism. When bands of ogres meet, one might attempt to capture the members of the other group to increase its numbers. However, ogre bands are just as likely to trade members freely, especially if the welcoming band is temporarily flush with food and weapons."
-											],
-											"type": "entries"
-										}
-									]
-								}
+								"The half-ogre offspring of an ogre and an orc is also called an ogrillon. An adult half-ogre or ogrillon stands 8 feet tall and weighs 450 pounds on average."
 							]
 						}
-					]
+					}
 				}
-			],
+			},
 			"images": [
 				{
 					"type": "image",
@@ -8418,6 +8272,23 @@
 									]
 								}
 							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"They break before our shields,",
+										"They fall beneath our blades;",
+										"Their home is ours to conquer,",
+										"Their children our slaves.",
+										"Acheron! Acheron!",
+										"Victory is ours!"
+									],
+									"by": "Translation of a Hobgoblin War Chant"
+								}
+							]
 						}
 					]
 				}
@@ -8817,6 +8688,18 @@
 									]
 								}
 							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"Don't cry. We have no intention of eating your brain. In fact, your brain is going on a wonderful journey!"
+									],
+									"by": "Qorik el-Slurrk, mind flayer"
+								}
+							]
 						}
 					]
 				}
@@ -8983,6 +8866,18 @@
 									]
 								}
 							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"If you hear a baby crying in an alley, walk the other way. That's my advice to you."
+									],
+									"by": "Endroth Knag, City Watch corporal in Waterdeep"
+								}
+							]
 						}
 					]
 				}
@@ -9086,16 +8981,28 @@
 									"entries": [
 										"Some krakens are virtual gods, with cults and minions spread across sea and land. Others are allied with Olhydra, the evil Princess of Elemental Water, and use her cultists to enforce their will on land and sea. A kraken pleased with its worshipers can becalm rough seas and bring a bounteous harvest of fish to the faithful. However, the devious mind of a kraken is ancient beyond reckoning, and is ultimately bent to the ruination of all things."
 									]
-								},
-								{
-									"type": "entries",
-									"name": "A Kraken's Lair",
-									"entries": [
-										"A kraken lives in dark depths, usually a sunken rift or a cavern filled with detritus, treasure, and wrecked ships."
-									]
 								}
 							]
 						}
+					]
+				},
+				{
+					"type": "insetReadaloud",
+					"entries": [
+						{
+							"type": "quote",
+							"entries": [
+								"A kraken dreams of casting its tentacles into the heavens and strangling that which birthed it, and when its dream exceeds its reach, it settles for the occasional passing ship."
+							],
+							"by": "From {@style Night of the Kraken Cult|small-caps} by Malfeore Serrang, pirate-mage of Tethyr"
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"name": "A Kraken's Lair",
+					"entries": [
+						"A kraken lives in dark depths, usually a sunken rift or a cavern filled with detritus, treasure, and wrecked ships."
 					]
 				}
 			],
@@ -9174,6 +9081,18 @@
 											"type": "entries"
 										}
 									]
+								}
+							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"They invent their own gods ... the very definition of insanity."
+									],
+									"by": "Sabal Mizzrym of Menzoberranzan"
 								}
 							]
 						}
@@ -9468,6 +9387,18 @@
 									]
 								}
 							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"In all my dealings with the lizardfolk, I was never able to tell what they were thinking. Their reptilian eyes belied no hint of their intentions. I gave them supplies. They gave me the willies."
+									],
+									"by": "A merchant's account of his experience with the lizardfolk tribes of the Lizard Marsh"
+								}
+							]
 						}
 					]
 				}
@@ -9740,6 +9671,18 @@
 									]
 								}
 							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"Manticores love the taste of human flesh. That's why, on trips through the moutnains, I always travel with human guards."
+									],
+									"by": "Marthok Uldarr, dwarf copper merchant"
+								}
+							]
 						}
 					]
 				}
@@ -9795,47 +9738,18 @@
 									"entries": [
 										"Marids are champion tale-tellers, whose favorite legends emphasize the prowess of marids in general and of the speaker in particular. Fanciful genies, they lie often and creatively. They aren't always malicious in their deception, but embellishments suit their fancy. Marids consider it a crime for a lesser being to interrupt one of their tales, and offending a marid is a sure way to invoke its wrath."
 									]
-								},
+								}
+							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
 								{
-									"type": "entries",
-									"name": "Genies",
+									"type": "quote",
 									"entries": [
-										"Genies are rare elemental creatures out of story and legend. Only a few can be found on the Material Plane. The rest reside on the Elemental Planes, where they rule from lavish palaces and are attended by worshipful slaves.",
-										"Genies are as brilliant as they are mighty, as proud as they are majestic. Haughty and decadent, they have a profound sense of entitlement that stems from the knowledge that few creatures except the gods and other genies can challenge their power.",
-										{
-											"name": "Creatures of the Elements",
-											"entries": [
-												"A genie is born when the soul of a sentient living creature melds with the primordial matter of an elemental plane. Only under rare circumstances does such an elemental-infused soul coalesce into a manifest form and create a genie.",
-												"A genie usually retains no connection to the soul that gave it form. That life force is a building block that determines the genie's form and apparent gender, as well as one or two key personality traits. Although they resemble humanoid beings, genies are elemental spirits given physical form. They don't mate with other genies or produce genie offspring, as all new genies are born out of the same mysterious fusion of spirit energy and elemental power. A genie with a stronger connection to its mortal soul might choose to sire a child with a mortal, although such offspring are rare.",
-												"When a genie perishes, it leaves nothing behind except what it was wearing or carrying, along with a small trace of its native element: a pile of dust, a gust of wind, a flash of fire and smoke, or a burst of water and foam.",
-												"In contrast to their love of slaves, most genies loathe being bound to service themselves. A genie obeys the will of another only when bribed or compelled by magic. All genies command the power of their native element, but a rare few also possess the power to grant wishes. For both these reasons, mortal mages often seek to bind genies into service.",
-												"Noble genies cultivate the jealousy and envy of other genies, asserting their superiority at every opportunity. Other genies respect the influence of the noble genies, knowing how unwise it is to defy a creature that can alter reality at a whim. A genie isn't beholden to any noble genie, however, and will sometimes choose to defy a noble genie's will and risk the consequences.",
-												"Their miraculous powers, the grandeur of their abodes, and the numbers of their slaves allow some genies to deceive themselves into believing they are as powerful as the gods. Some go so far as to demand that mortals of other realms-even whole continents or worlds-bow down before them."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Rule or Be Ruled",
-											"entries": [
-												"Mortal slaves serve to validate a genie's power and high self-opinion. A hundred flattering voices are music to a genie's ears, while two hundred mortal slaves prostrated at its feet are proof that it is lord and master. Genies view slaves as living property, and a genie without property amounts to nothing among its own kind. As a result, many genies treasure their slaves, treating them as honored members of their households. Evil genies freely threaten and abuse their slaves, but never to the extent that the slaves are no longer of use."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Decadent Nobility",
-											"entries": [
-												"Noble genies are the rarest of their kind. They are used to getting what they want, and have learned to trade their ability to grant wishes to attain the objects of their desire. This constant indulgence has made them decadent, while their supreme power over reality makes them haughty and arrogant. Their vast palaces overflow with wonders and sensory delights beyond imagination."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "The Power of Worship",
-											"entries": [
-												"Genies acknowledge the gods as powerful entities but have no desire to court or worship them. They find the endless fawning and mewling of religious devotees tiresome-except as it is directed toward them by their worshipful slaves."
-											],
-											"type": "entries"
-										}
-									]
+										"The marid poured out of the flask like water and said, 'Your wish is my command.' The halfling, overjoyed, wished for immortality, so the marid polymorphed him into a fish that flopped around humorously until, finally, it expired. It's a cautionary tale that has survived through the ages, so I suppose the halfling got his wish."
+									],
+									"by": "Kesto Brighteyes, Gnome Proprietor of the Parted Veil, a bookshop in Sigil"
 								}
 							]
 						}
@@ -10176,6 +10090,18 @@
 									]
 								}
 							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"Sometimes a chest is just a chest, but don't bet on it."
+									],
+									"by": "X the Mystic's 3rd rule of dungeon survival"
+								}
+							]
 						}
 					]
 				}
@@ -10337,62 +10263,16 @@
 		{
 			"name": "Monodrone",
 			"source": "MM",
-			"entries": [
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								"A monodrone can perform one simple task at a time and can relay a single message of up to forty-eight words.",
-								{
-									"type": "entries",
-									"name": "Modrons",
-									"entries": [
-										"Modrons are beings of absolute law that adhere to a hive-like hierarchy. They inhabit the plane of Mechanus and tend its eternally revolving gears, their existence a clockwork routine of perfect order.",
-										{
-											"name": "Absolute Law and Order",
-											"entries": [
-												"Under the direction of their leader, Primus, modrons increase order in the multiverse in accordance with laws beyond the comprehension of mortal minds. Their own minds are networked in a hierarchal pyramid, in which each modron receives commands from superiors and delegates orders to underlings. A modron carries out commands with total obedience, utmost efficiency, and an absence of morality or ego. Modrons have no sense of self beyond what is necessary to fulfill their duties. They exist as a unified collective, divided by ranks, yet they always refer to themselves collectively. To a modron, there is no \"I,\" but only \"we\" or \"us.\"",
-												{
-													"type": "inset",
-													"name": "Variant: Rogue Modrons",
-													"entries": [
-														"A modron unit sometimes becomes defective, either through natural decay or exposure to chaotic forces. Rogue modrons don't act in accordance with Primus's wishes and directives, breaking laws, disobeying orders, and even engaging in violence. Other modrons hunt down such rogues.",
-														"A rogue modron loses the Axiomatic Mind trait and can have any alignment other than lawful neutral. Otherwise, it has the same statistics as a regular modron of its rank."
-													]
-												}
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Absolute Hierarchy",
-											"entries": [
-												"Modrons communicate only with their own rank and the ranks immediately above and below them. Modrons more than one rank away are either too advanced or too simple to understand."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Cogs of the Great Machine",
-											"entries": [
-												"If a modron is destroyed, its remains disintegrate. A replacement from the next lowest rank then transforms in a flash of light, gaining the physical form of its new rank. The promoted modron is replaced by one of its underlings in the same manner, all the way to the lowest levels of the hierarchy. There, a new modron is created by Primus, with a steady stream of monodrones leaving the Great Modron Cathedral on Mechanus as a result."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "The Great Modron March",
-											"entries": [
-												"When the gears of Mechanus complete seventeen cycles once every 289 years, Primus sends a vast army of modrons across the Outer Planes, ostensibly on a reconnaissance mission. The march is long and dangerous, and only a small number of modrons returns to Mechanus."
-											],
-											"type": "entries"
-										}
-									]
-								}
-							]
-						}
-					]
+			"_copy": {
+				"name": "Modrons",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": "A monodrone can perform one simple task at a time and can relay a single message of up to forty-eight words."
+					}
 				}
-			],
+			},
 			"images": [
 				{
 					"type": "image",
@@ -10500,6 +10380,18 @@
 									]
 								}
 							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"Before opening a sarcophagus, light a torch."
+									],
+									"by": "X the Mystic's 7th rule of dungeon survival"
+								}
+							]
 						}
 					]
 				}
@@ -10517,93 +10409,46 @@
 		{
 			"name": "Mummy Lord",
 			"source": "MM",
-			"entries": [
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								"In the tombs of the ancients, tyrannical monarchs and the high priests of dark gods lie in dreamless rest, waiting for the time when they might reclaim their thrones and reforge their ancient empires. The regalia of their terrible rule still adorns their linen-wrapped bodies, their moldering robes stitched with evil symbols and bronze armor etched with devices of dynasties that fell a thousand years before.",
-								"Under the direction of the most powerful priests, the ritual that creates a mummy can be increased in potency. The mummy lord that rises from such a ritual retains the memories and personality of its former life, and is gifted with supernatural resilience. Dead emperors wield the same infamous rune-marked blades that they did in legend. Sorcerer lords work the forbidden magic that once controlled a terrified populace, and the dark gods reward dead priest-kings' prayers by imparting divine spells.",
-								{
-									"name": "Heart of the Mummy Lord",
-									"type": "entries",
-									"entries": [
-										"As part of the ritual that creates a mummy lord, the creature's heart and viscera are removed from the corpse and placed in canopic jars. These jars are usually carved from limestone or made of pottery, etched or painted with religious hieroglyphs.",
-										"As long as its shriveled heart remains intact, a mummy lord can't be permanently destroyed. When it drops to 0 hit points, the mummy lord turns to dust and re-forms at full strength 24 hours later, rising out of dust in close proximity to the canopic jar containing its heart. A mummy lord can be destroyed or prevented from re-forming by burning its heart to ashes. For this reason, a mummy lord usually keeps its heart and viscera in a hidden tomb or vault.",
-										"The mummy lord's heart has AC 5, 25 hit points, and immunity to all damage except fire."
-									]
-								},
-								{
-									"type": "entries",
-									"name": "A Mummy Lord's Lair",
-									"entries": [
-										"A mummy lord watches over an ancient temple or tomb that is protected by lesser undead and rigged with traps. Hidden in this temple is the sarcophagus where a mummy lord keeps its greatest treasures. A mummy lord encountered in its lair has a challenge rating of 16 (15,000 XP)."
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Mummies",
-									"entries": [
-										"Raised by dark funerary rituals, a mummy shambles from the shrouded stillness of a time-lost temple or tomb. Having been awoken from its rest, it punishes transgressors with the power of its unholy curse.",
-										{
-											"name": "Preserved Wrath",
-											"entries": [
-												"The long burial rituals that accompany a mummy's entombment help protect its body from rot. In the embalming process, the newly dead creature's organs are removed and placed in special jars, and its corpse is treated with preserving oils, herbs, and wrappings. After the body has been prepared, the corpse is typically wrapped in linen bandages.",
-												"More ephemeral or permanent offenses, such as revealing a secret the mummy wished kept or killing an individual the mummy loved, can't be so easily remedied. In such cases, a mummy might slaughter all the creatures responsible and still not sate its wrath."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "The Will of Dark Gods",
-											"entries": [
-												"An undead mummy is created when the priest of a death god or other dark deity ritually imbues a prepared corpse with necromantic magic. The mummy's linen wrappings are inscribed with necromantic markings before the burial ritual concludes with an invocation to darkness. As a mummy endures in undeath, it animates in response to conditions specified by the ritual. Most commonly, a transgression against its tomb, treasures, lands, or former loved ones will cause a mummy to rise."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "The Punished",
-											"entries": [
-												"Once deceased, an individual has no say in whether or not its body is made into a mummy. Some mummies were powerful individuals who displeased a high priest or pharaoh, or who committed crimes of treason, adultery, or murder. As punishment, they were cursed with eternal undeath, embalmed, mummified, and sealed away. Other times, mummies acting as tomb guardians are created from slaves put to death specifically to serve a greater purpose."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Creature of Ritual",
-											"entries": [
-												"A mummy obeys the conditions and parameters laid down by the rituals that created it, driven only to punish transgressors. The overwhelming terror that foreshadows a mummy's attack can leave the intended victim paralyzed with fright. In the days following a mummy's touch, a victim's body rots from the outside in, until nothing but dust remains."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Ending a Mummy's Curse",
-											"entries": [
-												"Rare magic can undo or dispel the ritual that gave rise to a mummy, allowing it to truly die. More commonly, a mummy can be sent back to its endless rest by undoing the transgression that caused it to rise. A sacred idol might be replaced in its niche, a stolen treasure could be returned to its tomb, or a temple might be purified of despoiling bloodshed."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Undead Archives",
-											"entries": [
-												"Though they seldom bother to do so, mummies can speak. As a result, some serve as undead repositories of lost lore, and can be consulted by the descendants of those who created them. Powerful individuals sometimes intentionally sequester mummies away for occasional consultation."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Undead Nature",
-											"entries": [
-												"A mummy doesn't require air, food, drink, or sleep."
-											],
-											"type": "entries"
-										}
-									]
-								}
-							]
-						}
-					]
+			"_copy": {
+				"name": "Mummy",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "appendArr",
+						"items": [
+							{
+								"type": "entries",
+								"name": "Mummy Lord",
+								"entries": [
+									"In the tombs of the ancients, tyrannical monarchs and the high priests of dark gods lie in dreamless rest, waiting for the time when they might reclaim their thrones and reforge their ancient empires. The regalia of their terrible rule still adorns their linen-wrapped bodies, their moldering robes stitched with evil symbols and bronze armor etched with devices of dynasties that fell a thousand years before.",
+									"Under the direction of the most powerful priests, the ritual that creates a mummy can be increased in potency. The mummy lord that rises from such a ritual retains the memories and personality of its former life, and is gifted with supernatural resilience. Dead emperors wield the same infamous rune-marked blades that they did in legend. Sorcerer lords work the forbidden magic that once controlled a terrified populace, and the dark gods reward dead priest-kings' prayers by imparting divine spells.",
+									{
+										"type": "entries",
+										"entries": [
+											{
+												"name": "Heart of the Mummy Lord",
+												"type": "entries",
+												"entries": [
+													"As part of the ritual that creates a mummy lord, the creature's heart and viscera are removed from the corpse and placed in canopic jars. These jars are usually carved from limestone or made of pottery, etched or painted with religious hieroglyphs.",
+													"As long as its shriveled heart remains intact, a mummy lord can't be permanently destroyed. When it drops to 0 hit points, the mummy lord turns to dust and re-forms at full strength 24 hours later, rising out of dust in close proximity to the canopic jar containing its heart. A mummy lord can be destroyed or prevented from re-forming by burning its heart to ashes. For this reason, a mummy lord usually keeps its heart and viscera in a hidden tomb or vault.",
+													"The mummy lord's heart has AC 5, 25 hit points, and immunity to all damage except fire."
+												]
+											}
+										]
+									}
+								]
+							},
+							{
+								"type": "entries",
+								"name": "A Mummy Lord's Lair",
+								"entries": [
+									"A mummy lord watches over an ancient temple or tomb that is protected by lesser undead and rigged with traps. Hidden in this temple is the sarcophagus where a mummy lord keeps its greatest treasures. A mummy lord encountered in its lair has a challenge rating of 16 (15,000 XP)."
+								]
+							}
+						]
+					}
 				}
-			]
+			}
 		},
 		{
 			"name": "Myconid",
@@ -10983,58 +10828,19 @@
 		{
 			"name": "Ochre Jelly",
 			"source": "MM",
-			"entries": [
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								"Ochre jellies are yellowish blobs that can slide under doors and through narrow cracks in pursuit of creatures to devour. They have enough bestial cunning to avoid large groups of enemies.",
-								"An ochre jelly follows at a safe distance as it pursues its meal. Its digestive enzymes dissolve flesh quickly but have no effect on other substances such as bone, wood, and metal.",
-								{
-									"type": "entries",
-									"name": "Oozes",
-									"entries": [
-										"Oozes thrive in the dark, shunning areas of bright light and extreme temperatures. They flow through the damp underground, feeding on any creature or object that can be dissolved, slinking along the ground, dripping from walls and ceilings, spreading across the edges of underground pools, and squeezing through cracks.",
-										"The first warning an adventurer receives of an ooze's presence is often the searing pain of its acidic touch. Oozes are drawn to movement and warmth. Organic material nourishes them, and when prey is scarce they feed on grime, fungus, and offal. Veteran explorers know that an immaculately clean passageway is a likely sign that an ooze lairs nearby.",
-										{
-											"name": "Slow Death",
-											"entries": [
-												"An ooze kills its prey slowly. Some varieties, such as black puddings and gelatinous cubes, engulf creatures to prevent escape. The only upside of this torturous death is that a victim's comrades can come to the rescue before it is too late.",
-												"Since not every ooze digests every type of substance, some have coins, metal gear, bones, and other debris suspended within their quivering bodies. A slain ooze can be a rich source of treasure for its killers.",
-												"Whether this is true or not, the Faceless Lord is one of the few beings that can control oozes and imbue them with a modicum of intelligence. Most of the time, oozes have no sense of tactics or self-preservation. They are direct and predictable, attacking and eating without cunning. Under the control of Juiblex, they exhibit glimmers of sentience and malevolent intent."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Unwitting Servants",
-											"entries": [
-												"Although an ooze lacks the intelligence to ally itself with other creatures, others that understand an ooze's need to feed might lure it into a location where it can be of use to them. Clever monsters keep oozes around to defend passageways or consume refuse. Likewise, an ooze can be enticed into a pit trap, where its captors feed it often enough to prevent it from coming after them. Crafty creatures place torches and flaming braziers in strategic areas to dissuade an ooze from leaving a particular tunnel or room."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Spawn of Juiblex",
-											"entries": [
-												"According to the Demonomicon of Iggwilv and other sources, oozes are scattered fragments or offspring of the demon lord Juiblex."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Ooze Nature",
-											"entries": [
-												"An ooze doesn't require sleep."
-											],
-											"type": "entries"
-										}
-									]
-								}
-							]
-						}
-					]
+			"_copy": {
+				"name": "Oozes",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": [
+							"Ochre jellies are yellowish blobs that can slide under doors and through narrow cracks in pursuit of creatures to devour. They have enough bestial cunning to avoid large groups of enemies.",
+							"An ochre jelly follows at a safe distance as it pursues its meal. Its digestive enzymes dissolve flesh quickly but have no effect on other substances such as bone, wood, and metal."
+						]
+					}
 				}
-			],
+			},
 			"images": [
 				{
 					"type": "image",
@@ -11114,6 +10920,18 @@
 									]
 								}
 							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"Worst. Dancers. Ever."
+									],
+									"by": "Riddlefiddle the Satyr, on ogres"
+								}
+							]
 						}
 					]
 				}
@@ -11169,6 +10987,25 @@
 									"entries": [
 										"Oni are sometimes called ogre mages because of their innate magical ability. Though they are only distantly related to true ogres, they share the ogres' habit of joining forces with other evil creatures. An oni serves a master if doing so proves lucrative or provides it with a luxurious, well-defended home. Oni covet magic, and they work for evil wizards and hags in exchange for useful magic items."
 									]
+								}
+							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"Lock the door, blow out the light;",
+										"The hungry oni haunts the night.",
+										"Hide and tremble, little one;",
+										"The oni wants to have some fun.",
+										"Hear it scratching on the door;",
+										"See its shadow cross the floor.",
+										"The sun won't rise for quite a while;",
+										"Till then, beware the oni's smile."
+									],
+									"by": "Children's rhyme"
 								}
 							]
 						}
@@ -11253,238 +11090,125 @@
 		{
 			"name": "Orc Eye of Gruumsh",
 			"source": "MM",
-			"entries": [
-				{
-					"type": "entries",
-					"entries": [
-						{
+			"_copy": {
+				"name": "Orc",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "appendArr",
+						"items": {
 							"type": "entries",
+							"name": "Orc Eye of Gruumsh",
 							"entries": [
 								"When an orc slays an elf in Gruumsh's name and offers the corpse of its foe as a sacrifice to the god of slaughter, an aspect of the god might appear. This aspect demands an additional sacrifice: one of the orc's eyes, symbolizing the loss Gruumsh suffered at the hands of his greatest enemy, Corellon Larethian.",
-								"If the orc plucks out one of its eyes, Gruumsh might grant the orc spellcasting ability and special favor, along with the right to call itself an Eye of Gruumsh. When not using their auguries to advise their war chiefs, these savage devotees of the god of slaughter hurl themselves into battle, their weapons stained with blood.",
-								{
-									"type": "entries",
-									"name": "Orcs",
-									"entries": [
-										"Orcs are savage raiders and pillagers with stooped postures, low foreheads, and piggish faces with prominent lower canines that resemble tusks.",
-										{
-											"name": "Gruumsh One-Eye",
-											"entries": [
-												"Orcs worship Gruumsh, the mightiest of the orc deities and their creator. The orcs believe that in ancient days, the gods gathered to divide the world among their followers. When Gruumsh claimed the mountains, he learned they had been taken by the dwarves. He laid claim to the forests, but those had been settled by the elves. Each place that Gruumsh wanted had already been claimed. The other gods laughed at Gruumsh, but he responded with a furious bellow. Grasping his mighty spear, he laid waste to the mountains, set the forests aflame, and carved great furrows in the fields. Such was the role of the orcs, he proclaimed, to take and destroy all that the other races would deny them. To this day, the orcs wage an endless war on humans, elves, dwarves, and other folk.",
-												"Orcs hold a particular hatred for elves. The elven god Corellon Larethian half-blinded Gruumsh with a well-placed arrow to the orc god's eye. Since then, the orcs have taken particular joy in slaughtering elves. Turning his injury into a baleful gift, Gruumsh grants divine might to any champion who willingly plucks out one of its eyes in his honor.",
-												{
-													"type": "entries",
-													"name": "Tribes like Plagues",
-													"entries": [
-														"Orcs gather in tribes that exert their dominance and satisfy their bloodlust by plundering villages, devouring or driving off roaming herds, and slaying any humanoids that stand against them. After savaging a settlement, orcs pick it clean of wealth and items usable in their own lands. They set the remains of villages and camps ablaze, then retreat whence they came, their bloodlust satisfied.",
-														"When an existing territory is depleted of food, an orc tribe divides into roving bands that scout for choice hunting grounds. When each party returns, it brings back trophies and news of targets ripe for attack, the richest of which is chosen. The tribe then sets out en masse to carve a bloody path to its new territory.",
-														"On rare occasions, a tribe's leader chooses to hold onto a particularly defensible lair for decades. The orcs of such a tribe must range far across the countryside to sate their appetites.",
-														"Strength and power are the greatest of orcish virtues, and orcs embrace all manner of mighty creatures in their tribes. Rejecting notions of racial purity, they proudly welcome ogres, trolls, half-orcs, and orogs into their ranks. As well, orcs respect and fear the size and power of evil giants, and often serve them as guards and soldiers."
-													]
-												}
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Ranging Scavengers",
-											"entries": [
-												"Their lust for slaughter demands that orcs dwell always within striking distance of new targets. As such, they seldom settle permanently, instead converting ruins, cavern complexes, and defeated foes' villages into fortified camps and strongholds. Orcs build only for defense, making no innovation or improvement to their lairs beyond mounting the severed body parts of their victims on spiked stockade walls or pikes jutting up from moats and trenches."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Leadership and Might",
-											"entries": [
-												"Orc tribes are mostly patriarchal, flaunting such vivid or grotesque titles as Many-Arrows, Screaming Eye, and Elf Ripper. Occasionally, a powerful war chief unites scattered orc tribes into a single rampaging horde, which runs roughshod over other orc tribes and humanoid settlements from a position of overwhelming strength."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Orc Crossbreeds",
-											"entries": [
-												"Luthic, the orc goddess of fertility and wife of Gruumsh, demands that orcs procreate often and indiscriminately so that orc hordes swell generation after generation. The orcs' drive to reproduce runs stronger than any other humanoid race, and they readily crossbreed with other races. When an orc procreates with a non-orc humanoid of similar size and stature (such as a human or a dwarf), the resulting child is either an orc or a half-orc. When an orc produces young with an ogre, the child is a half-ogre of intimidating strength and brutish features called an ogrillon."
-											],
-											"type": "entries"
-										}
-									]
-								}
+								"If the orc plucks out one of its eyes, Gruumsh might grant the orc spellcasting ability and special favor, along with the right to call itself an Eye of Gruumsh. When not using their auguries to advise their war chiefs, these savage devotees of the god of slaughter hurl themselves into battle, their weapons stained with blood."
 							]
 						}
-					]
-				}
-			],
-			"images": [
-				{
-					"type": "image",
-					"href": {
-						"type": "internal",
-						"path": "bestiary/MM/Orc.jpg"
 					}
 				}
-			]
+			}
 		},
 		{
 			"name": "Orc War Chief",
 			"source": "MM",
-			"entries": [
-				{
-					"type": "entries",
-					"entries": [
-						{
+			"_copy": {
+				"name": "Orc",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "appendArr",
+						"items": {
 							"type": "entries",
+							"name": "Orc War Chief",
 							"entries": [
-								"The war chief of an orc tribe is its strongest and most cunning member. The reign of a war chief lasts only as long as it commands the fear and respect of other tribe members, whose bloodlust must be regularly satisfied lest the chief appear weak. Scions of Slaughter. Gruumsh bestows special blessings upon war chiefs who prove themselves in battle time and again, imbuing them with slivers of his savagery. A war chief so blessed finds that his weapons cut deeper into his enemies, allowing him to inflict more carnage.",
-								"King Obould Many-Arrows",
-								"King Obould of the Many-Arrows tribe is a legend among the orc war chiefs of the Forgotten Realms, and he is the most famous orc chief in the history of the D&D game.",
-								"Smarter and more intuitive than most of his kind, Obould slew his chieftain to take control of his tribe. Skilled in the arts of war and renowned for his violent temper, Obould proved himself a fierce opponent in battle time and again. Over the years, he subsumed other orc tribes into his own, until he commanded a horde of thousands.",
-								"Obould leveraged his strength and influence to carve out a kingdom for himself in the Spine of the World, a mountain range overlooking numerous dwarven, human, and elven strongholds.",
-								"After years of bloody conflict with his more civilized neighbors, Obould did the unthinkable and brokered a peace treaty with his enemies. This treaty confused many of the orcs under Obould's command. It was either a clever ploy by Obould to buy time while he strengthened his army for a final, decisive sweep across the Savage Frontier, or it was a troubling sign that Obould had forsaken the ways of Gruumsh and needed to be destroyed.",
 								{
 									"type": "entries",
-									"name": "Orcs",
 									"entries": [
-										"Orcs are savage raiders and pillagers with stooped postures, low foreheads, and piggish faces with prominent lower canines that resemble tusks.",
+										"The war chief of an orc tribe is its strongest and most cunning member. The reign of a war chief lasts only as long as it commands the fear and respect of other tribe members, whose bloodlust must be regularly satisfied lest the chief appear weak.",
 										{
-											"name": "Gruumsh One-Eye",
+											"type": "entries",
+											"name": "Scions of Slaughter",
 											"entries": [
-												"Orcs worship Gruumsh, the mightiest of the orc deities and their creator. The orcs believe that in ancient days, the gods gathered to divide the world among their followers. When Gruumsh claimed the mountains, he learned they had been taken by the dwarves. He laid claim to the forests, but those had been settled by the elves. Each place that Gruumsh wanted had already been claimed. The other gods laughed at Gruumsh, but he responded with a furious bellow. Grasping his mighty spear, he laid waste to the mountains, set the forests aflame, and carved great furrows in the fields. Such was the role of the orcs, he proclaimed, to take and destroy all that the other races would deny them. To this day, the orcs wage an endless war on humans, elves, dwarves, and other folk.",
-												"Orcs hold a particular hatred for elves. The elven god Corellon Larethian half-blinded Gruumsh with a well-placed arrow to the orc god's eye. Since then, the orcs have taken particular joy in slaughtering elves. Turning his injury into a baleful gift, Gruumsh grants divine might to any champion who willingly plucks out one of its eyes in his honor.",
-												{
-													"type": "entries",
-													"name": "Tribes like Plagues",
-													"entries": [
-														"Orcs gather in tribes that exert their dominance and satisfy their bloodlust by plundering villages, devouring or driving off roaming herds, and slaying any humanoids that stand against them. After savaging a settlement, orcs pick it clean of wealth and items usable in their own lands. They set the remains of villages and camps ablaze, then retreat whence they came, their bloodlust satisfied.",
-														"When an existing territory is depleted of food, an orc tribe divides into roving bands that scout for choice hunting grounds. When each party returns, it brings back trophies and news of targets ripe for attack, the richest of which is chosen. The tribe then sets out en masse to carve a bloody path to its new territory.",
-														"On rare occasions, a tribe's leader chooses to hold onto a particularly defensible lair for decades. The orcs of such a tribe must range far across the countryside to sate their appetites.",
-														"Strength and power are the greatest of orcish virtues, and orcs embrace all manner of mighty creatures in their tribes. Rejecting notions of racial purity, they proudly welcome ogres, trolls, half-orcs, and orogs into their ranks. As well, orcs respect and fear the size and power of evil giants, and often serve them as guards and soldiers."
-													]
-												}
-											],
-											"type": "entries"
-										},
+												"Gruumsh bestows special blessings upon war chiefs who prove themselves in battle time and again, imbuing them with slivers of his savagery. A war chief so blessed finds that his weapons cut deeper into his enemies, allowing him to inflict more carnage."
+											]
+										}
+									]
+								},
+								{
+									"type": "inset",
+									"name": "King Obould Many-Arrows",
+									"entries": [
+										"King Obould of the Many-Arrows tribe is a legend among the orc war chiefs of the Forgotten Realms, and he is the most famous orc chief in the history of the D&D game.",
+										"Smarter and more intuitive than most of his kind, Obould slew his chieftain to take control of his tribe. Skilled in the arts of war and renowned for his violent temper, Obould proved himself a fierce opponent in battle time and again. Over the years, he subsumed other orc tribes into his own, until he commanded a horde of thousands.",
+										"Obould leveraged his strength and influence to carve out a kingdom for himself in the Spine of the World, a mountain range overlooking numerous dwarven, human, and elven strongholds.",
+										"After years of bloody conflict with his more civilized neighbors, Obould did the unthinkable and brokered a peace treaty with his enemies. This treaty confused many of the orcs under Obould's command. It was either a clever ploy by Obould to buy time while he strengthened his army for a final, decisive sweep across the Savage Frontier, or it was a troubling sign that Obould had forsaken the ways of Gruumsh and needed to be destroyed."
+									]
+								},
+								{
+									"type": "insetReadaloud",
+									"entries": [
 										{
-											"name": "Ranging Scavengers",
+											"type": "quote",
 											"entries": [
-												"Their lust for slaughter demands that orcs dwell always within striking distance of new targets. As such, they seldom settle permanently, instead converting ruins, cavern complexes, and defeated foes' villages into fortified camps and strongholds. Orcs build only for defense, making no innovation or improvement to their lairs beyond mounting the severed body parts of their victims on spiked stockade walls or pikes jutting up from moats and trenches."
+												"He worked his serrated long knife savagely, tearing out the king's throat to the howls of approval from his legions .The ferocious orc didn't stop there, digging and ripping the blade back and forth unrelentingly until he took the head off the dwarf king's shoulders."
 											],
-											"type": "entries"
-										},
-										{
-											"name": "Leadership and Might",
-											"entries": [
-												"Orc tribes are mostly patriarchal, flaunting such vivid or grotesque titles as Many-Arrows, Screaming Eye, and Elf Ripper. Occasionally, a powerful war chief unites scattered orc tribes into a single rampaging horde, which runs roughshod over other orc tribes and humanoid settlements from a position of overwhelming strength."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Orc Crossbreeds",
-											"entries": [
-												"Luthic, the orc goddess of fertility and wife of Gruumsh, demands that orcs procreate often and indiscriminately so that orc hordes swell generation after generation. The orcs' drive to reproduce runs stronger than any other humanoid race, and they readily crossbreed with other races. When an orc procreates with a non-orc humanoid of similar size and stature (such as a human or a dwarf), the resulting child is either an orc or a half-orc. When an orc produces young with an ogre, the child is a half-ogre of intimidating strength and brutish features called an ogrillon."
-											],
-											"type": "entries"
+											"by": "An account of War Chief Hartusk's brutality in the aftermath of the Battle of the Cold Vale"
 										}
 									]
 								}
 							]
 						}
-					]
-				}
-			],
-			"images": [
-				{
-					"type": "image",
-					"href": {
-						"type": "internal",
-						"path": "bestiary/MM/Orc.jpg"
 					}
 				}
-			]
+			}
 		},
 		{
 			"name": "Orog",
 			"source": "MM",
-			"entries": [
-				{
-					"type": "entries",
-					"entries": [
-						{
+			"_copy": {
+				"name": "Orc",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "appendArr",
+						"items": {
 							"type": "entries",
+							"name": "Orog",
 							"entries": [
-								"Orogs are orcs blessed with a surprisingly keen intellect that ordinary orcs believe is a gift from the orc goddess Luthic. Like Luthic, orogs prefer to live underground, although the scarcity of food often brings them to the surface to hunt. Orcs respect an orog's strength and cunning, and a lone orog might command an orc war band.",
-								{
-									"name": "Stronger and Smarter",
-									"type": "entries",
-									"entries": [
-										"An orog uses its strength to bully other orcs and its intelligence to surprise enemies on the battlefield. Many an overconfident elf, human, or dwarf commander has watched a \"simple\" orc warlord execute a clever maneuver to outflank and destroy an opposing force, not realizing the orc is an orog.",
-										"When encountered in great numbers, orogs form their own detachments within much larger orc hordes, and they are always at the forefront of any attack, relying on their superior strength and tactical insight to overcome anything that stands in their way.",
-										"Few orc tribes actively seek out orogs to bolster their ranks. The orogs' superiority makes them ideal leaders, and thus deadly rivals to orc war chiefs, who must be wary of orog treachery."
-									]
-								},
-								{
-									"name": "Detached Killers",
-									"type": "entries",
-									"entries": [
-										"Wanting nothing more than to hack their enemies to pieces, orogs are a terrifying presence on the battlefield. They form no attachments, even to their parents and siblings, and have no concept of love or dedication. They worship the orc pantheon of gods-Gruumsh and Luthic foremost-because they believe that the gods have strength beyond reason, and physical might is all they respect."
-									]
-								},
-								{
-									"name": "Servants of Darkness",
-									"type": "entries",
-									"entries": [
-										"Mistrusted by orcs, some orogs form independent mercenary war bands that sell themselves to the highest bidder. As long as they are rewarded, orog mercenaries gladly serve as elite warriors and shock troops for evil wizards, depraved giants, and other villains."
-									]
-								},
 								{
 									"type": "entries",
-									"name": "Orcs",
 									"entries": [
-										"Orcs are savage raiders and pillagers with stooped postures, low foreheads, and piggish faces with prominent lower canines that resemble tusks.",
+										"Orogs are orcs blessed with a surprisingly keen intellect that ordinary orcs believe is a gift from the orc goddess Luthic. Like Luthic, orogs prefer to live underground, although the scarcity of food often brings them to the surface to hunt. Orcs respect an orog's strength and cunning, and a lone orog might command an orc war band.",
 										{
-											"name": "Gruumsh One-Eye",
+											"name": "Stronger and Smarter",
+											"type": "entries",
 											"entries": [
-												"Orcs worship Gruumsh, the mightiest of the orc deities and their creator. The orcs believe that in ancient days, the gods gathered to divide the world among their followers. When Gruumsh claimed the mountains, he learned they had been taken by the dwarves. He laid claim to the forests, but those had been settled by the elves. Each place that Gruumsh wanted had already been claimed. The other gods laughed at Gruumsh, but he responded with a furious bellow. Grasping his mighty spear, he laid waste to the mountains, set the forests aflame, and carved great furrows in the fields. Such was the role of the orcs, he proclaimed, to take and destroy all that the other races would deny them. To this day, the orcs wage an endless war on humans, elves, dwarves, and other folk.",
-												"Orcs hold a particular hatred for elves. The elven god Corellon Larethian half-blinded Gruumsh with a well-placed arrow to the orc god's eye. Since then, the orcs have taken particular joy in slaughtering elves. Turning his injury into a baleful gift, Gruumsh grants divine might to any champion who willingly plucks out one of its eyes in his honor.",
-												{
-													"type": "entries",
-													"name": "Tribes like Plagues",
-													"entries": [
-														"Orcs gather in tribes that exert their dominance and satisfy their bloodlust by plundering villages, devouring or driving off roaming herds, and slaying any humanoids that stand against them. After savaging a settlement, orcs pick it clean of wealth and items usable in their own lands. They set the remains of villages and camps ablaze, then retreat whence they came, their bloodlust satisfied.",
-														"When an existing territory is depleted of food, an orc tribe divides into roving bands that scout for choice hunting grounds. When each party returns, it brings back trophies and news of targets ripe for attack, the richest of which is chosen. The tribe then sets out en masse to carve a bloody path to its new territory.",
-														"On rare occasions, a tribe's leader chooses to hold onto a particularly defensible lair for decades. The orcs of such a tribe must range far across the countryside to sate their appetites.",
-														"Strength and power are the greatest of orcish virtues, and orcs embrace all manner of mighty creatures in their tribes. Rejecting notions of racial purity, they proudly welcome ogres, trolls, half-orcs, and orogs into their ranks. As well, orcs respect and fear the size and power of evil giants, and often serve them as guards and soldiers."
-													]
-												}
-											],
-											"type": "entries"
+												"An orog uses its strength to bully other orcs and its intelligence to surprise enemies on the battlefield. Many an overconfident elf, human, or dwarf commander has watched a \"simple\" orc warlord execute a clever maneuver to outflank and destroy an opposing force, not realizing the orc is an orog.",
+												"When encountered in great numbers, orogs form their own detachments within much larger orc hordes, and they are always at the forefront of any attack, relying on their superior strength and tactical insight to overcome anything that stands in their way.",
+												"Few orc tribes actively seek out orogs to bolster their ranks. The orogs' superiority makes them ideal leaders, and thus deadly rivals to orc war chiefs, who must be wary of orog treachery."
+											]
 										},
 										{
-											"name": "Ranging Scavengers",
+											"name": "Detached Killers",
+											"type": "entries",
 											"entries": [
-												"Their lust for slaughter demands that orcs dwell always within striking distance of new targets. As such, they seldom settle permanently, instead converting ruins, cavern complexes, and defeated foes' villages into fortified camps and strongholds. Orcs build only for defense, making no innovation or improvement to their lairs beyond mounting the severed body parts of their victims on spiked stockade walls or pikes jutting up from moats and trenches."
-											],
-											"type": "entries"
+												"Wanting nothing more than to hack their enemies to pieces, orogs are a terrifying presence on the battlefield. They form no attachments, even to their parents and siblings, and have no concept of love or dedication. They worship the orc pantheon of gods-Gruumsh and Luthic foremost-because they believe that the gods have strength beyond reason, and physical might is all they respect."
+											]
 										},
 										{
-											"name": "Leadership and Might",
+											"name": "Servants of Darkness",
+											"type": "entries",
 											"entries": [
-												"Orc tribes are mostly patriarchal, flaunting such vivid or grotesque titles as Many-Arrows, Screaming Eye, and Elf Ripper. Occasionally, a powerful war chief unites scattered orc tribes into a single rampaging horde, which runs roughshod over other orc tribes and humanoid settlements from a position of overwhelming strength."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Orc Crossbreeds",
-											"entries": [
-												"Luthic, the orc goddess of fertility and wife of Gruumsh, demands that orcs procreate often and indiscriminately so that orc hordes swell generation after generation. The orcs' drive to reproduce runs stronger than any other humanoid race, and they readily crossbreed with other races. When an orc procreates with a non-orc humanoid of similar size and stature (such as a human or a dwarf), the resulting child is either an orc or a half-orc. When an orc produces young with an ogre, the child is a half-ogre of intimidating strength and brutish features called an ogrillon."
-											],
-											"type": "entries"
+												"Mistrusted by orcs, some orogs form independent mercenary war bands that sell themselves to the highest bidder. As long as they are rewarded, orog mercenaries gladly serve as elite warriors and shock troops for evil wizards, depraved giants, and other villains."
+											]
 										}
 									]
 								}
 							]
 						}
-					]
+					}
 				}
-			],
+			},
 			"images": [
 				{
 					"type": "image",
@@ -11581,6 +11305,18 @@
 									]
 								}
 							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"The only good thing about owlbears is that the wizard who created them is probably dead."
+									],
+									"by": "Xarshel Ravenshadow, Gnome Professor of Transmutative Science at Morgrave University"
+								}
+							]
 						}
 					]
 				}
@@ -11628,6 +11364,18 @@
 									]
 								}
 							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"Behold, the pegasus. It can outrace a dragon in the open sky, and only the best among us can ever hope to ride one. A fitting emblem for our great house, don't you think?"
+									],
+									"by": "Tyllenvane d'Orien, dragonmarked scion arguing to change the symbol of House Orien from the unicorn to the pegasus"
+								}
+							]
 						}
 					]
 				}
@@ -11643,21 +11391,20 @@
 			]
 		},
 		{
-			"name": "Pentadrone",
+			"name": "Modrons",
 			"source": "MM",
 			"entries": [
 				{
-					"type": "entries",
+					"type": "section",
+					"name": "Modrons",
 					"entries": [
+						"Modrons are beings of absolute law that adhere to a hive-like hierarchy. They inhabit the plane of Mechanus and tend its eternally revolving gears, their existence a clockwork routine of perfect order.",
 						{
 							"type": "entries",
 							"entries": [
-								"Pentadrones oversee Mechanus's worker populace and can improvise in response to new situations.",
 								{
 									"type": "entries",
-									"name": "Modrons",
 									"entries": [
-										"Modrons are beings of absolute law that adhere to a hive-like hierarchy. They inhabit the plane of Mechanus and tend its eternally revolving gears, their existence a clockwork routine of perfect order.",
 										{
 											"name": "Absolute Law and Order",
 											"entries": [
@@ -11697,10 +11444,36 @@
 									]
 								}
 							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"Every 289 years, the entire multiverse goes mad. Like clockwork."
+									],
+									"by": "Kwint Stormbellow, rock gnome adventurer"
+								}
+							]
 						}
 					]
 				}
-			],
+			]
+		},
+		{
+			"name": "Pentadrone",
+			"source": "MM",
+			"_copy": {
+				"name": "Modrons",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": "Pentadrones oversee Mechanus's worker populace and can improvise in response to new situations."
+					}
+				}
+			},
 			"images": [
 				{
 					"type": "image",
@@ -11892,6 +11665,18 @@
 									"entries": [
 										"Unlike their fey cousins, the sprites, pixies abhor weapons and would sooner flee than get into a physical altercation with any enemy."
 									]
+								}
+							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"Petal gowns and acorn caps are so last summer!"
+									],
+									"by": "Rivergleam, pixie fashionista"
 								}
 							]
 						}
@@ -12175,62 +11960,16 @@
 		{
 			"name": "Quadrone",
 			"source": "MM",
-			"entries": [
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								"Astute combatants, quadrones serve as artillery and field officers in the regiments of modron armies.",
-								{
-									"type": "entries",
-									"name": "Modrons",
-									"entries": [
-										"Modrons are beings of absolute law that adhere to a hive-like hierarchy. They inhabit the plane of Mechanus and tend its eternally revolving gears, their existence a clockwork routine of perfect order.",
-										{
-											"name": "Absolute Law and Order",
-											"entries": [
-												"Under the direction of their leader, Primus, modrons increase order in the multiverse in accordance with laws beyond the comprehension of mortal minds. Their own minds are networked in a hierarchal pyramid, in which each modron receives commands from superiors and delegates orders to underlings. A modron carries out commands with total obedience, utmost efficiency, and an absence of morality or ego. Modrons have no sense of self beyond what is necessary to fulfill their duties. They exist as a unified collective, divided by ranks, yet they always refer to themselves collectively. To a modron, there is no \"I,\" but only \"we\" or \"us.\"",
-												{
-													"type": "inset",
-													"name": "Variant: Rogue Modrons",
-													"entries": [
-														"A modron unit sometimes becomes defective, either through natural decay or exposure to chaotic forces. Rogue modrons don't act in accordance with Primus's wishes and directives, breaking laws, disobeying orders, and even engaging in violence. Other modrons hunt down such rogues.",
-														"A rogue modron loses the Axiomatic Mind trait and can have any alignment other than lawful neutral. Otherwise, it has the same statistics as a regular modron of its rank."
-													]
-												}
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Absolute Hierarchy",
-											"entries": [
-												"Modrons communicate only with their own rank and the ranks immediately above and below them. Modrons more than one rank away are either too advanced or too simple to understand."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Cogs of the Great Machine",
-											"entries": [
-												"If a modron is destroyed, its remains disintegrate. A replacement from the next lowest rank then transforms in a flash of light, gaining the physical form of its new rank. The promoted modron is replaced by one of its underlings in the same manner, all the way to the lowest levels of the hierarchy. There, a new modron is created by Primus, with a steady stream of monodrones leaving the Great Modron Cathedral on Mechanus as a result."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "The Great Modron March",
-											"entries": [
-												"When the gears of Mechanus complete seventeen cycles once every 289 years, Primus sends a vast army of modrons across the Outer Planes, ostensibly on a reconnaissance mission. The march is long and dangerous, and only a small number of modrons returns to Mechanus."
-											],
-											"type": "entries"
-										}
-									]
-								}
-							]
-						}
-					]
+			"_copy": {
+				"name": "Modrons",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": "Astute combatants, quadrones serve as artillery and field officers in the regiments of modron armies."
+					}
 				}
-			],
+			},
 			"images": [
 				{
 					"type": "image",
@@ -12480,6 +12219,19 @@
 										"When the rakshasa is reborn, it has all the memories and knowledge of its former life, and it seeks retribution against the one who slew it. If the target has somehow slipped through its grasp, the rakshasa might punish its killer's family, friends, or descendants.",
 										"Like devils, rakshasas killed in the Nine Hells are forever destroyed."
 									]
+								}
+							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"Slay me once, shame on you.",
+										"Slay me twice, shame on me."
+									],
+									"by": "Rakshasa maxim"
 								}
 							]
 						}
@@ -12911,6 +12663,18 @@
 									]
 								}
 							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"Destroyed me hammer and me axe, it did. Put me faith to the test that day, it did."
+									],
+									"by": "Brawn Thunderstones, dwarf paladin of Dumathoin"
+								}
+							]
 						}
 					]
 				}
@@ -12960,6 +12724,18 @@
 										"So intense is sahuagin hatred for the aquatic elves that the sea devils have adapted to combat their ancient foes. A sahuagin born near enough to an aquatic elf community can enter the world as a malenti-a sahuagin that physically resembles an aquatic elf in every way. Sahuagin are prone to mutation, but whether this rare phenomenon is a result of the wars between the sahuagin and the aquatic elves-or whether it preceded or even began the conflict-none can say.",
 										"The sahuagin put the malenti to good use as spies and assassins in aquatic elf cities and the societies of other creatures that pose a threat to sahuagin. The mere shadow of the malenti threat incites paranoia and suspicion among aquatic elves, whose resilience is weakened as the prelude to an actual sahuagin invasion."
 									]
+								}
+							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"TThe village was empty, the seagulls were strangely quiet, and all we could hear was the surge of the sea."
+									],
+									"by": "An account of the aftermath of a sahuagin raid"
 								}
 							]
 						}
@@ -13079,6 +12855,31 @@
 										"Satyrs crave the strongest drink, the most fragrant spices, and the most dizzying dances. A satyr feels starved when it can't indulge itself, and it goes to great lengths to sate its desires. It might kidnap a fine minstrel to hear lovely songs, sneak through a well-defended garden to gaze upon a beautiful lad or lass, or infiltrate a palace to taste the finest food in the land. Satyrs allow no festivity to pass them by. They partake in any holiday they've heard of. Civilizations of the world have enough festivals and holy days among them to justify nonstop celebration.",
 										"Inebriated on drink and pleasure, satyrs give no thought to the consequences of the hedonism they incite in others. They leave such creatures mystified at their own behavior. Such revelers might have to scrounge for excuses to explain their disordered state to parents, employers, family, or friends."
 									]
+								}
+							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"Twixt day and night the spirits goad me on",
+										"They pine for ages past when hearts were pure",
+										"Against all reason now they seem unsure",
+										"They laugh and scream between mine ears anon.",
+										"Now fill my cup not once, not twice, but thrice",
+										"With flag's brim upon my lips I dance",
+										"Let unseen pixies toss their gowns askance",
+										"While I, the Carnal King, indulge my vice.",
+										"With folded boughs, the treants take their leave",
+										"As merry damsels' corsets come undone",
+										"My song doth stir them like a summer breeze",
+										"They fill mine empty cup without reprieve.",
+										"The sun becomes the moon becomes the sun",
+										"I while away the hours as I please."
+									],
+									"by": "Sonnet of a Naughty Satyr"
 								}
 							]
 						}
@@ -13510,28 +13311,16 @@
 		{
 			"name": "Shrieker",
 			"source": "MM",
-			"entries": [
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								"A shrieker is a human-sized mushroom that emits a piercing screech to drive off creatures that disturb it. Other creatures use the fungi as an alarm to signal the approach of prey, and various intelligent races of the Underdark cultivate shriekers on the outskirts of their communities to discourage trespassers.",
-								{
-									"type": "entries",
-									"name": "Fungi",
-									"entries": [
-										"With its sky of jagged stone and perpetual night, the Underdark is home to all manner of fungi. Taking the place of plants in the subterranean realm, fungi are vital to the survival of many underground species, providing nourishment and shelter in the unforgiving darkness.",
-										"Fungi spawn in organic matter, then break that matter down to consume it, feeding on filth and corpses. As they mature, fungi eject spores that drift on the lightest breeze to spawn new fungi.",
-										"Not needing sunlight or warmth to grow, fungi thrive in every corner and crevice of the Underdark. Transformed by the magic that permeates that underground realm, Underdark fungi often develop potent defensive mechanisms or abilities of mimicry and attack. The largest specimens can spread to create vast subterranean forests in which countless creatures live and feed."
-									]
-								}
-							]
-						}
-					]
+			"_copy": {
+				"name": "Fungi",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": "A shrieker is a human-sized mushroom that emits a piercing screech to drive off creatures that disturb it. Other creatures use the fungi as an alarm to signal the approach of prey, and various intelligent races of the Underdark cultivate shriekers on the outskirts of their communities to discourage trespassers."
+					}
 				}
-			],
+			},
 			"images": [
 				{
 					"type": "image",
@@ -14010,21 +13799,58 @@
 		{
 			"name": "Spirit Naga",
 			"source": "MM",
+			"_copy": {
+				"name": "Nagas",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": [
+							"Spirit nagas live in gloom and spitefulness, constantly plotting vengeance against creatures that have wronged them-or that they believe have wronged them. Lairing in dismal caverns and ruins, they devote their time to developing new spells and enslaving the mortals with which they surround themselves. A spirit naga likes to charm its foes, drawing them close so that it can sink its poisonous fangs into their flesh.",
+							{
+								"type": "insetReadaloud",
+								"entries": [
+									{
+										"type": "quote",
+										"entries": [
+											"If you destroy me, I will return, and everyone you care about will suffer for it."
+										],
+										"by": "Explictica Defilus, spirit naga"
+									}
+								]
+							}
+						]
+						
+					}
+				}
+			},
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "internal",
+						"path": "bestiary/MM/Spirit Naga.jpg"
+					}
+				}
+			]
+		},
+		{
+			"name": "Nagas",
+			"source": "MM",
 			"entries": [
 				{
-					"type": "entries",
+					"type": "section",
+					"name": "Nagas",
 					"entries": [
+						"Nagas are intelligent serpents that inhabit the ruins of the past, amassing arcane treasures and knowledge.",
+						"The first nagas were created as immortal guardians by a humanoid race long lost to history. When this race died out, the nagas deemed themselves the rightful inheritors of their masters' treasures and magical lore. Industrious and driven, nagas occasionally venture out from their lairs to track down magic items or rare spellbooks.",
+						"Nagas never feel the ravages of time or succumb to sickness. Even if it is struck down, a naga's immortal spirit reforms in a new body in a matter of days, ready to continue its eternal work.",
 						{
 							"type": "entries",
 							"entries": [
-								"Spirit nagas live in gloom and spitefulness, constantly plotting vengeance against creatures that have wronged them-or that they believe have wronged them. Lairing in dismal caverns and ruins, they devote their time to developing new spells and enslaving the mortals with which they surround themselves. A spirit naga likes to charm its foes, drawing them close so that it can sink its poisonous fangs into their flesh.",
 								{
 									"type": "entries",
-									"name": "Nagas",
 									"entries": [
-										"Nagas are intelligent serpents that inhabit the ruins of the past, amassing arcane treasures and knowledge.",
-										"The first nagas were created as immortal guardians by a humanoid race long lost to history. When this race died out, the nagas deemed themselves the rightful inheritors of their masters' treasures and magical lore. Industrious and driven, nagas occasionally venture out from their lairs to track down magic items or rare spellbooks.",
-										"Nagas never feel the ravages of time or succumb to sickness. Even if it is struck down, a naga's immortal spirit reforms in a new body in a matter of days, ready to continue its eternal work.",
 										{
 											"name": "Benevolent Dictators and Brutal Tyrants",
 											"entries": [
@@ -14051,15 +13877,6 @@
 							]
 						}
 					]
-				}
-			],
-			"images": [
-				{
-					"type": "image",
-					"href": {
-						"type": "internal",
-						"path": "bestiary/MM/Spirit Naga.jpg"
-					}
 				}
 			]
 		},
@@ -14759,54 +14576,16 @@
 		{
 			"name": "Tridrone",
 			"source": "MM",
-			"entries": [
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								"Tridrones are shaped like inverted pyramids. They lead lesser modrons in battle.",
-								{
-									"type": "entries",
-									"name": "Modrons",
-									"entries": [
-										"Modrons are beings of absolute law that adhere to a hive-like hierarchy. They inhabit the plane of Mechanus and tend its eternally revolving gears, their existence a clockwork routine of perfect order.",
-										{
-											"name": "Absolute Law and Order",
-											"entries": [
-												"Under the direction of their leader, Primus, modrons increase order in the multiverse in accordance with laws beyond the comprehension of mortal minds. Their own minds are networked in a hierarchal pyramid, in which each modron receives commands from superiors and delegates orders to underlings. A modron carries out commands with total obedience, utmost efficiency, and an absence of morality or ego. Modrons have no sense of self beyond what is necessary to fulfill their duties. They exist as a unified collective, divided by ranks, yet they always refer to themselves collectively. To a modron, there is no \"I,\" but only \"we\" or \"us.\""
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Absolute Hierarchy",
-											"entries": [
-												"Modrons communicate only with their own rank and the ranks immediately above and below them. Modrons more than one rank away are either too advanced or too simple to understand."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Cogs of the Great Machine",
-											"entries": [
-												"If a modron is destroyed, its remains disintegrate. A replacement from the next lowest rank then transforms in a flash of light, gaining the physical form of its new rank. The promoted modron is replaced by one of its underlings in the same manner, all the way to the lowest levels of the hierarchy. There, a new modron is created by Primus, with a steady stream of monodrones leaving the Great Modron Cathedral on Mechanus as a result."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "The Great Modron March",
-											"entries": [
-												"When the gears of Mechanus complete seventeen cycles once every 289 years, Primus sends a vast army of modrons across the Outer Planes, ostensibly on a reconnaissance mission. The march is long and dangerous, and only a small number of modrons returns to Mechanus."
-											],
-											"type": "entries"
-										}
-									]
-								}
-							]
-						}
-					]
+			"_copy": {
+				"name": "Modrons",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": "Tridrones are shaped like inverted pyramids. They lead lesser modrons in battle."
+					}
 				}
-			],
+			},
 			"images": [
 				{
 					"type": "image",
@@ -15359,28 +15138,16 @@
 		{
 			"name": "Violet Fungus",
 			"source": "MM",
-			"entries": [
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								"This purplish mushroom uses root-like feelers growing from its base to creep across cavern floors. The four stalks protruding from a violet fungi's central mass are used to lash out at prey, rotting flesh with the slightest touch. Any creature killed by a violet fungus decomposes rapidly. A new violet fungus sprouts from the moldering corpse, growing to full size in {@dice 2d6} days.",
-								{
-									"type": "entries",
-									"name": "Fungi",
-									"entries": [
-										"With its sky of jagged stone and perpetual night, the Underdark is home to all manner of fungi. Taking the place of plants in the subterranean realm, fungi are vital to the survival of many underground species, providing nourishment and shelter in the unforgiving darkness.",
-										"Fungi spawn in organic matter, then break that matter down to consume it, feeding on filth and corpses. As they mature, fungi eject spores that drift on the lightest breeze to spawn new fungi.",
-										"Not needing sunlight or warmth to grow, fungi thrive in every corner and crevice of the Underdark. Transformed by the magic that permeates that underground realm, Underdark fungi often develop potent defensive mechanisms or abilities of mimicry and attack. The largest specimens can spread to create vast subterranean forests in which countless creatures live and feed."
-									]
-								}
-							]
-						}
-					]
+			"_copy": {
+				"name": "Fungi",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": "This purplish mushroom uses root-like feelers growing from its base to creep across cavern floors. The four stalks protruding from a violet fungi's central mass are used to lash out at prey, rotting flesh with the slightest touch. Any creature killed by a violet fungus decomposes rapidly. A new violet fungus sprouts from the moldering corpse, growing to full size in {@dice 2d6} days."
+					}
 				}
-			],
+			},
 			"images": [
 				{
 					"type": "image",
@@ -15684,6 +15451,18 @@
 									"entries": [
 										"A werewolf is a savage predator. In its humanoid form, a werewolf has heightened senses, a fiery temper, and a tendency to eat rare meat. Its wolf form is a fearsome predator, but its hybrid form is more terrifying by far-a furred and well-muscled humanoid body topped by a ravening wolf's head. A werewolf can wield weapons in hybrid form, though it prefers to tear foes apart with its powerful claws and bite.",
 										"Most werewolves flee civilized lands not long after becoming afflicted. Those that reject the curse fear what will happen if they remain among their friends and family. Those that embrace the curse fear discovery and the consequences of their murderous acts. In the wild, werewolves form packs that also include wolves and dire wolves."
+									]
+								},
+								{
+									"type": "insetReadaloud",
+									"entries": [
+										{
+											"type": "quote",
+											"entries": [
+												"The Company of the Black Moon\u2014they used to be adventurers loyal to the realm. Now they roam the woods as a pack of werewolves. The king has promised estates, titles, and gold to anyone who can undo the curse afflicting them. I, for one, have no interest in such rewards."
+											],
+											"by": "Thornstaff, elf druid"
+										}
 									]
 								}
 							]

--- a/data/bestiary/fluff-bestiary-mm.json
+++ b/data/bestiary/fluff-bestiary-mm.json
@@ -87,16 +87,28 @@
 										"The aboleths' fall from power is written in stark clarity on their flawless memories, for aboleths never truly die. If an aboleth's body is destroyed, its spirit returns to the Elemental Plane of Water, where a new body coalesces for it over days or months.",
 										"Ultimately, aboleths dream of overthrowing the gods and regaining control of the world. Aboleths have had untold eons to plot and to prepare their plans for perfect execution."
 									]
-								},
-								{
-									"type": "entries",
-									"name": "An Aboleth's Lair",
-									"entries": [
-										"Aboleths lair in subterranean lakes or the rocky depths of the ocean, often surrounded by the ruins of an ancient, fallen aboleth city. An aboleth spends most of its existence underwater, surfacing occasionally to treat with visitors or deranged worshipers."
-									]
 								}
 							]
 						}
+					]
+				},
+				{
+					"type": "insetReadaloud",
+					"entries": [
+						{
+							"type": "quote",
+							"entries": [
+								"Could it be that the aboleths are older than the gods... that before the divine ones came to be, such horrors shaped the multiverse? Now there's a chilling thought."
+							],
+							"by": "Vaqir Zekh'r, githzerai philosopher and author of {@style The Far Realm: Real Yet Unreal|small-caps}"
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"name": "An Aboleth's Lair",
+					"entries": [
+						"Aboleths lair in subterranean lakes or the rocky depths of the ocean, often surrounded by the ruins of an ancient, fallen aboleth city. An aboleth spends most of its existence underwater, surfacing occasionally to treat with visitors or deranged worshipers."
 					]
 				}
 			],
@@ -580,34 +592,19 @@
 		{
 			"name": "Animated Armor",
 			"source": "MM",
-			"entries": [
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								"Animated objects are crafted with potent magic to follow the commands of their creators. When not commanded, they follow the last order they received to the best of their ability, and can act independently to fulfill simple instructions. Some animated objects (including many of those created in the Feywild) might converse fluently or adopt a persona, but most are simple automatons.",
-								{
-									"name": "Constructed Nature",
-									"type": "entries",
-									"entries": [
-										"An animated object doesn't require air, food, drink, or sleep. The magic that animates an object is dispelled when the construct drops to 0 hit points. An animated object reduced to 0 hit points becomes inanimate and is too damaged to be of much use or value to anyone."
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Animated Armor",
-									"entries": [
-										"This empty steel shell clamors as it moves, heavy plates banging and grinding against one another like the vengeful spirit of a fallen knight. Ponderous but persistent, this magical guardian is almost always a suit of plate armor.",
-										"To add to its menace, animated armor is frequently enchanted with scripted speech, so the armor can utter warnings, demand passwords, or deliver riddles. Rare suits of animated armor are able to carry on an actual conversation."
-									]
-								}
-							]
-						}
-					]
+			"_copy": {
+				"name": "Animated Objects",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": [
+							"This empty steel shell clamors as it moves, heavy plates banging and grinding against one another like the vengeful spirit of a fallen knight. Ponderous but persistent, this magical guardian is almost always a suit of plate armor.",
+							"To add to its menace, animated armor is frequently enchanted with scripted speech, so the armor can utter warnings, demand passwords, or deliver riddles. Rare suits of animated armor are able to carry on an actual conversation."
+						]
+					}
 				}
-			],
+			},
 			"images": [
 				{
 					"type": "image",
@@ -886,6 +883,18 @@
 									]
 								}
 							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"Give me a hundred azer slaves, and I can forge an empire that would make the gods tremble."
+									],
+									"by": "Arakses al-Saqar, efreeti pasha"
+								}
+							]
 						}
 					]
 				}
@@ -1146,6 +1155,18 @@
 									]
 								}
 							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"No one carves statues of frightened warriors. If you see one, keep your eyes closed and your ears open."
+									],
+									"by": "X the Mystic's 4th rule of dungeon survival"
+								}
+							]
 						}
 					]
 				}
@@ -1237,6 +1258,18 @@
 									]
 								}
 							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"I've already eaten three giant bats, six troglodytes, and a mind flayer today, but that's okay. Plenty of room in my belly for you and your friends."
+									],
+									"by": "Lludd the behir, confronting adventurers in the Lost Caverns of Tsojcanth"
+								}
+							]
 						}
 					]
 				}
@@ -1285,16 +1318,28 @@
 										"Because they refuse to share territory with others, most beholders withdraw to frigid hills, abandoned ruins, and deep caverns to scheme. A beholder's lair is carved out by its disintegration eye ray, emphasizing vertical passages connecting chambers stacked on top of each other. Such an environment allows a beholder to move freely, even as it prevents intruders from easily creeping about. When intruders do break in, the height of its open ceilings allows a beholder to float up and harry foes on the floor.",
 										"As alien as their creator, the rooms in a beholder's lair reflect the creature's arrogance. It festoons its chambers with trophies from the battles it has won, including {@condition petrified} adventurers standing frozen in their horrified final moments, pieces of other beholders, and magic items wrested from powerful foes. A beholder judges its own worth by its acquisitions, and it never willingly parts with its treasures."
 									]
-								},
-								{
-									"type": "entries",
-									"name": "A Beholder's Lair",
-									"entries": [
-										"A beholder's central lair is typically a large, spacious cavern with high ceilings, where it can attack without fear of closing to melee range. A beholder encountered in its lair has a challenge rating of 14 (11,500 XP)."
-									]
 								}
 							]
 						}
+					]
+				},
+				{
+					"type": "insetReadaloud",
+					"entries": [
+						{
+							"type": "quote",
+							"entries": [
+								"Every beholder thinks it is the epitome of beholderkind, and the only thing it fears is that it might be wrong."
+							],
+							"by": "Valkara Ironfeel, dwarf sage"
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"name": "A Beholder's Lair",
+					"entries": [
+						"A beholder's central lair is typically a large, spacious cavern with high ceilings, where it can attack without fear of closing to melee range. A beholder encountered in its lair has a challenge rating of 14 (11,500 XP)."
 					]
 				}
 			],
@@ -1351,51 +1396,53 @@
 				"_mod": {
 					"entries": {
 						"mode": "prependArr",
-						"items": {
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"entries": [
-										"The most evil-tempered and vile of the chromatic dragons, black dragons collect the wreckage and treasures of fallen peoples. These dragons loathe seeing the weak prosper and revel in the collapse of humanoid kingdoms. They make their homes in fetid swamps and crumbling ruins where kingdoms once stood.",
-										"With deep-socketed eyes and broad nasal openings, a black dragon's face resembles a skull. Its curving, segmented horns are bone-colored near the base and darken to dead black at the tips. As a black dragon ages, the flesh around its horns and cheekbones deteriorates as though eaten by acid, leaving thin layers of hide that enhance its skeletal appearance. A black dragon's head is marked by spikes and horns. Its tongue is flat with a forked tip, drooling slime whose acidic scent adds to the dragon's reek of rotting vegetation and foul water.",
-										"When it hatches, a black dragon has glossy black scale. As it ages, its scales become thicker and duller, helping it blend in to the marshes and blasted ruins that are its home.",
-										{
-											"name": "Brutal and Cruel",
-											"type": "entries",
-											"entries": [
-												"All chromatic dragons are evil, but black dragons stand apart for their sadistic nature. A black dragon lives to watch its prey beg for mercy, and will often offer the illusion of respite or escape before finishing off its enemies.",
-												"A black dragon strikes at its weakest enemies first, ensuring a quick and brutal victory, which bolsters its ego as it terrifies its remaining foes. On the verge of defeat, a black dragon does anything it can to save itself, but it accepts death before allowing any other creature to claim mastery over it."
-											]
-										},
-										{
-											"name": "Foes and Servants",
-											"type": "entries",
-											"entries": [
-												"Black dragons hate and fear other dragons. They spy on draconic rivals from afar, looking for opportunities to slay weaker dragons and avoid stronger ones. If a stronger dragon threatens it, a black dragon abandons its lair and seeks out new territory.",
-												"Evil lizardfolk venerate and serve black dragons, raiding humanoid settlements for treasure and food to give as tribute and building crude draconic effigies along the borders of their dragon master's domain.",
-												"A black dragon's malevolent influence might also cause the spontaneous creation of evil shambling mounds that seek out and slay good creatures approaching the dragon's lair.",
-												"Kobolds infest the lairs of many black dragons like vermin. They become as cruel as their dark masters, often torturing and weakening captives with centipede bites and scorpion stings before delivering them to sate the dragon's hunger."
-											]
-										},
-										{
-											"name": "Wealth of the Ancients",
-											"type": "entries",
-											"entries": [
-												"Black dragons hoard the treasures and magic items of crumbled empires and conquered kingdoms to remind themselves of their greatness. The more civilizations a dragon outlasts, the more entitled it feels to claim the wealth of current civilizations for itself."
-											]
-										},
-										{
-											"type": "entries",
-											"name": "A Black Dragon's Lair",
-											"entries": [
-												"Black dragons dwell in swamps on the frayed edges of civilization. A black dragon's lair is a dismal cave, grotto, or ruin that is at least partially flooded, providing pools where the dragon rests, and where its victims can ferment. The lair is littered with the acid-pitted bones of previous victims and the fly-ridden carcasses of fresh kills, watched over by crumbling statues. Centipedes, scorpions, and snakes infest the lair, which is filled with the stench of death and decay."
-											]
-										}
-									]
-								}
-							]
-						}
+						"items": [
+							{
+								"type": "entries",
+								"entries": [
+									{
+										"type": "entries",
+										"entries": [
+											"The most evil-tempered and vile of the chromatic dragons, black dragons collect the wreckage and treasures of fallen peoples. These dragons loathe seeing the weak prosper and revel in the collapse of humanoid kingdoms. They make their homes in fetid swamps and crumbling ruins where kingdoms once stood.",
+											"With deep-socketed eyes and broad nasal openings, a black dragon's face resembles a skull. Its curving, segmented horns are bone-colored near the base and darken to dead black at the tips. As a black dragon ages, the flesh around its horns and cheekbones deteriorates as though eaten by acid, leaving thin layers of hide that enhance its skeletal appearance. A black dragon's head is marked by spikes and horns. Its tongue is flat with a forked tip, drooling slime whose acidic scent adds to the dragon's reek of rotting vegetation and foul water.",
+											"When it hatches, a black dragon has glossy black scale. As it ages, its scales become thicker and duller, helping it blend in to the marshes and blasted ruins that are its home.",
+											{
+												"name": "Brutal and Cruel",
+												"type": "entries",
+												"entries": [
+													"All chromatic dragons are evil, but black dragons stand apart for their sadistic nature. A black dragon lives to watch its prey beg for mercy, and will often offer the illusion of respite or escape before finishing off its enemies.",
+													"A black dragon strikes at its weakest enemies first, ensuring a quick and brutal victory, which bolsters its ego as it terrifies its remaining foes. On the verge of defeat, a black dragon does anything it can to save itself, but it accepts death before allowing any other creature to claim mastery over it."
+												]
+											},
+											{
+												"name": "Foes and Servants",
+												"type": "entries",
+												"entries": [
+													"Black dragons hate and fear other dragons. They spy on draconic rivals from afar, looking for opportunities to slay weaker dragons and avoid stronger ones. If a stronger dragon threatens it, a black dragon abandons its lair and seeks out new territory.",
+													"Evil lizardfolk venerate and serve black dragons, raiding humanoid settlements for treasure and food to give as tribute and building crude draconic effigies along the borders of their dragon master's domain.",
+													"A black dragon's malevolent influence might also cause the spontaneous creation of evil shambling mounds that seek out and slay good creatures approaching the dragon's lair.",
+													"Kobolds infest the lairs of many black dragons like vermin. They become as cruel as their dark masters, often torturing and weakening captives with centipede bites and scorpion stings before delivering them to sate the dragon's hunger."
+												]
+											},
+											{
+												"name": "Wealth of the Ancients",
+												"type": "entries",
+												"entries": [
+													"Black dragons hoard the treasures and magic items of crumbled empires and conquered kingdoms to remind themselves of their greatness. The more civilizations a dragon outlasts, the more entitled it feels to claim the wealth of current civilizations for itself."
+												]
+											}
+										]
+									}
+								]
+							},
+							{
+								"type": "entries",
+								"name": "A Black Dragon's Lair",
+								"entries": [
+									"Black dragons dwell in swamps on the frayed edges of civilization. A black dragon's lair is a dismal cave, grotto, or ruin that is at least partially flooded, providing pools where the dragon rests, and where its victims can ferment. The lair is littered with the acid-pitted bones of previous victims and the fly-ridden carcasses of fresh kills, watched over by crumbling statues. Centipedes, scorpions, and snakes infest the lair, which is filled with the stench of death and decay."
+								]
+							}
+						]
 					},
 					"images": {
 						"mode": "prependArr",
@@ -1559,60 +1606,62 @@
 				"_mod": {
 					"entries": {
 						"mode": "prependArr",
-						"items": {
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"entries": [
-										"Vain and territorial, blue dragons soar through the skies over deserts, preying on caravans and plundering herds and settlements in the verdant lands beyond the desert's reach. These dragons can also be found in dry steppes, searing badlands, and rocky coasts. They guard their territories against all potential competitors, especially brass dragons.",
-										"A blue dragon is recognized by its dramatic frilled ears and the massive ridged horn atop its blunt head. Rows of spikes extend back from its nostrils to line its brow, and cluster on its jutting lower jaw.",
-										"A blue dragon's scales vary in color from an iridescent azure to a deep indigo, polished to a glossy finish by the desert sands. As the dragon ages, its scales become thicker and harder, and its hide hums and crackles with static electricity. These effects intensify when the dragon is angry or about to attack, giving off an odor of ozone and dusty air.",
-										{
-											"name": "Vain and Deadly",
-											"type": "entries",
-											"entries": [
-												"A blue dragon will not stand for any remark or insinuation that it is weak or inferior, taking great pleasure in lording its power over humanoids and other lesser creatures.",
-												"A blue dragon is a patient and methodical combatant. When fighting on its own terms, it turns combat into an extended affair of hours or even days, attacking from a distance with volleys of lightning, then flying well out of harm's reach as it waits to attack again."
-											]
-										},
-										{
-											"name": "Desert Predators",
-											"type": "entries",
-											"entries": [
-												"Though they sometimes eat cacti and other desert plants to sate their great hunger, blue dragons are carnivores. They prefer to dine on herd animals, cooking those creatures with their lightning breath before gorging themselves. Their dining habits make blue dragons an enormous threat to desert caravans and nomadic tribes, which become convenient collections of food and treasure to a dragon's eye.",
-												"When it hunts, a blue dragon buries itself in the desert sand so that only the horn on its nose pokes above the surface, appearing to be an outcropping of stone. When prey draws near, the dragon rises up, sand pouring from its wings like an avalanche as it attacks."
-											]
-										},
-										{
-											"name": "Overlords and Minions",
-											"type": "entries",
-											"entries": [
-												"Blue dragons covet valuable and talented creatures whose service reinforces their sense of superiority. Bards, sages, artists, wizards, and assassins can become valuable agents for a blue dragon, which rewards loyal service handsomely.",
-												"A blue dragon keeps its lair secret and well protected, and even its most trusted servants are rarely allowed within. It encourages ankhegs, giant scorpions, and other creatures of the desert to dwell near its lair for additional security. Older blue dragons sometimes attract air elementals and other creatures to serve them."
-											]
-										},
-										{
-											"name": "Hoarders of Gems",
-											"type": "entries",
-											"entries": [
-												"Though blue dragons collect anything that looks valuable, they are especially fond of gems. Considering blue to be the most noble and beautiful of colors, they covet sapphires, favoring jewelery and magic items adorned with those gems.",
-												"A blue dragon buries its most valuable treasures deep in the sand, while scattering a few less valuable trinkets in plainer sight over hidden sinkholes to punish and eliminate would-be thieves."
-											]
-										},
-										{
-											"type": "entries",
-											"name": "A Blue Dragon's Lair",
-											"entries": [
-												"Blue dragons make their lairs in barren places, using their lightning breath and their burrowing ability to carve out crystallized caverns and tunnels beneath the sands.",
-												"Thunderstorms rage around a legendary blue dragon's lair, and narrow tubes lined with glassy sand ventilate the lair, all the while avoiding the deadly sinkholes that are the dragon's first line of defense.",
-												"A blue dragon will collapse the caverns that make up its lair if that lair is invaded. The dragon then burrows out, leaving its attackers to be crushed and suffocated. When it returns later, it collects its possessions-along with the wealth of the dead intruders."
-											]
-										}
-									]
-								}
-							]
-						}
+						"items": [
+							{
+								"type": "entries",
+								"entries": [
+									{
+										"type": "entries",
+										"entries": [
+											"Vain and territorial, blue dragons soar through the skies over deserts, preying on caravans and plundering herds and settlements in the verdant lands beyond the desert's reach. These dragons can also be found in dry steppes, searing badlands, and rocky coasts. They guard their territories against all potential competitors, especially brass dragons.",
+											"A blue dragon is recognized by its dramatic frilled ears and the massive ridged horn atop its blunt head. Rows of spikes extend back from its nostrils to line its brow, and cluster on its jutting lower jaw.",
+											"A blue dragon's scales vary in color from an iridescent azure to a deep indigo, polished to a glossy finish by the desert sands. As the dragon ages, its scales become thicker and harder, and its hide hums and crackles with static electricity. These effects intensify when the dragon is angry or about to attack, giving off an odor of ozone and dusty air.",
+											{
+												"name": "Vain and Deadly",
+												"type": "entries",
+												"entries": [
+													"A blue dragon will not stand for any remark or insinuation that it is weak or inferior, taking great pleasure in lording its power over humanoids and other lesser creatures.",
+													"A blue dragon is a patient and methodical combatant. When fighting on its own terms, it turns combat into an extended affair of hours or even days, attacking from a distance with volleys of lightning, then flying well out of harm's reach as it waits to attack again."
+												]
+											},
+											{
+												"name": "Desert Predators",
+												"type": "entries",
+												"entries": [
+													"Though they sometimes eat cacti and other desert plants to sate their great hunger, blue dragons are carnivores. They prefer to dine on herd animals, cooking those creatures with their lightning breath before gorging themselves. Their dining habits make blue dragons an enormous threat to desert caravans and nomadic tribes, which become convenient collections of food and treasure to a dragon's eye.",
+													"When it hunts, a blue dragon buries itself in the desert sand so that only the horn on its nose pokes above the surface, appearing to be an outcropping of stone. When prey draws near, the dragon rises up, sand pouring from its wings like an avalanche as it attacks."
+												]
+											},
+											{
+												"name": "Overlords and Minions",
+												"type": "entries",
+												"entries": [
+													"Blue dragons covet valuable and talented creatures whose service reinforces their sense of superiority. Bards, sages, artists, wizards, and assassins can become valuable agents for a blue dragon, which rewards loyal service handsomely.",
+													"A blue dragon keeps its lair secret and well protected, and even its most trusted servants are rarely allowed within. It encourages ankhegs, giant scorpions, and other creatures of the desert to dwell near its lair for additional security. Older blue dragons sometimes attract air elementals and other creatures to serve them."
+												]
+											},
+											{
+												"name": "Hoarders of Gems",
+												"type": "entries",
+												"entries": [
+													"Though blue dragons collect anything that looks valuable, they are especially fond of gems. Considering blue to be the most noble and beautiful of colors, they covet sapphires, favoring jewelery and magic items adorned with those gems.",
+													"A blue dragon buries its most valuable treasures deep in the sand, while scattering a few less valuable trinkets in plainer sight over hidden sinkholes to punish and eliminate would-be thieves."
+												]
+											}
+										]
+									}
+								]
+							},
+							{
+								"type": "entries",
+								"name": "A Blue Dragon's Lair",
+								"entries": [
+									"Blue dragons make their lairs in barren places, using their lightning breath and their burrowing ability to carve out crystallized caverns and tunnels beneath the sands.",
+									"Thunderstorms rage around a legendary blue dragon's lair, and narrow tubes lined with glassy sand ventilate the lair, all the while avoiding the deadly sinkholes that are the dragon's first line of defense.",
+									"A blue dragon will collapse the caverns that make up its lair if that lair is invaded. The dragon then burrows out, leaving its attackers to be crushed and suffocated. When it returns later, it collects its possessions-along with the wealth of the dead intruders."
+								]
+							}
+						]
 					},
 					"images": {
 						"mode": "prependArr",
@@ -1761,41 +1810,43 @@
 				"_mod": {
 					"entries": {
 						"mode": "prependArr",
-						"items": {
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"entries": [
-										"The most gregarious of the true dragons, brass dragons crave conversation, sunlight, and hot, dry climates.",
-										"A brass dragon's head is defined by the broad protective plate that expands from its forehead and the spikes protruding from its chin. A frill runs the length of its neck, and its tapering wings extend down the length of its tail. A brass dragon wyrmling's scales are a dull, mottled brown. As it ages, the dragon's scales begin to shine, eventually taking on a warm, burnished luster. Its wings and frills are mottled green toward the edges, darkening with age. As a brass dragon grows older, its pupils fade until its eyes resemble molten metal orbs.",
-										{
-											"name": "Boldly Talkative",
-											"type": "entries",
-											"entries": [
-												"A brass dragon engages in conversations with thousands of creatures throughout its long life, accumulating useful information which it will gladly share for gifts of treasure. If an intelligent creature tries to leave a brass dragon's presence without engaging in conversation, the dragon follows it. If the creature attempts to escape by magic or force, the dragon might respond with a fit of pique, using its sleep gas to incapacitate the creature. When it wakes, the creature finds itself pinned to the ground by giant claws or buried up to its neck in the sand while the dragon's thirst for small talk is slaked.",
-												"A brass dragon is trusting of creatures that appear to enjoy conversation as much as it does, but is smart enough to know when it is being manipulated. When that happens, the dragon often responds in kind, treating a bout of mutual trickery as a game."
-											]
-										},
-										{
-											"name": "Prized Treasures",
-											"type": "entries",
-											"entries": [
-												"Brass dragons covet magic items that allow them to converse with interesting personalities. An intelligent telepathic weapon or a magic lamp with a djinni bound inside it are among the greatest treasures a brass dragon can possess.",
-												"Brass dragons conceal their hoards under mounds of sand or in secret places far from their primary lairs. They have no trouble remembering where their treasure is buried, and therefore have no need for maps. Adventurers and wanderers should be wary if they happen across a chest hidden in an oasis or a treasure cache tucked away in a half-buried desert ruin, for these might be parts of a brass dragon's hoard."
-											]
-										},
-										{
-											"type": "entries",
-											"name": "A Brass Dragon's Lair",
-											"entries": [
-												"A brass dragon's desert lair is typically a ruin, canyon, or cave network with ceiling holes to allow for sunlight."
-											]
-										}
-									]
-								}
-							]
-						}
+						"items": [
+							{
+								"type": "entries",
+								"entries": [
+									{
+										"type": "entries",
+										"entries": [
+											"The most gregarious of the true dragons, brass dragons crave conversation, sunlight, and hot, dry climates.",
+											"A brass dragon's head is defined by the broad protective plate that expands from its forehead and the spikes protruding from its chin. A frill runs the length of its neck, and its tapering wings extend down the length of its tail. A brass dragon wyrmling's scales are a dull, mottled brown. As it ages, the dragon's scales begin to shine, eventually taking on a warm, burnished luster. Its wings and frills are mottled green toward the edges, darkening with age. As a brass dragon grows older, its pupils fade until its eyes resemble molten metal orbs.",
+											{
+												"name": "Boldly Talkative",
+												"type": "entries",
+												"entries": [
+													"A brass dragon engages in conversations with thousands of creatures throughout its long life, accumulating useful information which it will gladly share for gifts of treasure. If an intelligent creature tries to leave a brass dragon's presence without engaging in conversation, the dragon follows it. If the creature attempts to escape by magic or force, the dragon might respond with a fit of pique, using its sleep gas to incapacitate the creature. When it wakes, the creature finds itself pinned to the ground by giant claws or buried up to its neck in the sand while the dragon's thirst for small talk is slaked.",
+													"A brass dragon is trusting of creatures that appear to enjoy conversation as much as it does, but is smart enough to know when it is being manipulated. When that happens, the dragon often responds in kind, treating a bout of mutual trickery as a game."
+												]
+											},
+											{
+												"name": "Prized Treasures",
+												"type": "entries",
+												"entries": [
+													"Brass dragons covet magic items that allow them to converse with interesting personalities. An intelligent telepathic weapon or a magic lamp with a djinni bound inside it are among the greatest treasures a brass dragon can possess.",
+													"Brass dragons conceal their hoards under mounds of sand or in secret places far from their primary lairs. They have no trouble remembering where their treasure is buried, and therefore have no need for maps. Adventurers and wanderers should be wary if they happen across a chest hidden in an oasis or a treasure cache tucked away in a half-buried desert ruin, for these might be parts of a brass dragon's hoard."
+												]
+											}
+										]
+									}
+								]
+							},
+							{
+								"type": "entries",
+								"name": "A Brass Dragon's Lair",
+								"entries": [
+									"A brass dragon's desert lair is typically a ruin, canyon, or cave network with ceiling holes to allow for sunlight."
+								]
+							}
+						]
 					},
 					"images": {
 						"mode": "prependArr",
@@ -1827,46 +1878,53 @@
 				"_mod": {
 					"entries": {
 						"mode": "prependArr",
-						"items": {
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"entries": [
-										"Bronze dragons are coastal dwellers that feed primarily on aquatic plants and fish. They take the forms of friendly animals to observe other creatures of interest. They are also fascinated by warfare and eagerly join armies fighting for a just cause.",
-										"A ribbed and fluted crest defines the shape of a bronze dragon's head. Curving horns extend out from the crest, echoed by spines on its lower jaw and chin. To help them swim, bronze dragons have webbed feet and smooth scales. A bronze wyrmling's scales are yellow tinged with green; only as the dragon approaches adulthood does its color deepen to a darker, rich bronze tone. The pupils of a bronze dragon's eyes fade as the dragon ages, until they resemble glowing green orbs.",
-										{
-											"name": "Dragons of the Coast",
-											"type": "entries",
-											"entries": [
-												"Bronze dragons love to watch ships traveling up and down the coastlines near their lairs, sometimes taking the forms of dolphins or seagulls to inspect those ships and their crews more closely. A daring bronze dragon might slip aboard a ship in the guise of a bird or rat, inspecting the hold for treasure. If the dragon finds a worthy addition to its hoard, it barters with the ship's captain for the item."
-											]
-										},
-										{
-											"name": "War Machines",
-											"type": "entries",
-											"entries": [
-												"Bronze dragons actively oppose tyranny, and many bronze dragons yearn to test their mettle by putting their size and strength to good use. When a conflict unfolds near its lair, a bronze dragon ascertains the underlying cause, then offers its services to any side that fights for good. Once a bronze dragon commits to a cause, it remains a staunch ally.",
-												{
-													"name": "Well-Organized Wealth",
-													"entries": [
-														"Bronze dragons loot sunken ships and also collect colorful coral and pearls from the reefs and seabeds near their lairs. When a bronze dragon pledges to help an army wage war against tyranny, it asks for nominal payment. If such a request is beyond its allies' means, it might settle for a collection of old books on military history or a ceremonial item commemorating the alliance. A bronze dragon might also lay claim to a treasure held by the enemy that it feels would be safer under its protection."
-													],
-													"type": "entries"
-												}
-											]
-										},
-										{
-											"type": "entries",
-											"name": "A Bronze Dragon's Lair",
-											"entries": [
-												"A bronze dragon lairs in coastal caves. It might salvage a wrecked ship, reconstruct it within the confines of its lair, and use it as a treasure vault or nest for its eggs."
-											]
-										}
-									]
-								}
-							]
-						}
+						"items": [
+							{
+								"type": "entries",
+								"entries": [
+									{
+										"type": "entries",
+										"entries": [
+											"Bronze dragons are coastal dwellers that feed primarily on aquatic plants and fish. They take the forms of friendly animals to observe other creatures of interest. They are also fascinated by warfare and eagerly join armies fighting for a just cause.",
+											"A ribbed and fluted crest defines the shape of a bronze dragon's head. Curving horns extend out from the crest, echoed by spines on its lower jaw and chin. To help them swim, bronze dragons have webbed feet and smooth scales. A bronze wyrmling's scales are yellow tinged with green; only as the dragon approaches adulthood does its color deepen to a darker, rich bronze tone. The pupils of a bronze dragon's eyes fade as the dragon ages, until they resemble glowing green orbs.",
+											{
+												"type": "entries",
+												"entries": [
+													{
+														"name": "Dragons of the Coast",
+														"type": "entries",
+														"entries": [
+															"Bronze dragons love to watch ships traveling up and down the coastlines near their lairs, sometimes taking the forms of dolphins or seagulls to inspect those ships and their crews more closely. A daring bronze dragon might slip aboard a ship in the guise of a bird or rat, inspecting the hold for treasure. If the dragon finds a worthy addition to its hoard, it barters with the ship's captain for the item."
+														]
+													},
+													{
+														"name": "War Machines",
+														"type": "entries",
+														"entries": [
+															"Bronze dragons actively oppose tyranny, and many bronze dragons yearn to test their mettle by putting their size and strength to good use. When a conflict unfolds near its lair, a bronze dragon ascertains the underlying cause, then offers its services to any side that fights for good. Once a bronze dragon commits to a cause, it remains a staunch ally.",
+															{
+																"name": "Well-Organized Wealth",
+																"entries": [
+																	"Bronze dragons loot sunken ships and also collect colorful coral and pearls from the reefs and seabeds near their lairs. When a bronze dragon pledges to help an army wage war against tyranny, it asks for nominal payment. If such a request is beyond its allies' means, it might settle for a collection of old books on military history or a ceremonial item commemorating the alliance. A bronze dragon might also lay claim to a treasure held by the enemy that it feels would be safer under its protection."
+																],
+																"type": "entries"
+															}
+														]
+													}
+												]
+											}
+										]
+									}
+								]
+							},
+							{
+								"type": "entries",
+								"name": "A Bronze Dragon's Lair",
+								"entries": [
+									"A bronze dragon lairs in coastal caves. It might salvage a wrecked ship, reconstruct it within the confines of its lair, and use it as a treasure vault or nest for its eggs."
+								]
+							}
+						]
 					},
 					"images": {
 						"mode": "prependArr",
@@ -2086,6 +2144,18 @@
 									]
 								}
 							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"They crawl from their mother's wombs to spread corruption throughout the multiverse. What's not to love?"
+									],
+									"by": "Baba Yaga"
+								}
+							]
 						}
 					]
 				}
@@ -2173,6 +2243,18 @@
 										"A centaur that can't keep pace with the rest of its tribe is left behind. Some such centaurs vanish into the wilderness and are never seen again. Those that can bear the loss of their tribe might take up residence among other races. Frontier settlements value the nature knowledge of their centaur residents. Many such communities owe their survival to the insight and acumen of a centaur.",
 										"Despite their reclusive nature, centaurs trade with elves and with the caravans of other benevolent humanoids they meet during their wanderings. A trader might save the life of a wounded or an elderly centaur unfit for long travel, escorting it to a settlement where it can peacefully live out the rest of its days."
 									]
+								}
+							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"I hear centaurs make excellent mounts!"
+									],
+									"by": "Batley Summerfoot, a halfling adventurer who never read {@style Hooves of Fury|small-caps} by Irvil Grayborn of Sundown"
 								}
 							]
 						}
@@ -2315,34 +2397,39 @@
 							"entries": [
 								"The black, blue, green, red, and white dragons represent the evil side of dragonkind. Aggressive, gluttonous, and vain, chromatic dragons are dark sages and powerful tyrants feared by all creatures-including each other.",
 								{
-									"name": "Driven by Greed",
-									"entries": [
-										"Chromatic dragons lust after treasure, and this greed colors their every scheme and plot. They believe that the world's wealth belongs to them by right, and a chromatic dragon seizes that wealth without regard for the humanoids and other creatures that have \"stolen\" it. With its piles of coins, gleaming gems, and magic items, a dragon's hoard is the stuff of legend. However, chromatic dragons have no interest in commerce, amassing wealth for no other reason than to have it."
-									],
-									"type": "entries"
-								},
-								{
-									"name": "Creatures of Ego",
 									"type": "entries",
 									"entries": [
-										"Chromatic dragons are united by their sense of superiority, believing themselves the most powerful and worthy of all mortal creatures. When they interact with other creatures, it is only to further their own interests. They believe in their innate right to rule, and this belief is the cornerstone of every chromatic dragon's personality and worldview. Trying to humble a chromatic dragon is like trying to convince the wind to stop blowing. To these creatures, humanoids are animals, fit to serve as prey or beasts of burden, and wholly unworthy of respect."
-									]
-								},
-								{
-									"name": "Dangerous Lairs",
-									"type": "entries",
-									"entries": [
-										"A dragon's lair serves as the seat of its power and a vault for its treasure. With its innate toughness and tolerance for severe environmental effects, a dragon selects or builds a lair not for shelter but for defense, favoring multiple entrances and exits, and security for its hoard.",
-										"Most chromatic dragon lairs are hidden in dangerous and remote locations to prevent all but the most audacious mortals from reaching them. A black dragon might lair in the heart of a vast swamp, while a red dragon might claim the caldera of an active volcano. In addition to the natural defenses of their lairs, powerful chromatic dragons use magical guardians, traps, and subservient creatures to protect their treasures."
-									]
-								},
-								{
-									"name": "Queen of Evil Dragons",
-									"type": "entries",
-									"entries": [
-										"Tiamat the Dragon Queen is the chief deity of evil dragonkind. She dwells on Avernus, the first layer of the Nine Hells. As a lesser god, Tiamat has the power to grant spells to her worshipers, though she is loath to share her power. She epitomizes the avarice of evil dragons, believing that the multiverse and all its treasures will one day be hers and hers alone.",
-										"Tiamat is a gigantic dragon whose five heads reflect the forms of the chromatic dragons that worship her-black, blue, green, red, and white. She is a terror on the battlefield, capable of annihilating whole armies with her five breath weapons, her formidable spellcasting, and her fearsome claws.",
-										"Tiamat's most hated enemy is Bahamut the Platinum Dragon, with whom she shares control of the faith of dragonkind. She also holds a special enmity for Asmodeus, who long ago stripped her of the rule of Avernus and who continues to curb the Dragon Queen's power."
+										{
+											"name": "Driven by Greed",
+											"entries": [
+												"Chromatic dragons lust after treasure, and this greed colors their every scheme and plot. They believe that the world's wealth belongs to them by right, and a chromatic dragon seizes that wealth without regard for the humanoids and other creatures that have \"stolen\" it. With its piles of coins, gleaming gems, and magic items, a dragon's hoard is the stuff of legend. However, chromatic dragons have no interest in commerce, amassing wealth for no other reason than to have it."
+											],
+											"type": "entries"
+										},
+										{
+											"name": "Creatures of Ego",
+											"type": "entries",
+											"entries": [
+												"Chromatic dragons are united by their sense of superiority, believing themselves the most powerful and worthy of all mortal creatures. When they interact with other creatures, it is only to further their own interests. They believe in their innate right to rule, and this belief is the cornerstone of every chromatic dragon's personality and worldview. Trying to humble a chromatic dragon is like trying to convince the wind to stop blowing. To these creatures, humanoids are animals, fit to serve as prey or beasts of burden, and wholly unworthy of respect."
+											]
+										},
+										{
+											"name": "Dangerous Lairs",
+											"type": "entries",
+											"entries": [
+												"A dragon's lair serves as the seat of its power and a vault for its treasure. With its innate toughness and tolerance for severe environmental effects, a dragon selects or builds a lair not for shelter but for defense, favoring multiple entrances and exits, and security for its hoard.",
+												"Most chromatic dragon lairs are hidden in dangerous and remote locations to prevent all but the most audacious mortals from reaching them. A black dragon might lair in the heart of a vast swamp, while a red dragon might claim the caldera of an active volcano. In addition to the natural defenses of their lairs, powerful chromatic dragons use magical guardians, traps, and subservient creatures to protect their treasures."
+											]
+										},
+										{
+											"name": "Queen of Evil Dragons",
+											"type": "entries",
+											"entries": [
+												"Tiamat the Dragon Queen is the chief deity of evil dragonkind. She dwells on Avernus, the first layer of the Nine Hells. As a lesser god, Tiamat has the power to grant spells to her worshipers, though she is loath to share her power. She epitomizes the avarice of evil dragons, believing that the multiverse and all its treasures will one day be hers and hers alone.",
+												"Tiamat is a gigantic dragon whose five heads reflect the forms of the chromatic dragons that worship her-black, blue, green, red, and white. She is a terror on the battlefield, capable of annihilating whole armies with her five breath weapons, her formidable spellcasting, and her fearsome claws.",
+												"Tiamat's most hated enemy is Bahamut the Platinum Dragon, with whom she shares control of the faith of dragonkind. She also holds a special enmity for Asmodeus, who long ago stripped her of the rule of Avernus and who continues to curb the Dragon Queen's power."
+											]
+										}
 									]
 								}
 							]
@@ -2682,41 +2769,48 @@
 				"_mod": {
 					"entries": {
 						"mode": "prependArr",
-						"items": {
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"entries": [
-										"Copper dragons are incorrigible pranksters, joke tellers, and riddlers that live in hills and rocky uplands. Despite their gregarious and even-tempered natures, they possess a covetous, miserly streak, and can become dangerous when their hoards are threatened.",
-										"A copper dragon has brow plates jutting over its eyes, extending back to long horns that grow as a series of overlapping segments. Its backswept cheek ridges and jaw frills give it a pensive look. At birth, a copper dragon's scales are a ruddy brown with a metallic tint. As the dragon ages, its scales become more coppery in color, later taking on a green tint as it ages. A copper dragon's pupils fade with age, and the eyes of the oldest copper dragons resemble glowing turquoise orbs.",
-										{
-											"name": "Good Hosts",
-											"type": "entries",
-											"entries": [
-												"A copper dragon appreciates wit, a good joke, humorous story, or riddle. A copper dragon becomes annoyed with any creature that doesn't laugh at its jokes or accept its tricks with good humor.",
-												"Copper dragons are particularly fond of bards. A dragon might carve out part of its lair as a temporary abode for a bard willing to regale it with stories, riddles, and music. To a copper dragon, such companionship is a treasure to be coveted."
-											]
-										},
-										{
-											"name": "Cautious and Crafty",
-											"type": "entries",
-											"entries": [
-												"When building its hoard, a copper dragon prefers treasures from the earth. Metals and precious stones are favorites of these creatures.",
-												"A copper dragon is wary when it comes to showing off its possessions. If it knows that other creatures seek a specific item in its hoard, a copper dragon will not admit to possessing the item. Instead, it might send curious treasure hunters on a wild goose chase to search for the object while it watches from afar for its own pleasure."
-											]
-										},
-										{
-											"type": "entries",
-											"name": "A Copper Dragon's Lair",
-											"entries": [
-												"Copper dragons dwell in dry uplands and on hilltops, where they make their lairs in narrow caves. False walls in the lair hide secret antechambers where the dragon stores valuable ores, art objects, and other oddities it has collected over its lifetime. Worthless items are put on display in open caves to tantalize treasure seekers and distract them from where the real treasure is hidden."
-											]
-										}
-									]
-								}
-							]
-						}
+						"items": [
+							{
+								"type": "entries",
+								"entries": [
+									{
+										"type": "entries",
+										"entries": [
+											"Copper dragons are incorrigible pranksters, joke tellers, and riddlers that live in hills and rocky uplands. Despite their gregarious and even-tempered natures, they possess a covetous, miserly streak, and can become dangerous when their hoards are threatened.",
+											"A copper dragon has brow plates jutting over its eyes, extending back to long horns that grow as a series of overlapping segments. Its backswept cheek ridges and jaw frills give it a pensive look. At birth, a copper dragon's scales are a ruddy brown with a metallic tint. As the dragon ages, its scales become more coppery in color, later taking on a green tint as it ages. A copper dragon's pupils fade with age, and the eyes of the oldest copper dragons resemble glowing turquoise orbs.",
+											{
+												"type": "entries",
+												"entries": [
+													{
+														"name": "Good Hosts",
+														"type": "entries",
+														"entries": [
+															"A copper dragon appreciates wit, a good joke, humorous story, or riddle. A copper dragon becomes annoyed with any creature that doesn't laugh at its jokes or accept its tricks with good humor.",
+															"Copper dragons are particularly fond of bards. A dragon might carve out part of its lair as a temporary abode for a bard willing to regale it with stories, riddles, and music. To a copper dragon, such companionship is a treasure to be coveted."
+														]
+													},
+													{
+														"name": "Cautious and Crafty",
+														"type": "entries",
+														"entries": [
+															"When building its hoard, a copper dragon prefers treasures from the earth. Metals and precious stones are favorites of these creatures.",
+															"A copper dragon is wary when it comes to showing off its possessions. If it knows that other creatures seek a specific item in its hoard, a copper dragon will not admit to possessing the item. Instead, it might send curious treasure hunters on a wild goose chase to search for the object while it watches from afar for its own pleasure."
+														]
+													}
+												]
+											}
+										]
+									}
+								]
+							},
+							{
+								"type": "entries",
+								"name": "A Copper Dragon's Lair",
+								"entries": [
+									"Copper dragons dwell in dry uplands and on hilltops, where they make their lairs in narrow caves. False walls in the lair hide secret antechambers where the dragon stores valuable ores, art objects, and other oddities it has collected over its lifetime. Worthless items are put on display in open caves to tantalize treasure seekers and distract them from where the real treasure is hidden."
+								]
+							}
+						]
 					},
 					"images": {
 						"mode": "prependArr",
@@ -2835,6 +2929,18 @@
 									"entries": [
 										"A crawling claw doesn't require air, food, drink, or sleep."
 									]
+								}
+							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"Makes you wonder what can be done with all those other murderer parts, doesn't it?"
+									],
+									"by": "Evangeliza Lavain, necromancer"
 								}
 							]
 						}
@@ -3020,6 +3126,18 @@
 								"A darkmantle clings to cavern ceilings, remaining perfectly still as it waits for creatures to pass beneath it. From a distance, it can pass itself off as a stalactite or a lump of stone. Then it drops from the ceiling and unfurls, surrounding itself with magical darkness as it engulfs and crushes its prey.",
 								"Darkmantles are found throughout the Underdark, but they are equally common on the Shadowfell. Thriving in that dark realm, they fill an ecological niche similar to bats on the Material Plane. Intelligent creatures of the Shadowfell sometimes train darkmantles as guardians or companions."
 							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"Remind me again why we're on this quest?"
+									],
+									"by": "Ethelrede the fighter, after his first darkmantle encounter"
+								}
+							]
 						}
 					]
 				}
@@ -3181,17 +3299,29 @@
 									"entries": [
 										"A death tyrant doesn't require air, food, drink, or sleep."
 									]
-								},
-								{
-									"type": "entries",
-									"name": "A Death Tyrant's Lair",
-									"entries": [
-										"A death tyrant's lair is usually the same site it held as a beholder, but it contains more trappings of death and decay. A death tyrant encountered in its lair has a challenge rating of 15 (13,000 XP).",
-										"The death tyrant can't repeat an effect until all three have been used, and it can't use the same effect on consecutive rounds."
-									]
 								}
 							]
 						}
+					]
+				},
+				{
+					"type": "insetReadaloud",
+					"entries": [
+						{
+							"type": "quote",
+							"entries": [
+								"A cluster of tiny lights descended from a dark crevice in the ceiling. These motes cast an eerie glow on the great, alien skull that hung beneath them."
+							],
+							"by": "From the Journal of Jastus Hollowquill, explorer of Undermountain"
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"name": "A Death Tyrant's Lair",
+					"entries": [
+						"A death tyrant's lair is usually the same site it held as a beholder, but it contains more trappings of death and decay. A death tyrant encountered in its lair has a challenge rating of 15 (13,000 XP).",
+						"The death tyrant can't repeat an effect until all three have been used, and it can't use the same effect on consecutive rounds."
 					]
 				}
 			],
@@ -3303,6 +3433,18 @@
 											"type": "entries"
 										}
 									]
+								}
+							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"I, Achererak the Eternal, beckon you to you rdoom. Come, foolish ones, plunger my treasures, if you dare! Others have tried. All have failed! From your skin, tapestries shall be woven, and your bones will carpet my tomb. Only I am beyond Death's reach. Only I know the secret to true immortality!"
+									],
+									"by": "Epitaph of a demilich"
 								}
 							]
 						}
@@ -3674,6 +3816,18 @@
 										},
 										"A summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
 									]
+								}
+							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"Demons are painfully difficult to summon and control. It is not a burden for the weak of heart or the weak of spirit."
+									],
+									"by": "From the {@style Demonomicon of Iggwilv|small-caps}"
 								}
 							]
 						}
@@ -4300,44 +4454,50 @@
 			"name": "Dragons",
 			"source": "MM",
 			"entries": [
-				"True dragons are winged reptiles of ancient lineage and fearsome power. They are known and feared for their predatory cunning and greed, with the oldest dragons accounted as some of the most powerful creatures in the world. Dragons are also magical creatures whose innate power fuels their dreaded breath weapons and other preternatural abilities.",
-				"Many creatures, including wyverns and dragon turtles, have draconic blood. However, true dragons fall into the two broad categories of chromatic and metallic dragons. The black, blue, green, red, and white dragons are selfish, evil, and feared by all. The brass, bronze, copper, gold, and silver dragons are noble, good, and highly respected by the wise.",
-				"Though their goals and ideals vary tremendously, all true dragons covet wealth, hoarding mounds of coins and gathering gems, jewels, and magic items. Dragons with large hoards are loath to leave them for long, venturing out of their lairs only to patrol or feed.",
-				"True dragons pass through four distinct stages of life, from lowly wyrmlings to ancient dragons, which can live for over a thousand years. In that time, their might can become unrivaled and their hoards can grow beyond price.",
-				"Dragon Age Categories",
 				{
-					"type": "table",
-					"colLabels": [
-						"Category",
-						"Size",
-						"Age Range"
-					],
-					"colStyles": [
-						"col-4",
-						"col-4",
-						"col-4"
-					],
-					"rows": [
-						[
-							"Wyrmling",
-							"Medium",
-							"5 years or less"
-						],
-						[
-							"Young",
-							"Large",
-							"6\u2013100 years"
-						],
-						[
-							"Adult",
-							"Huge",
-							"101\u2013800 years"
-						],
-						[
-							"Ancient",
-							"Gargantuan",
-							"801 years or more"
-						]
+					"type": "section",
+					"name": "Dragons",
+					"entries": [
+						"True dragons are winged reptiles of ancient lineage and fearsome power. They are known and feared for their predatory cunning and greed, with the oldest dragons accounted as some of the most powerful creatures in the world. Dragons are also magical creatures whose innate power fuels their dreaded breath weapons and other preternatural abilities.",
+						"Many creatures, including wyverns and dragon turtles, have draconic blood. However, true dragons fall into the two broad categories of chromatic and metallic dragons. The black, blue, green, red, and white dragons are selfish, evil, and feared by all. The brass, bronze, copper, gold, and silver dragons are noble, good, and highly respected by the wise.",
+						"Though their goals and ideals vary tremendously, all true dragons covet wealth, hoarding mounds of coins and gathering gems, jewels, and magic items. Dragons with large hoards are loath to leave them for long, venturing out of their lairs only to patrol or feed.",
+						"True dragons pass through four distinct stages of life, from lowly wyrmlings to ancient dragons, which can live for over a thousand years. In that time, their might can become unrivaled and their hoards can grow beyond price.",
+						{
+							"type": "table",
+							"caption": "Dragon Age Categories",
+							"colLabels": [
+								"Category",
+								"Size",
+								"Age Range"
+							],
+							"colStyles": [
+								"col-4",
+								"col-4",
+								"col-4"
+							],
+							"rows": [
+								[
+									"Wyrmling",
+									"Medium",
+									"5 years or less"
+								],
+								[
+									"Young",
+									"Large",
+									"6\u2013100 years"
+								],
+								[
+									"Adult",
+									"Huge",
+									"101\u2013800 years"
+								],
+								[
+									"Ancient",
+									"Gargantuan",
+									"801 years or more"
+								]
+							]
+						}
 					]
 				}
 			]
@@ -4394,6 +4554,18 @@
 										"Drow transformed into driders return to the Material Plane as twisted and debased creatures. Driven by madness, they disappear into the Underdark to become hermits and hunters, either wandering alone or leading packs of giant spiders.",
 										"On rare occasion, a drider returns to the fringes of drow society despite its curse, most often to fulfill some longstanding vow or vendetta from its former life. Drow fear and shun the driders, holding them in lower esteem than slaves. However, they tolerate the presence of these creatures as living representatives of Lolth's will, and a reminder of the fate that awaits all who fail the Spider Queen."
 									]
+								}
+							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
+								{
+									"type": "quote",
+									"entries": [
+										"I failed the Spider Queen once. Never again."
+									],
+									"by": "Pellanistra the drider"
 								}
 							]
 						}
@@ -4507,6 +4679,18 @@
 													]
 												}
 											]
+										}
+									]
+								},
+								{
+									"type": "insetReadaloud",
+									"entries": [
+										{
+											"type": "quote",
+											"entries": [
+												"Such depravity. Such terrifying cruelty. They are the vile poison that plagues all elvenkind."
+											],
+											"by": "Nelar Autumnwell, elf cleric of Corellon Larethian"
 										}
 									]
 								}
@@ -4885,39 +5069,45 @@
 			"name": "Elementals",
 			"source": "MM",
 			"entries": [
-				"Elementals are incarnations of the elements that make up the universe: air, earth, fire, and water. Though little more than animated energy on their own planes of existence, they can be called on by spellcasters and powerful beings to take shape and perform tasks.",
 				{
-					"type": "entries",
+					"type": "section",
+					"name": "Elementals",
 					"entries": [
+						"Elementals are incarnations of the elements that make up the universe: air, earth, fire, and water. Though little more than animated energy on their own planes of existence, they can be called on by spellcasters and powerful beings to take shape and perform tasks.",
 						{
 							"type": "entries",
 							"entries": [
 								{
 									"type": "entries",
-									"name": "Living Elements",
 									"entries": [
-										"On its home plane, an elemental is a bodiless life force. Its dim consciousness manifests as a physical shape only when focused by the power of magic. A wild spirit of elemental force has no desire except to course through the element of its native plane. Like beasts of the Material Plane, these elemental spirits have no society or culture, and little sense of being."
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Conjured by Magic",
-									"entries": [
-										"Certain spells and magic items can conjure an elemental, summoning it from the Inner Planes to the Material Plane. Elementals instinctively resent being pulled from their native planes and bound into service. A creature that summons an elemental must assert force of will to control it."
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Bound and Shaped",
-									"entries": [
-										"Powerful magic can bind an elemental spirit into a material template that defines a specific use and function. Invisible stalkers are air elementals bound to a specific form, in the same way that water elementals can be shaped into water weirds."
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Elemental Nature",
-									"entries": [
-										"An elemental doesn't require air, food, drink, or sleep."
+										{
+											"type": "entries",
+											"name": "Living Elements",
+											"entries": [
+												"On its home plane, an elemental is a bodiless life force. Its dim consciousness manifests as a physical shape only when focused by the power of magic. A wild spirit of elemental force has no desire except to course through the element of its native plane. Like beasts of the Material Plane, these elemental spirits have no society or culture, and little sense of being."
+											]
+										},
+										{
+											"type": "entries",
+											"name": "Conjured by Magic",
+											"entries": [
+												"Certain spells and magic items can conjure an elemental, summoning it from the Inner Planes to the Material Plane. Elementals instinctively resent being pulled from their native planes and bound into service. A creature that summons an elemental must assert force of will to control it."
+											]
+										},
+										{
+											"type": "entries",
+											"name": "Bound and Shaped",
+											"entries": [
+												"Powerful magic can bind an elemental spirit into a material template that defines a specific use and function. Invisible stalkers are air elementals bound to a specific form, in the same way that water elementals can be shaped into water weirds."
+											]
+										},
+										{
+											"type": "entries",
+											"name": "Elemental Nature",
+											"entries": [
+												"An elemental doesn't require air, food, drink, or sleep."
+											]
+										}
 									]
 								}
 							]
@@ -4990,6 +5180,18 @@
 									"entries": [
 										"The most beautiful and striking of all lesser and greater devils, the erinyes are fierce and disciplined warriors. Sweeping down from the skies, they bring swift death to creatures that have wronged their masters or defied the edicts of Asmodeus. The erinyes appear as male or female humanoids with statuesque builds and large feathery wings. Most wear stylized armor and horned helms, and carry exquisite swords and bows. A few also use ropes of entanglement to ensnare powerful foes.",
 										"Legends tell that the first erinyes were angels that fell from the Upper Planes because of temptation or misdeed. Erinyes are always willing to take advantage of being mistaken for celestials in their missions of conquest and corruption.",
+										{
+											"type": "insetReadaloud",
+											"entries": [
+												{
+													"type": "quote",
+													"entries": [
+														"They live by the sword and kill by the sword. Their beauty is nothing compared to their wrath."
+													],
+													"by": "From {@style The Book of Vile Darkness|small-caps}"
+												}
+											]
+										},
 										{
 											"type": "inset",
 											"name": "Variant: Rope of Entanglement",
@@ -5561,35 +5763,62 @@
 			]
 		},
 		{
-			"name": "Flying Sword",
+			"name": "Animated Objects",
 			"source": "MM",
 			"entries": [
 				{
-					"type": "entries",
+					"type": "section",
+					"name": "Animated Objects",
 					"entries": [
+						"Animated objects are crafted with potent magic to follow the commands of their creators. When not commanded, they follow the last order they received to the best of their ability, and can act independently to fulfill simple instructions. Some animated objects (including many of those created in the Feywild) might converse fluently or adopt a persona, but most are simple automatons.",
 						{
 							"type": "entries",
 							"entries": [
-								"Animated objects are crafted with potent magic to follow the commands of their creators. When not commanded, they follow the last order they received to the best of their ability, and can act independently to fulfill simple instructions. Some animated objects (including many of those created in the Feywild) might converse fluently or adopt a persona, but most are simple automatons.",
-								{
-									"name": "Constructed Nature",
-									"type": "entries",
-									"entries": [
-										"An animated object doesn't require air, food, drink, or sleep. The magic that animates an object is dispelled when the construct drops to 0 hit points. An animated object reduced to 0 hit points becomes inanimate and is too damaged to be of much use or value to anyone."
-									]
-								},
 								{
 									"type": "entries",
-									"name": "Flying Sword",
 									"entries": [
-										"A flying sword dances through the air, fighting with the confidence of a warrior that can't be injured. Swords are the most common weapons animated with magic. Axes, clubs, daggers, maces, spears, and even self-loading crossbows are also known to exist in animated object form."
+										{
+											"name": "Constructed Nature",
+											"type": "entries",
+											"entries": [
+												"An animated object doesn't require air, food, drink, or sleep. The magic that animates an object is dispelled when the construct drops to 0 hit points. An animated object reduced to 0 hit points becomes inanimate and is too damaged to be of much use or value to anyone."
+											]
+										}
 									]
 								}
 							]
 						}
 					]
 				}
-			],
+			]
+		},
+		{
+			"name": "Flying Sword",
+			"source": "MM",
+			"_copy": {
+				"name": "Animated Objects",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": [
+							"A flying sword dances through the air, fighting with the confidence of a warrior that can't be injured. Swords are the most common weapons animated with magic. Axes, clubs, daggers, maces, spears, and even self-loading crossbows are also known to exist in animated object form.",
+							{
+								"type": "insetReadaloud",
+								"entries": [
+									{
+										"type": "quote",
+										"entries": [
+											"Lyin' next to the chest were the bones of {@style Cap'n Scornblade|small-caps} himself, still clutchin' his rusty sword. Imagine my surprise when the blade flew from his bony grasp! Still go the scar."
+										],
+										"by": "Levity Quickstitch, halfling rogue"
+									}
+								]
+							}
+						]
+					}
+				}
+			},
 			"images": [
 				{
 					"type": "image",
@@ -6980,47 +7209,49 @@
 				"_mod": {
 					"entries": {
 						"mode": "prependArr",
-						"items": {
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"entries": [
-										"The most powerful and majestic of the metallic dragons, gold dragons are dedicated foes of evil.",
-										"A gold dragon has a sagacious face anointed with flexible spines that resemble whiskers. Its horns sweep back from its nose and brow, echoing twin frills that adorn its long neck. A gold dragon's sail-like wings start at its shoulders and trace down to the tip of its tail, letting it fly with a distinctive rippling motion as if swimming through the air. A gold dragon wyrmling has scales of dark yellow with metallic flecks. Those flecks grow larger as the dragon matures. As a gold dragon ages, its pupils fade until its eyes resemble pools of molten gold.",
-										{
-											"name": "Devourer of Wealth",
-											"type": "entries",
-											"entries": [
-												"Gold dragons can eat just about anything, but their preferred diet consists of pearls and gems. Thankfully, a gold dragon doesn't need to gorge itself on such wealth to feel satisfied. Gifts of treasure that it can consume are well received by a gold dragon, as long as they aren't bribes."
-											]
-										},
-										{
-											"name": "Reserved Shapeshifters",
-											"type": "entries",
-											"entries": [
-												"Gold dragons are respected by the other metallic dragons for their wisdom and fairness, but they are the most aloof and grim of the good-aligned dragons. They value their privacy to the extent that they rarely fraternize with other dragons except their own mates and offspring.",
-												"Older gold dragons can assume animal and humanoid forms. Rarely does a gold dragon in disguise reveal its true form. In the guise of a peddler, it might regularly visit a town to catch up on local gossip, patronize honest businesses, and lend a helping hand in unseen ways. In the guise of an animal, the dragon might befriend a lost child, a wandering minstrel, or an innkeeper, serving as a companion for days or weeks on end."
-											]
-										},
-										{
-											"name": "Master Hoarders",
-											"type": "entries",
-											"entries": [
-												"A gold dragon keeps its hoard in a well-guarded vault deep within its lair. Magical wards placed on the vault make it all but impossible to remove any treasures without the dragon knowing about it."
-											]
-										},
-										{
-											"type": "entries",
-											"name": "A Gold Dragon's Lair",
-											"entries": [
-												"Gold dragons make their homes in out-of-the-way places, where they can do as they please without arousing suspicion or fear. Most dwell near idyllic lakes and rivers, mist-shrouded islands, cave complexes hidden behind sparkling waterfalls, or ancient ruins."
-											]
-										}
-									]
-								}
-							]
-						}
+						"items": [
+							{
+								"type": "entries",
+								"entries": [
+									{
+										"type": "entries",
+										"entries": [
+											"The most powerful and majestic of the metallic dragons, gold dragons are dedicated foes of evil.",
+											"A gold dragon has a sagacious face anointed with flexible spines that resemble whiskers. Its horns sweep back from its nose and brow, echoing twin frills that adorn its long neck. A gold dragon's sail-like wings start at its shoulders and trace down to the tip of its tail, letting it fly with a distinctive rippling motion as if swimming through the air. A gold dragon wyrmling has scales of dark yellow with metallic flecks. Those flecks grow larger as the dragon matures. As a gold dragon ages, its pupils fade until its eyes resemble pools of molten gold.",
+											{
+												"name": "Devourer of Wealth",
+												"type": "entries",
+												"entries": [
+													"Gold dragons can eat just about anything, but their preferred diet consists of pearls and gems. Thankfully, a gold dragon doesn't need to gorge itself on such wealth to feel satisfied. Gifts of treasure that it can consume are well received by a gold dragon, as long as they aren't bribes."
+												]
+											},
+											{
+												"name": "Reserved Shapeshifters",
+												"type": "entries",
+												"entries": [
+													"Gold dragons are respected by the other metallic dragons for their wisdom and fairness, but they are the most aloof and grim of the good-aligned dragons. They value their privacy to the extent that they rarely fraternize with other dragons except their own mates and offspring.",
+													"Older gold dragons can assume animal and humanoid forms. Rarely does a gold dragon in disguise reveal its true form. In the guise of a peddler, it might regularly visit a town to catch up on local gossip, patronize honest businesses, and lend a helping hand in unseen ways. In the guise of an animal, the dragon might befriend a lost child, a wandering minstrel, or an innkeeper, serving as a companion for days or weeks on end."
+												]
+											},
+											{
+												"name": "Master Hoarders",
+												"type": "entries",
+												"entries": [
+													"A gold dragon keeps its hoard in a well-guarded vault deep within its lair. Magical wards placed on the vault make it all but impossible to remove any treasures without the dragon knowing about it."
+												]
+											}
+										]
+									}
+								]
+							},
+							{
+								"type": "entries",
+								"name": "A Gold Dragon's Lair",
+								"entries": [
+									"Gold dragons make their homes in out-of-the-way places, where they can do as they please without arousing suspicion or fear. Most dwell near idyllic lakes and rivers, mist-shrouded islands, cave complexes hidden behind sparkling waterfalls, or ancient ruins."
+								]
+							}
+						]
 					},
 					"images": {
 						"mode": "prependArr",
@@ -7185,61 +7416,75 @@
 				"_mod": {
 					"entries": {
 						"mode": "prependArr",
-						"items": {
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"entries": [
-										"The most cunning and treacherous of true dragons, green dragons use misdirection and trickery to get the upper hand against their enemies. Nasty tempered and thoroughly evil, they take special pleasure in subverting and corrupting the good-hearted. In the ancient forests they roam, green dragons demonstrate an aggression that is often less about territory than it is about gaining power and wealth with as little effort as possible.",
-										"A green dragon is recognized by its curved jawline and the crest that begins near its eyes and continues down its spine, reaching full height just behind the skull. A green dragon has no external ears, but bears leathery spiked plates that run down the sides of its neck.",
-										"A wyrmling green dragon's thin scales are a shade of green so dark as to appear nearly black. As a green dragon ages, its scales grow larger and lighter, turning shades of forest, emerald, and olive green to help it blend in with its wooded surroundings. Its wings have a dappled pattern, darker near the leading edges and lighter toward the trailing edges.",
-										"A green dragon's legs are longer in relation to its body than with any other dragon, enabling it to easily pass over underbrush and forest debris when it walks. With its equally long neck, an older green dragon can peer over the tops of trees without rearing up.",
-										{
-											"name": "Capricious Hunters",
-											"type": "entries",
-											"entries": [
-												"A green dragon hunts by patrolling its forest territory from the air and the ground. It eats any creature it can see, and will consume shrubs and small trees when hungry enough, but its favorite prey is elves.",
-												"Green dragons are consummate liars and masters of double talk. They favor intimidation of lesser creatures, but employ more subtle manipulations when dealing with other dragons. A green dragon attacks animals and monsters with no provocation, especially when dealing with potential threats to its territory. When dealing with sentient creatures, a green dragon demonstrates a lust for power that rivals its draconic desire for treasure, and it is always on the lookout for creatures that can help it further its ambitions.",
-												"A green dragon stalks its victims as it plans its assault, sometimes shadowing creatures for days. If a target is weak, the dragon enjoys the terror its appearance evokes before it attacks. It never slays all its foes, preferring to use intimidation to establish control over survivors. It then learns what it can about other creatures' activities near its territory, and about any treasure to be found nearby. Green dragons occasionally release prisoners if they can be ransomed. Otherwise, a creature must prove its value to the dragon daily or die."
-											]
-										},
-										{
-											"name": "Manipulative Schemers",
-											"type": "entries",
-											"entries": [
-												"A wily and subtle creature, a green dragon bends other creatures to its will by assessing and playing off their deepest desires. Any creature foolish enough to attempt to subdue a green dragon eventually realizes that the creature is only pretending to serve while it assesses its would-be master.",
-												"When manipulating other creatures, green dragons are honey-tongued, smooth, and sophisticated. Among their own kind, they are loud, crass, and rude, especially when dealing with dragons of the same age and status."
-											]
-										},
-										{
-											"name": "Conflict and Corruption",
-											"type": "entries",
-											"entries": [
-												"Green dragons sometimes clash with other dragons over territory where forest crosses over into other terrain. A green dragon typically pretends to back down, only to wait and watch-sometimes for decades-for the chance to slay the other dragon, then claim its lair and hoard.",
-												"Green dragons accept the servitude of sentient creatures such as goblinoids, ettercaps, ettins, kobolds, orcs, and yuan-ti. They also delight in corrupting and bending elves to their will. A green dragon sometimes wracks its minions' minds with fear to the point of insanity, with the fog that spreads throughout its forest reflecting those minions' tortured dreams."
-											]
-										},
-										{
-											"name": "Living Treasures",
-											"type": "entries",
-											"entries": [
-												"A green dragon's favored treasures are the sentient creatures it bends to its will, including significant figures such as popular heroes, well-known sages, and renowned bards. Among material treasures, a green dragon favors emeralds, wood carvings, musical instruments, and sculptures of humanoid subjects."
-											]
-										},
-										{
-											"type": "entries",
-											"name": "A Green Dragon's Lair",
-											"entries": [
-												"The forest-loving green dragons sometimes compete for territory with black dragons in marshy woods and with white dragons in subarctic taiga. However, a forest controlled by a green dragon is easy to spot. A perpetual fog hangs in the air in a legendary green dragon's wood, carrying an acrid whiff of the creature's poison breath.",
-												"The moss-covered trees grow close together except where winding pathways trace their way like a maze into the heart of the forest. The light that reaches the forest floor carries an emerald green cast, and every sound seems muffled.",
-												"At the center of its forest, a green dragon chooses a cave in a sheer cliff or hillside for its lair, preferring an entrance hidden from prying eyes. Some seek out cave mouths concealed behind waterfalls, or partly submerged caverns that can be accessed through lakes or streams. Others conceal the entrances to their lairs with vegetation."
-											]
-										}
-									]
-								}
-							]
-						}
+						"items": [
+							{
+								"type": "entries",
+								"entries": [
+									{
+										"type": "entries",
+										"entries": [
+											"The most cunning and treacherous of true dragons, green dragons use misdirection and trickery to get the upper hand against their enemies. Nasty tempered and thoroughly evil, they take special pleasure in subverting and corrupting the good-hearted. In the ancient forests they roam, green dragons demonstrate an aggression that is often less about territory than it is about gaining power and wealth with as little effort as possible.",
+											"A green dragon is recognized by its curved jawline and the crest that begins near its eyes and continues down its spine, reaching full height just behind the skull. A green dragon has no external ears, but bears leathery spiked plates that run down the sides of its neck.",
+											"A wyrmling green dragon's thin scales are a shade of green so dark as to appear nearly black. As a green dragon ages, its scales grow larger and lighter, turning shades of forest, emerald, and olive green to help it blend in with its wooded surroundings. Its wings have a dappled pattern, darker near the leading edges and lighter toward the trailing edges.",
+											"A green dragon's legs are longer in relation to its body than with any other dragon, enabling it to easily pass over underbrush and forest debris when it walks. With its equally long neck, an older green dragon can peer over the tops of trees without rearing up.",
+											{
+												"name": "Capricious Hunters",
+												"type": "entries",
+												"entries": [
+													"A green dragon hunts by patrolling its forest territory from the air and the ground. It eats any creature it can see, and will consume shrubs and small trees when hungry enough, but its favorite prey is elves.",
+													"Green dragons are consummate liars and masters of double talk. They favor intimidation of lesser creatures, but employ more subtle manipulations when dealing with other dragons. A green dragon attacks animals and monsters with no provocation, especially when dealing with potential threats to its territory. When dealing with sentient creatures, a green dragon demonstrates a lust for power that rivals its draconic desire for treasure, and it is always on the lookout for creatures that can help it further its ambitions.",
+													"A green dragon stalks its victims as it plans its assault, sometimes shadowing creatures for days. If a target is weak, the dragon enjoys the terror its appearance evokes before it attacks. It never slays all its foes, preferring to use intimidation to establish control over survivors. It then learns what it can about other creatures' activities near its territory, and about any treasure to be found nearby. Green dragons occasionally release prisoners if they can be ransomed. Otherwise, a creature must prove its value to the dragon daily or die."
+												]
+											},
+											{
+												"name": "Manipulative Schemers",
+												"type": "entries",
+												"entries": [
+													"A wily and subtle creature, a green dragon bends other creatures to its will by assessing and playing off their deepest desires. Any creature foolish enough to attempt to subdue a green dragon eventually realizes that the creature is only pretending to serve while it assesses its would-be master.",
+													"When manipulating other creatures, green dragons are honey-tongued, smooth, and sophisticated. Among their own kind, they are loud, crass, and rude, especially when dealing with dragons of the same age and status."
+												]
+											},
+											{
+												"name": "Conflict and Corruption",
+												"type": "entries",
+												"entries": [
+													"Green dragons sometimes clash with other dragons over territory where forest crosses over into other terrain. A green dragon typically pretends to back down, only to wait and watch-sometimes for decades-for the chance to slay the other dragon, then claim its lair and hoard.",
+													"Green dragons accept the servitude of sentient creatures such as goblinoids, ettercaps, ettins, kobolds, orcs, and yuan-ti. They also delight in corrupting and bending elves to their will. A green dragon sometimes wracks its minions' minds with fear to the point of insanity, with the fog that spreads throughout its forest reflecting those minions' tortured dreams."
+												]
+											},
+											{
+												"name": "Living Treasures",
+												"type": "entries",
+												"entries": [
+													"A green dragon's favored treasures are the sentient creatures it bends to its will, including significant figures such as popular heroes, well-known sages, and renowned bards. Among material treasures, a green dragon favors emeralds, wood carvings, musical instruments, and sculptures of humanoid subjects."
+												]
+											}
+										]
+									}
+								]
+							},
+							{
+								"type": "insetReadaloud",
+								"entries": [
+									{
+										"type": "quote",
+										"entries": [
+											"I see an ancient elf king, his majesty long since faded, slumped and half asleep in his throne. A green dragon whispers in the king's ear, corrupting and twisting the king's dreams. This dragon's name is Cyan Bloodbane, and he means the destruction of us all."
+										],
+										"by": "Pelios of Ergoth, Silvanesti seer"
+									}
+								]
+							},
+							{
+								"type": "entries",
+								"name": "A Green Dragon's Lair",
+								"entries": [
+									"The forest-loving green dragons sometimes compete for territory with black dragons in marshy woods and with white dragons in subarctic taiga. However, a forest controlled by a green dragon is easy to spot. A perpetual fog hangs in the air in a legendary green dragon's wood, carrying an acrid whiff of the creature's poison breath.",
+									"The moss-covered trees grow close together except where winding pathways trace their way like a maze into the heart of the forest. The light that reaches the forest floor carries an emerald green cast, and every sound seems muffled.",
+									"At the center of its forest, a green dragon chooses a cave in a sheer cliff or hillside for its lair, preferring an entrance hidden from prying eyes. Some seek out cave mouths concealed behind waterfalls, or partly submerged caverns that can be accessed through lakes or streams. Others conceal the entrances to their lairs with vegetation."
+								]
+							}
+						]
 					},
 					"images": {
 						"mode": "prependArr",
@@ -9626,6 +9871,18 @@
 										"Souls of evil creatures that descend to the Lower Planes are transformed into manes-the lowest form of demonkind. These wretched fiends attack any non-demon they see, and they are called to the Material Plane by those seeking to sow death and chaos.",
 										"Orcus, the Prince of Undeath, has the power to transform manes into undead monsters, most often ghouls and shadows. Other demon lords feed on manes, destroying them utterly. Otherwise, killing a manes causes it to dissipate into a cloud of reeking vapor that reforms into another manes after one day."
 									]
+								},
+								{
+									"type": "insetReadaloud",
+									"entries": [
+										{
+											"type": "quote",
+											"entries": [
+												"Have no pity for this damnable wretch. Bloody thing could grow up to be a demon lord one day."
+											],
+											"by": "Emirikol the Chaotic"
+										}
+									]
 								}
 							]
 						}
@@ -9783,6 +10040,18 @@
 									"entries": [
 										"Terrible to behold, a marilith has the lower body of a great serpent and the upper torso of a humanoid female with six arms. Wielding a wicked blade in each of its six hands, a marilith is a devastating foe that few can match in battle.",
 										"These demons possess keen minds and a finely honed sense of tactics, and they are able to lead and unite other demons in common cause. Mariliths are often encountered as captains at the head of a demonic horde, where they embrace any opportunity to rush headlong into battle."
+									]
+								},
+								{
+									"type": "insetReadaloud",
+									"entries": [
+										{
+											"type": "quote",
+											"entries": [
+												"The temple was strewn with body parts. We concluded that the cultists had summoned a powerful demon and not lived to regret it. Not wanting to get hacked to pieces ourselves, we cut short our expedition and returned to the village of Hommlet with our tails between our legs. Rufus and Burne had a good laugh at our expense, let me tell you."
+											],
+											"by": "Nelumé, a young half-elf wizard, chronicling her one and only visit to the Temple of Elemental Evil"
+										}
 									]
 								}
 							]
@@ -9992,34 +10261,39 @@
 							"entries": [
 								"Metallic dragons seek to preserve and protect, viewing themselves as one powerful race among the many races that have a place in the world.",
 								{
-									"name": "Noble Curiosity",
 									"type": "entries",
 									"entries": [
-										"Metallic dragons covet treasure as do their evil chromatic kin, but they aren't driven as much by greed in their pursuit of wealth. Rather, metallic dragons are driven to investigate and collect, taking unclaimed relics and storing them in their lairs. A metallic dragon's treasure hoard is filled with items that reflect its persona, tell its history, and preserve its memories. Metallic dragons also seek to protect other creatures from dangerous magic. As such, powerful magic items and even evil artifacts are sometimes secreted away in a metallic dragon's hoard.",
-										"A metallic dragon can be persuaded to part with an item in its hoard for the greater good. However, another creature's need for or right to the item is often unclear from the dragon's point of view. A metallic dragon must be bribed or otherwise convinced to part with the item."
-									]
-								},
-								{
-									"name": "Solitary Shapeshifters",
-									"type": "entries",
-									"entries": [
-										"At some point in their long lives, metallic dragons gain the magical ability to assume the forms of humanoids and beasts. When a dragon learns how to disguise itself, it might immerse itself in other cultures for a time. Some dragons are too shy or paranoid to stray far from their lairs and their treasure hoards, but bolder dragons love to wander city streets in humanoid form, taking in the local culture and cuisine, and amusing themselves by observing how the smaller races live.",
-										"Some metallic dragons prefer to stay as far away from civilization as possible so as to not attract enemies. However, this means that they are often far out of touch with current events."
-									]
-								},
-								{
-									"name": "The Persistence of Memory",
-									"type": "entries",
-									"entries": [
-										"Metallic dragons have long memories, and they form opinions of humanoids based on previous contact with related humanoids. Good dragons can recognize humanoid bloodlines by smell, sniffing out each person they meet and remembering any relatives they have come into contact with over the years. A gold dragon might never suspect duplicity from a cunning villain, assuming that the villain is of the same mind and heart as a good and virtuous grandmother. On the other hand, the dragon might resent a noble paladin whose ancestor stole a silver statue from the dragon's hoard three centuries before."
-									]
-								},
-								{
-									"name": "King of Good Dragons",
-									"type": "entries",
-									"entries": [
-										"The chief deity of the metallic dragons is Bahamut, the Platinum Dragon. He dwells in the Seven Heavens of Mount Celestia, but often wanders the Material Plane in the magical guise of a venerable human male in peasant robes. In this form, he is usually accompanied by seven golden canaries-actually seven ancient gold dragons in polymorphed form.",
-										"Bahamut seldom interferes in the affairs of mortal creatures, though he makes exceptions to help thwart the machinations of Tiamat the Dragon Queen and her evil brood. Good-aligned clerics and paladins sometimes worship Bahamut for his dedication to justice and protection. As a lesser god, he has the power to grant divine spells."
+										{
+											"name": "Noble Curiosity",
+											"type": "entries",
+											"entries": [
+												"Metallic dragons covet treasure as do their evil chromatic kin, but they aren't driven as much by greed in their pursuit of wealth. Rather, metallic dragons are driven to investigate and collect, taking unclaimed relics and storing them in their lairs. A metallic dragon's treasure hoard is filled with items that reflect its persona, tell its history, and preserve its memories. Metallic dragons also seek to protect other creatures from dangerous magic. As such, powerful magic items and even evil artifacts are sometimes secreted away in a metallic dragon's hoard.",
+												"A metallic dragon can be persuaded to part with an item in its hoard for the greater good. However, another creature's need for or right to the item is often unclear from the dragon's point of view. A metallic dragon must be bribed or otherwise convinced to part with the item."
+											]
+										},
+										{
+											"name": "Solitary Shapeshifters",
+											"type": "entries",
+											"entries": [
+												"At some point in their long lives, metallic dragons gain the magical ability to assume the forms of humanoids and beasts. When a dragon learns how to disguise itself, it might immerse itself in other cultures for a time. Some dragons are too shy or paranoid to stray far from their lairs and their treasure hoards, but bolder dragons love to wander city streets in humanoid form, taking in the local culture and cuisine, and amusing themselves by observing how the smaller races live.",
+												"Some metallic dragons prefer to stay as far away from civilization as possible so as to not attract enemies. However, this means that they are often far out of touch with current events."
+											]
+										},
+										{
+											"name": "The Persistence of Memory",
+											"type": "entries",
+											"entries": [
+												"Metallic dragons have long memories, and they form opinions of humanoids based on previous contact with related humanoids. Good dragons can recognize humanoid bloodlines by smell, sniffing out each person they meet and remembering any relatives they have come into contact with over the years. A gold dragon might never suspect duplicity from a cunning villain, assuming that the villain is of the same mind and heart as a good and virtuous grandmother. On the other hand, the dragon might resent a noble paladin whose ancestor stole a silver statue from the dragon's hoard three centuries before."
+											]
+										},
+										{
+											"name": "King of Good Dragons",
+											"type": "entries",
+											"entries": [
+												"The chief deity of the metallic dragons is Bahamut, the Platinum Dragon. He dwells in the Seven Heavens of Mount Celestia, but often wanders the Material Plane in the magical guise of a venerable human male in peasant robes. In this form, he is usually accompanied by seven golden canaries-actually seven ancient gold dragons in polymorphed form.",
+												"Bahamut seldom interferes in the affairs of mortal creatures, though he makes exceptions to help thwart the machinations of Tiamat the Dragon Queen and her evil brood. Good-aligned clerics and paladins sometimes worship Bahamut for his dedication to justice and protection. As a lesser god, he has the power to grant divine spells."
+											]
+										}
 									]
 								}
 							]
@@ -10553,49 +10827,19 @@
 		{
 			"name": "Needle Blight",
 			"source": "MM",
-			"entries": [
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								"Awakened plants gifted with the powers of intelligence and mobility, blights plague lands contaminated by darkness. Drinking that darkness from the soil, a blight carries out the will of ancient evil and attempts to spread that evil wherever it can.",
-								{
-									"name": "Roots of the Gulthias Tree",
-									"type": "entries",
-									"entries": [
-										"Legends tell of a vampire named Gulthias who worked terrible magic and raised up an abominable tower called Nightfang Spire. Gulthias was undone when a hero plunged a wooden stake through his heart, but as the vampire was destroyed, his blood infused the stake with a dreadful power. In time, tendrils of new growth sprouted from the wood, growing into a sapling infused with the vampire's evil essence. It is said that a mad druid discovered the sapling, transplanting it to an underground grotto where it could grow. From this Gulthias tree came the seeds from which the first blights were sown."
-									]
-								},
-								{
-									"name": "Dark Conquest",
-									"type": "entries",
-									"entries": [
-										"Wherever a tree or plant is contaminated by a fragment of an evil mind or power, a Gulthias tree can rise to infest and corrupt the surrounding forest. Its evil spreads through root and soil to other plants, which perish or transform into blights. As those blights spread, they poison and uproot healthy plants, replacing them with brambles, toxic weeds, and others of their kind. In time, an infestation of blights can turn any land or forest into a place of corruption.",
-										"In forests infested with blights, trees and plants grow with supernatural speed. Vines and undergrowth rapidly spread through buildings and overrun trails and roads. After blights have killed or driven off their inhabitants, whole villages can disappear in the space of days.",
-										{
-											"name": "Controlled by Evil",
-											"entries": [
-												"Blights are independent creatures, but most act under a Gulthias tree's control, often displaying the habits and traits of the life force or spirit that spawned them. By attacking their progenitor's old foes or seeking out treasures valuable to it, they carry on the legacy of long-lost evil."
-											],
-											"type": "entries"
-										}
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Needle Blight",
-									"entries": [
-										"In the shadows of a forest, needle blights might be taken at a distance for shuffling, hunched humanoids. Up close, these creatures reveal themselves as horrid plants whose conifer-like needles grow across their bodies in quivering clumps. A needle blight lashes out with these needles or launches them as an aerial assault that can punch through armor and flesh.",
-										"When needle blights detect a threat, they loose a pollen that the wind carries to other needle blights throughout the forest. Alerted to their foes' location, needle blights converge from all sides to drench their roots in blood."
-									]
-								}
-							]
-						}
-					]
+			"_copy": {
+				"name": "Blights",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": [
+							"In the shadows of a forest, needle blights might be taken at a distance for shuffling, hunched humanoids. Up close, these creatures reveal themselves as horrid plants whose conifer-like needles grow across their bodies in quivering clumps. A needle blight lashes out with these needles or launches them as an aerial assault that can punch through armor and flesh.",
+							"When needle blights detect a threat, they loose a pollen that the wind carries to other needle blights throughout the forest. Alerted to their foes' location, needle blights converge from all sides to drench their roots in blood."
+						]
+					}
 				}
-			],
+			},
 			"images": [
 				{
 					"type": "image",
@@ -11607,6 +11851,18 @@
 										"With an inflated sense of superiority and entitlement, pit fiends form a grotesque aristocracy in the infernal realm. These domineering and manipulative tyrants conspire to eliminate anything that stands between them and their desires, even as they negotiate the convoluted and dangerous politics of the Nine Hells.",
 										"A pit fiend is a hulking monster with a whip-like tail and enormous wings that it wraps around itself like a cloak. Armored scales cover its body, and its fanged maw drips a venom that can lay the mightiest mortal creatures low. Fearless in battle, a pit fiend takes on the most powerful foes in single combat, demonstrating its supremacy and an arrogance that prevents it from acknowledging any chance of defeat."
 									]
+								},
+								{
+									"type": "insetReadaloud",
+									"entries": [
+										{
+											"type": "quote",
+											"entries": [
+												"Your war-torn kingdom is rife with corruption, its people dying from starvation and strife. They cry out for new leadership\u2014someone with the charisma and the courage to put an end to the turmoil and suffering. You could be that someone!"
+											],
+											"by": "Herobaal, the Pit Fiend"
+										}
+									]
 								}
 							]
 						}
@@ -12283,57 +12539,59 @@
 				"_mod": {
 					"entries": {
 						"mode": "prependArr",
-						"items": {
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"entries": [
-										"The most covetous of the true dragons, red dragons tirelessly seek to increase their treasure hoards. They are exceptionally vain, even for dragons, and their conceit is reflected in their proud bearing and their disdain for other creatures. The odor of sulfur and pumice surrounds a red dragon, whose swept-back horns and spinal frill define its silhouette. Its beaked snout vents smoke at all times, and its eyes dance with flame when it is angry. Its wings are the longest of any chromatic dragon, and have a blue-black tint along the trailing edge that resembles metal burned blue by fire.",
-										"The scales of a red dragon wyrmling are a bright glossy scarlet, turning a dull, deeper red and becoming as thick and strong as metal as the dragon ages. Its pupils also fade as it ages, and the oldest red dragons have eyes that resemble molten lava orbs.",
-										{
-											"name": "Mountain Masters",
-											"type": "entries",
-											"entries": [
-												"Red dragons prefer mountainous terrain, badlands, and any other locale where they can perch high and survey their domain. Their preference for mountains brings them into conflict with the hill-dwelling copper dragons from time to time."
-											]
-										},
-										{
-											"name": "Arrogant Tyrants",
-											"type": "entries",
-											"entries": [
-												"Red dragons fly into destructive rages and act on impulse when angered. They are so ferocious and vengeful that they are regarded as the archetypical evil dragon by many cultures.",
-												"No other dragon comes close to the arrogance of the red dragon. These creatures see themselves as kings and emperors, and view the rest of dragonkind as inferior. Believing that they are chosen by Tiamat to rule in her name, red dragons consider the world and every creature in it as theirs to command."
-											]
-										},
-										{
-											"name": "Status and Slaves",
-											"type": "entries",
-											"entries": [
-												"Red dragons are fiercely territorial and isolationist. However, they yearn to know about events in the wider world, and they make use of lesser creatures as informants, messengers, and spies. They are most interested in news about other red dragons, with which they compete constantly for status.",
-												"When it requires servants, a red dragon demands fealty from chaotic evil humanoids. If allegiance isn't forthcoming, it slaughters a tribe's leaders and claims lordship over the survivors. Creatures serving a red dragon live in constant terror of being roasted and eaten for displeasing it. They spend most of their time fawning over the creature in an attempt to stay alive."
-											]
-										},
-										{
-											"name": "Obsessive Collectors",
-											"type": "entries",
-											"entries": [
-												"Red dragons value wealth above all else, and their treasure hoards are legendary. They covet anything of monetary value, and can often judge the worth of a bauble to within a copper piece at a glance. A red dragon has a special affection for treasure claimed from powerful enemies it has slain, exhibiting that treasure to prove its superiority.",
-												"A red dragon knows the value and provenance of every item in its hoard, along with each item's exact location. It might notice the absence of a single coin, igniting its rage as it tracks down and slays the thief without mercy. If the thief can't be found, the dragon goes on a rampage, laying waste to towns and villages in an attempt to sate its wrath."
-											]
-										},
-										{
-											"type": "entries",
-											"name": "A Red Dragon's Lair",
-											"entries": [
-												"Red dragons lair in high mountains or hills, dwelling in caverns under snow-capped peaks, or within the deep halls of abandoned mines and dwarven strongholds. Caves with volcanic or geothermal activity are the most highly prized red dragon lairs, creating hazards that hinder intruders and letting searing heat and volcanic gases wash over a dragon as it sleeps. With its hoard well protected deep within the lair, a red dragon spends as much of its time outside the mountain as in it. For a red dragon, the great heights of the world are the throne from which it can look out to survey all it controls-and the wider world it seeks to control.",
-												"Throughout the lair complex, servants erect monuments to the dragon's power, telling the grim story of its life, the enemies it has slain, and the nations it has conquered."
-											]
-										}
-									]
-								}
-							]
-						}
+						"items": [
+							{
+								"type": "entries",
+								"entries": [
+									"The most covetous of the true dragons, red dragons tirelessly seek to increase their treasure hoards. They are exceptionally vain, even for dragons, and their conceit is reflected in their proud bearing and their disdain for other creatures. The odor of sulfur and pumice surrounds a red dragon, whose swept-back horns and spinal frill define its silhouette. Its beaked snout vents smoke at all times, and its eyes dance with flame when it is angry. Its wings are the longest of any chromatic dragon, and have a blue-black tint along the trailing edge that resembles metal burned blue by fire.",
+									"The scales of a red dragon wyrmling are a bright glossy scarlet, turning a dull, deeper red and becoming as thick and strong as metal as the dragon ages. Its pupils also fade as it ages, and the oldest red dragons have eyes that resemble molten lava orbs.",
+									{
+										"type": "entries",
+										"entries": [
+											{
+												"name": "Mountain Masters",
+												"type": "entries",
+												"entries": [
+													"Red dragons prefer mountainous terrain, badlands, and any other locale where they can perch high and survey their domain. Their preference for mountains brings them into conflict with the hill-dwelling copper dragons from time to time."
+												]
+											},
+											{
+												"name": "Arrogant Tyrants",
+												"type": "entries",
+												"entries": [
+													"Red dragons fly into destructive rages and act on impulse when angered. They are so ferocious and vengeful that they are regarded as the archetypical evil dragon by many cultures.",
+													"No other dragon comes close to the arrogance of the red dragon. These creatures see themselves as kings and emperors, and view the rest of dragonkind as inferior. Believing that they are chosen by Tiamat to rule in her name, red dragons consider the world and every creature in it as theirs to command."
+												]
+											},
+											{
+												"name": "Status and Slaves",
+												"type": "entries",
+												"entries": [
+													"Red dragons are fiercely territorial and isolationist. However, they yearn to know about events in the wider world, and they make use of lesser creatures as informants, messengers, and spies. They are most interested in news about other red dragons, with which they compete constantly for status.",
+													"When it requires servants, a red dragon demands fealty from chaotic evil humanoids. If allegiance isn't forthcoming, it slaughters a tribe's leaders and claims lordship over the survivors. Creatures serving a red dragon live in constant terror of being roasted and eaten for displeasing it. They spend most of their time fawning over the creature in an attempt to stay alive."
+												]
+											},
+											{
+												"name": "Obsessive Collectors",
+												"type": "entries",
+												"entries": [
+													"Red dragons value wealth above all else, and their treasure hoards are legendary. They covet anything of monetary value, and can often judge the worth of a bauble to within a copper piece at a glance. A red dragon has a special affection for treasure claimed from powerful enemies it has slain, exhibiting that treasure to prove its superiority.",
+													"A red dragon knows the value and provenance of every item in its hoard, along with each item's exact location. It might notice the absence of a single coin, igniting its rage as it tracks down and slays the thief without mercy. If the thief can't be found, the dragon goes on a rampage, laying waste to towns and villages in an attempt to sate its wrath."
+												]
+											}
+										]
+									}
+								]
+							},
+							{
+								"type": "entries",
+								"name": "A Red Dragon's Lair",
+								"entries": [
+									"Red dragons lair in high mountains or hills, dwelling in caverns under snow-capped peaks, or within the deep halls of abandoned mines and dwarven strongholds. Caves with volcanic or geothermal activity are the most highly prized red dragon lairs, creating hazards that hinder intruders and letting searing heat and volcanic gases wash over a dragon as it sleeps. With its hoard well protected deep within the lair, a red dragon spends as much of its time outside the mountain as in it. For a red dragon, the great heights of the world are the throne from which it can look out to survey all it controls-and the wider world it seeks to control.",
+									"Throughout the lair complex, servants erect monuments to the dragon's power, telling the grim story of its life, the enemies it has slain, and the nations it has conquered."
+								]
+							}
+						]
 					},
 					"images": {
 						"mode": "prependArr",
@@ -12595,35 +12853,20 @@
 		{
 			"name": "Rug of Smothering",
 			"source": "MM",
-			"entries": [
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								"Would-be thieves and careless heroes arrive at the doorsteps of an enemy's abode, eyes and ears alert for traps, only to end their quest prematurely as the rugs beneath their feet animate and smother them to death.",
-								"A rug of smothering can be made in many different forms, from a finely woven carpet fit for a queen to a coarse mat in a peasant's hovel. Creatures with the ability to sense magic detect the rug's false magical aura.",
-								"In some cases, a rug of smothering is disguised as a carpet of flying or another beneficial magic item. However, a character who stands or sits on the rug, or who attempts to utter a word of command, is quickly trapped as the rug of smothering rolls itself tightly around its victim.",
-								{
-									"type": "entries",
-									"name": "Animated Objects",
-									"entries": [
-										"Animated objects are crafted with potent magic to follow the commands of their creators. When not commanded, they follow the last order they received to the best of their ability, and can act independently to fulfill simple instructions. Some animated objects (including many of those created in the Feywild) might converse fluently or adopt a persona, but most are simple automatons.",
-										{
-											"name": "Constructed Nature",
-											"entries": [
-												"An animated object doesn't require air, food, drink, or sleep. The magic that animates an object is dispelled when the construct drops to 0 hit points. An animated object reduced to 0 hit points becomes inanimate and is too damaged to be of much use or value to anyone."
-											],
-											"type": "entries"
-										}
-									]
-								}
-							]
-						}
-					]
+			"_copy": {
+				"name": "Animated Objects",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": [
+							"Would-be thieves and careless heroes arrive at the doorsteps of an enemy's abode, eyes and ears alert for traps, only to end their quest prematurely as the rugs beneath their feet animate and smother them to death.",
+							"A rug of smothering can be made in many different forms, from a finely woven carpet fit for a queen to a coarse mat in a peasant's hovel. Creatures with the ability to sense magic detect the rug's false magical aura.",
+							"In some cases, a rug of smothering is disguised as a {@item carpet of flying} or another beneficial magic item. However, a character who stands or sits on the rug, or who attempts to utter a word of command, is quickly trapped as the rug of smothering rolls itself tightly around its victim.",
+						]
+					}
 				}
-			],
+			},
 			"images": [
 				{
 					"type": "image",
@@ -13340,54 +13583,61 @@
 				"_mod": {
 					"entries": {
 						"mode": "prependArr",
-						"items": {
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"entries": [
-										"The friendliest and most social of the metallic dragons, silver dragons cheerfully assist good creatures in need.",
-										"A silver dragon shimmers as if sculpted from pure metal, its face given a noble cast by its high eyes and sweeping beard-like chin spikes. A spiny frill rises high over its head, tracing down its neck to the tip of its tail. A silver wyrmling's scales are blue-gray with silver highlights. As the dragon approaches adulthood, its color gradually brightens until its individual scales are barely visible. As a silver dragon grows older, its pupils fade until its eyes resemble orbs of mercury.",
-										{
-											"name": "Dragons of Virtue",
-											"type": "entries",
-											"entries": [
-												"Silver dragons believe that living a moral life involves doing good deeds and ensuring that one's actions cause no undeserved harm to other sentient beings. They don't take it upon themselves to root out evil, as gold and bronze dragons do, but they will gladly oppose creatures that dare to commit evil acts or harm the innocent."
-											]
-										},
-										{
-											"name": "Friends of the Small Races",
-											"type": "entries",
-											"entries": [
-												"Silver dragons enjoy the company of other silver dragons. Their only true friendships outside their own kin arise in the company of humanoids, and many silver dragons spend as much time in humanoid form as they do in draconic form. A silver dragon adopts a benign humanoid persona such as a kindly old sage or a young wanderer, and it often has mortal companions with whom it develops strong friendships.",
-												"Silver dragons must step away from their humanoid lives on a regular basis, returning to their true forms to mate and rear offspring, or to tend to their hoards and personal affairs. Because many lose track of time while away, they sometimes return to find that their companions have grown old or died. Silver dragons often end up befriending several generations of humanoids within a single family as a result.",
-												{
-													"name": "Respect for Humanity",
-													"entries": [
-														"Silver dragons befriend humanoids of all races, but shorter-lived races such as humans spark their curiosity in a way the longer-lived elves and dwarves don't. Humans have a drive and zest for life that silver dragons find fascinating."
-													],
-													"type": "entries"
-												}
-											]
-										},
-										{
-											"name": "Hoarding History",
-											"type": "entries",
-											"entries": [
-												"Silver dragons love to possess relics of humanoid history. This includes the great piles of coins they covet, minted by current and fallen humanoid empires, as well as art objects and fine jewelery crafted by numerous races. Other treasures that make up their hoards can include intact ships, the remains of kings and queens, thrones, the crown jewels of ancient empires, inventions and contraptions, and monoliths carried from the ruins of fallen cities."
-											]
-										},
-										{
-											"type": "entries",
-											"name": "A Silver Dragon's Lair",
-											"entries": [
-												"Silver dragons dwell among the clouds, making their lairs on secluded cold mountain peaks. Though many are comfortable in natural cavern complexes or abandoned mines, silver dragons covet the lost outposts of humanoid civilization. An abandoned mountaintop citadel or a remote tower raised by a long-dead wizard is the sort of lair that every silver dragon dreams of."
-											]
-										}
-									]
-								}
-							]
-						}
+						"items": [
+							{
+								"type": "entries",
+								"entries": [
+									{
+										"type": "entries",
+										"entries": [
+											"The friendliest and most social of the metallic dragons, silver dragons cheerfully assist good creatures in need.",
+											"A silver dragon shimmers as if sculpted from pure metal, its face given a noble cast by its high eyes and sweeping beard-like chin spikes. A spiny frill rises high over its head, tracing down its neck to the tip of its tail. A silver wyrmling's scales are blue-gray with silver highlights. As the dragon approaches adulthood, its color gradually brightens until its individual scales are barely visible. As a silver dragon grows older, its pupils fade until its eyes resemble orbs of mercury.",
+											{
+												"type": "entries",
+												"entries": [
+													{
+														"name": "Dragons of Virtue",
+														"type": "entries",
+														"entries": [
+															"Silver dragons believe that living a moral life involves doing good deeds and ensuring that one's actions cause no undeserved harm to other sentient beings. They don't take it upon themselves to root out evil, as gold and bronze dragons do, but they will gladly oppose creatures that dare to commit evil acts or harm the innocent."
+														]
+													},
+													{
+														"name": "Friends of the Small Races",
+														"type": "entries",
+														"entries": [
+															"Silver dragons enjoy the company of other silver dragons. Their only true friendships outside their own kin arise in the company of humanoids, and many silver dragons spend as much time in humanoid form as they do in draconic form. A silver dragon adopts a benign humanoid persona such as a kindly old sage or a young wanderer, and it often has mortal companions with whom it develops strong friendships.",
+															"Silver dragons must step away from their humanoid lives on a regular basis, returning to their true forms to mate and rear offspring, or to tend to their hoards and personal affairs. Because many lose track of time while away, they sometimes return to find that their companions have grown old or died. Silver dragons often end up befriending several generations of humanoids within a single family as a result.",
+															{
+																"name": "Respect for Humanity",
+																"entries": [
+																	"Silver dragons befriend humanoids of all races, but shorter-lived races such as humans spark their curiosity in a way the longer-lived elves and dwarves don't. Humans have a drive and zest for life that silver dragons find fascinating."
+																],
+																"type": "entries"
+															}
+														]
+													},
+													{
+														"name": "Hoarding History",
+														"type": "entries",
+														"entries": [
+															"Silver dragons love to possess relics of humanoid history. This includes the great piles of coins they covet, minted by current and fallen humanoid empires, as well as art objects and fine jewelery crafted by numerous races. Other treasures that make up their hoards can include intact ships, the remains of kings and queens, thrones, the crown jewels of ancient empires, inventions and contraptions, and monoliths carried from the ruins of fallen cities."
+														]
+													}
+												]
+											}
+										]
+									}
+								]
+							},
+							{
+								"type": "entries",
+								"name": "A Silver Dragon's Lair",
+								"entries": [
+									"Silver dragons dwell among the clouds, making their lairs on secluded cold mountain peaks. Though many are comfortable in natural cavern complexes or abandoned mines, silver dragons covet the lost outposts of humanoid civilization. An abandoned mountaintop citadel or a remote tower raised by a long-dead wizard is the sort of lair that every silver dragon dreams of."
+								]
+							}
+						]
 					},
 					"images": {
 						"mode": "prependArr",
@@ -13778,6 +14028,18 @@
 									"entries": [
 										"Smaller than most other devils, spinagons act as messengers and spies for greater devils and archdevils. They are the eyes and ears of the Nine Hells, and even fiends that despise a spined devil's weakness treat it with a modicum of respect. A spined devil's body and tail bristle with spines, and it can fling its tail spines as ranged weapons. The spines burst into flame on impact.",
 										"When not delivering messages or gathering intelligence, spined devils serve in the infernal legions as flying artillery, making up for their relative weakness by mobbing together to overwhelm their foes. Though they crave promotion and power, spined devils are craven by nature, and they will quickly scatter if a fight goes against them."
+									]
+								},
+								{
+									"type": "insetReadaloud",
+									"entries": [
+										{
+											"type": "quote",
+											"entries": [
+												"Fly, my pretties, fly! {@style Fly!|small-caps}"
+											],
+											"by": "Fierna, Archduchess of Phlegethos, commanding her spined devil legions"
+										}
 									]
 								}
 							]
@@ -14693,50 +14955,20 @@
 		{
 			"name": "Twig Blight",
 			"source": "MM",
-			"entries": [
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								"Awakened plants gifted with the powers of intelligence and mobility, blights plague lands contaminated by darkness. Drinking that darkness from the soil, a blight carries out the will of ancient evil and attempts to spread that evil wherever it can.",
-								{
-									"name": "Roots of the Gulthias Tree",
-									"type": "entries",
-									"entries": [
-										"Legends tell of a vampire named Gulthias who worked terrible magic and raised up an abominable tower called Nightfang Spire. Gulthias was undone when a hero plunged a wooden stake through his heart, but as the vampire was destroyed, his blood infused the stake with a dreadful power. In time, tendrils of new growth sprouted from the wood, growing into a sapling infused with the vampire's evil essence. It is said that a mad druid discovered the sapling, transplanting it to an underground grotto where it could grow. From this Gulthias tree came the seeds from which the first blights were sown."
-									]
-								},
-								{
-									"name": "Dark Conquest",
-									"type": "entries",
-									"entries": [
-										"Wherever a tree or plant is contaminated by a fragment of an evil mind or power, a Gulthias tree can rise to infest and corrupt the surrounding forest. Its evil spreads through root and soil to other plants, which perish or transform into blights. As those blights spread, they poison and uproot healthy plants, replacing them with brambles, toxic weeds, and others of their kind. In time, an infestation of blights can turn any land or forest into a place of corruption.",
-										"In forests infested with blights, trees and plants grow with supernatural speed. Vines and undergrowth rapidly spread through buildings and overrun trails and roads. After blights have killed or driven off their inhabitants, whole villages can disappear in the space of days.",
-										{
-											"name": "Controlled by Evil",
-											"entries": [
-												"Blights are independent creatures, but most act under a Gulthias tree's control, often displaying the habits and traits of the life force or spirit that spawned them. By attacking their progenitor's old foes or seeking out treasures valuable to it, they carry on the legacy of long-lost evil."
-											],
-											"type": "entries"
-										}
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Twig Blight",
-									"entries": [
-										"Twig blights can root in soil, which they do when living prey are scarce. While rooted, they resemble woody shrubs. When it pulls its roots free of the ground to move, a twig blight's branches twist together to form a humanoid-looking body with a head and limbs.",
-										"Twig blights seek out campsites and watering holes, rooting there to set up ambushes for potential victims coming to drink or rest. Huddled together in groups, twig blights blend in with an area's natural vegetation or with piles of debris or firewood.",
-										"Given how dry they are, twig blights are particularly susceptible to fire."
-									]
-								}
-							]
-						}
-					]
+			"_copy": {
+				"name": "Blights",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": [
+							"Twig blights can root in soil, which they do when living prey are scarce. While rooted, they resemble woody shrubs. When it pulls its roots free of the ground to move, a twig blight's branches twist together to form a humanoid-looking body with a head and limbs.",
+							"Twig blights seek out campsites and watering holes, rooting there to set up ambushes for potential victims coming to drink or rest. Huddled together in groups, twig blights blend in with an area's natural vegetation or with piles of debris or firewood.",
+							"Given how dry they are, twig blights are particularly susceptible to fire."
+						]
+					}
 				}
-			],
+			},
 			"images": [
 				{
 					"type": "image",
@@ -15083,27 +15315,56 @@
 		{
 			"name": "Vine Blight",
 			"source": "MM",
+			"_copy": {
+				"name": "Blights",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": "Appearing as masses of slithering creepers, vine blights hide in undergrowth and wait for prey to draw near. By animating the plants around them, vine blights entangle and hinder their foes before attacking. Vine blights are the only blights capable of speech. Through its connection to the evil spirit of the Gulthias tree it serves, a vine blight speaks in a fractured version of its dead master's voice, taunting victims or bargaining with powerful foes."
+					}
+				}
+			},
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "internal",
+						"path": "bestiary/MM/Vine Blight.png"
+					}
+				}
+			]
+		},
+		{
+			"name": "Blights",
+			"source": "MM",
 			"entries": [
 				{
-					"type": "entries",
+					"type": "section",
+					"name": "Blights",
 					"entries": [
 						{
 							"type": "entries",
 							"entries": [
 								"Awakened plants gifted with the powers of intelligence and mobility, blights plague lands contaminated by darkness. Drinking that darkness from the soil, a blight carries out the will of ancient evil and attempts to spread that evil wherever it can.",
 								{
-									"name": "Roots of the Gulthias Tree",
 									"type": "entries",
 									"entries": [
-										"Legends tell of a vampire named Gulthias who worked terrible magic and raised up an abominable tower called Nightfang Spire. Gulthias was undone when a hero plunged a wooden stake through his heart, but as the vampire was destroyed, his blood infused the stake with a dreadful power. In time, tendrils of new growth sprouted from the wood, growing into a sapling infused with the vampire's evil essence. It is said that a mad druid discovered the sapling, transplanting it to an underground grotto where it could grow. From this Gulthias tree came the seeds from which the first blights were sown."
-									]
-								},
-								{
-									"name": "Dark Conquest",
-									"type": "entries",
-									"entries": [
-										"Wherever a tree or plant is contaminated by a fragment of an evil mind or power, a Gulthias tree can rise to infest and corrupt the surrounding forest. Its evil spreads through root and soil to other plants, which perish or transform into blights. As those blights spread, they poison and uproot healthy plants, replacing them with brambles, toxic weeds, and others of their kind. In time, an infestation of blights can turn any land or forest into a place of corruption.",
-										"In forests infested with blights, trees and plants grow with supernatural speed. Vines and undergrowth rapidly spread through buildings and overrun trails and roads. After blights have killed or driven off their inhabitants, whole villages can disappear in the space of days.",
+										{
+											"name": "Roots of the Gulthias Tree",
+											"type": "entries",
+											"entries": [
+												"Legends tell of a vampire named Gulthias who worked terrible magic and raised up an abominable tower called Nightfang Spire. Gulthias was undone when a hero plunged a wooden stake through his heart, but as the vampire was destroyed, his blood infused the stake with a dreadful power. In time, tendrils of new growth sprouted from the wood, growing into a sapling infused with the vampire's evil essence. It is said that a mad druid discovered the sapling, transplanting it to an underground grotto where it could grow. From this Gulthias tree came the seeds from which the first blights were sown."
+											]
+										},
+										{
+											"name": "Dark Conquest",
+											"type": "entries",
+											"entries": [
+												"Wherever a tree or plant is contaminated by a fragment of an evil mind or power, a Gulthias tree can rise to infest and corrupt the surrounding forest. Its evil spreads through root and soil to other plants, which perish or transform into blights. As those blights spread, they poison and uproot healthy plants, replacing them with brambles, toxic weeds, and others of their kind. In time, an infestation of blights can turn any land or forest into a place of corruption.",
+												"In forests infested with blights, trees and plants grow with supernatural speed. Vines and undergrowth rapidly spread through buildings and overrun trails and roads. After blights have killed or driven off their inhabitants, whole villages can disappear in the space of days."
+											]
+										},
 										{
 											"name": "Controlled by Evil",
 											"entries": [
@@ -15112,26 +15373,21 @@
 											"type": "entries"
 										}
 									]
-								},
+								}
+							]
+						},
+						{
+							"type": "insetReadaloud",
+							"entries": [
 								{
-									"type": "entries",
-									"name": "Vine Blight",
+									"type": "quote",
 									"entries": [
-										"Appearing as masses of slithering creepers, vine blights hide in undergrowth and wait for prey to draw near. By animating the plants around them, vine blights entangle and hinder their foes before attacking. Vine blights are the only blights capable of speech. Through its connection to the evil spirit of the Gulthias tree it serves, a vine blight speaks in a fractured version of its dead master's voice, taunting victims or bargaining with powerful foes."
+										"Behold the legacy of Gulthias the vampire: plants with a taste for blood."
 									]
 								}
 							]
 						}
 					]
-				}
-			],
-			"images": [
-				{
-					"type": "image",
-					"href": {
-						"type": "internal",
-						"path": "bestiary/MM/Vine Blight.png"
-					}
 				}
 			]
 		},
@@ -15490,54 +15746,56 @@
 				"_mod": {
 					"entries": {
 						"mode": "prependArr",
-						"items": {
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"entries": [
-										"The smallest, least intelligent, and most animalistic of the chromatic dragons, white dragons dwell in frigid climes, favoring arctic areas or icy mountains. They are vicious, cruel reptiles driven by hunger and greed.",
-										"A white dragon has feral eyes, a sleek profile, and a spined crest. The scales of a wyrmling white dragon glisten pure white. As the dragon ages, its sheen disappears and some of its scales begin to darken, so that by the time it is old, it is mottled by patches of pale blue and light gray. This patterning helps the dragon blend into the realms of ice and stone in which it hunts, and to fade from view when it soars across a cloud-filled sky.",
-										{
-											"name": "Primal and Vengeful",
-											"type": "entries",
-											"entries": [
-												"White dragons lack the cunning and tactics of most other dragons. However, their bestial nature makes them the best hunters among all dragonkind, singularly focused on surviving and slaughtering their enemies. A white dragon consumes only food that has been frozen, devouring creatures killed by its breath weapon while they are still stiff and frigid. It encases other kills in ice or buries them in snow near its lair, and finding such a larder is a good indication that a white dragon dwells nearby.",
-												"A white dragon also keeps the bodies of its greatest enemies as trophies, freezing corpses where it can look upon them and gloat. The remains of giants, remorhazes, and other dragons are often positioned prominently within a white dragon's lair as warnings to intruders.",
-												"Though only moderately intelligent, white dragons have extraordinary memories. They recall every slight and defeat, and have been known to conduct malicious vendettas against creatures that have offended them. This often includes silver dragons, which lair in the same territories as whites. White dragons can speak as all dragons can, but they rarely talk unless moved to do so."
-											]
-										},
-										{
-											"name": "Lone Masters",
-											"type": "entries",
-											"entries": [
-												"White dragons avoid all other dragons except whites of the opposite sex. Even then, when white dragons seek each other out as mates, they stay together only long enough to conceive offspring before fleeing into isolation again.",
-												"White dragons can't abide rivals near their lairs. As a result, a white dragon attacks other creatures without provocation, viewing such creatures as either too weak or too powerful to live. The only creatures that typically serve a white dragon are intelligent humanoids that demonstrate enough strength to assuage the dragon's wrath, and can put up with sustaining regular losses as a result of its hunger. This includes dragon-worshiping kobolds, which are commonly found in their lairs.",
-												"Powerful creatures can sometimes gain a white dragon's obedience through a demonstration of physical or magical might. Frost giants challenge white dragons to prove their own strength and improve their status in their clans, and their cracked bones litter many a white dragon's lair. However, a white dragon defeated by a frost giant often becomes its servant, accepting the mastery of a superior creature in exchange for asserting its own domination over the other creatures that serve or oppose the giant."
-											]
-										},
-										{
-											"name": "Treasure Under Ice",
-											"type": "entries",
-											"entries": [
-												"White dragons love the cold sparkle of ice and favor treasure with similar qualities, particularly diamonds. However, in their remote arctic climes, the treasure hoards of white dragons more often contain walrus and mammoth tusk ivory, whale-bone sculptures, figureheads from ships, furs, and magic items seized from overly bold adventurers.",
-												"Loose coins and gems are spread across a white dragon's lair, glittering like stars when the light strikes them. Larger treasures and chests are encased in layers of rime created by the white dragon's breath, and held safe beneath layers of transparent ice. The dragon's great strength allows it to easily access its wealth, while lesser creatures must spend hours chipping away or melting the ice to reach the dragon's main hoard.",
-												"A white dragon's flawless memory means that it knows how it came to possess every coin, gem, and magic item in its hoard, and it associates each item with a specific victory. White dragons are notoriously difficult to bribe, since any offers of treasure are seen as an insult to their ability to simply slay the creature making the offer and seize the treasure on their own."
-											]
-										},
-										{
-											"type": "entries",
-											"name": "A White Dragon's Lair",
-											"entries": [
-												"White dragons lair in icy caves and deep subterranean chambers far from the sun. They favor high mountain vales accessible only by flying, caverns in cliff faces, and labyrinthine ice caves in glaciers. White dragons love vertical heights in their caverns, flying up to the ceiling to latch on like bats or slithering down icy crevasses.",
-												"A legendary white dragon's innate magic deepens the cold in the area around its lair. Mountain caverns are fast frozen by the white dragon's presence. A white dragon can often detect intruders by the way the keening wind in its lair changes tone.",
-												"A white dragon rests on high ice shelves and cliffs in its lair, the floor around it a treacherous morass of broken ice and stone, hidden pits, and slippery slopes. As foes struggle to move toward it, the dragon flies from perch to perch and destroys them with its freezing breath."
-											]
-										}
-									]
-								}
-							]
-						}
+						"items": [
+							{
+								"type": "entries",
+								"entries": [
+									{
+										"type": "entries",
+										"entries": [
+											"The smallest, least intelligent, and most animalistic of the chromatic dragons, white dragons dwell in frigid climes, favoring arctic areas or icy mountains. They are vicious, cruel reptiles driven by hunger and greed.",
+											"A white dragon has feral eyes, a sleek profile, and a spined crest. The scales of a wyrmling white dragon glisten pure white. As the dragon ages, its sheen disappears and some of its scales begin to darken, so that by the time it is old, it is mottled by patches of pale blue and light gray. This patterning helps the dragon blend into the realms of ice and stone in which it hunts, and to fade from view when it soars across a cloud-filled sky.",
+											{
+												"name": "Primal and Vengeful",
+												"type": "entries",
+												"entries": [
+													"White dragons lack the cunning and tactics of most other dragons. However, their bestial nature makes them the best hunters among all dragonkind, singularly focused on surviving and slaughtering their enemies. A white dragon consumes only food that has been frozen, devouring creatures killed by its breath weapon while they are still stiff and frigid. It encases other kills in ice or buries them in snow near its lair, and finding such a larder is a good indication that a white dragon dwells nearby.",
+													"A white dragon also keeps the bodies of its greatest enemies as trophies, freezing corpses where it can look upon them and gloat. The remains of giants, remorhazes, and other dragons are often positioned prominently within a white dragon's lair as warnings to intruders.",
+													"Though only moderately intelligent, white dragons have extraordinary memories. They recall every slight and defeat, and have been known to conduct malicious vendettas against creatures that have offended them. This often includes silver dragons, which lair in the same territories as whites. White dragons can speak as all dragons can, but they rarely talk unless moved to do so."
+												]
+											},
+											{
+												"name": "Lone Masters",
+												"type": "entries",
+												"entries": [
+													"White dragons avoid all other dragons except whites of the opposite sex. Even then, when white dragons seek each other out as mates, they stay together only long enough to conceive offspring before fleeing into isolation again.",
+													"White dragons can't abide rivals near their lairs. As a result, a white dragon attacks other creatures without provocation, viewing such creatures as either too weak or too powerful to live. The only creatures that typically serve a white dragon are intelligent humanoids that demonstrate enough strength to assuage the dragon's wrath, and can put up with sustaining regular losses as a result of its hunger. This includes dragon-worshiping kobolds, which are commonly found in their lairs.",
+													"Powerful creatures can sometimes gain a white dragon's obedience through a demonstration of physical or magical might. Frost giants challenge white dragons to prove their own strength and improve their status in their clans, and their cracked bones litter many a white dragon's lair. However, a white dragon defeated by a frost giant often becomes its servant, accepting the mastery of a superior creature in exchange for asserting its own domination over the other creatures that serve or oppose the giant."
+												]
+											},
+											{
+												"name": "Treasure Under Ice",
+												"type": "entries",
+												"entries": [
+													"White dragons love the cold sparkle of ice and favor treasure with similar qualities, particularly diamonds. However, in their remote arctic climes, the treasure hoards of white dragons more often contain walrus and mammoth tusk ivory, whale-bone sculptures, figureheads from ships, furs, and magic items seized from overly bold adventurers.",
+													"Loose coins and gems are spread across a white dragon's lair, glittering like stars when the light strikes them. Larger treasures and chests are encased in layers of rime created by the white dragon's breath, and held safe beneath layers of transparent ice. The dragon's great strength allows it to easily access its wealth, while lesser creatures must spend hours chipping away or melting the ice to reach the dragon's main hoard.",
+													"A white dragon's flawless memory means that it knows how it came to possess every coin, gem, and magic item in its hoard, and it associates each item with a specific victory. White dragons are notoriously difficult to bribe, since any offers of treasure are seen as an insult to their ability to simply slay the creature making the offer and seize the treasure on their own."
+												]
+											}
+										]
+									}
+								]
+							},
+							{
+								"type": "entries",
+								"name": "A White Dragon's Lair",
+								"entries": [
+									"White dragons lair in icy caves and deep subterranean chambers far from the sun. They favor high mountain vales accessible only by flying, caverns in cliff faces, and labyrinthine ice caves in glaciers. White dragons love vertical heights in their caverns, flying up to the ceiling to latch on like bats or slithering down icy crevasses.",
+									"A legendary white dragon's innate magic deepens the cold in the area around its lair. Mountain caverns are fast frozen by the white dragon's presence. A white dragon can often detect intruders by the way the keening wind in its lair changes tone.",
+									"A white dragon rests on high ice shelves and cliffs in its lair, the floor around it a treacherous morass of broken ice and stone, hidden pits, and slippery slopes. As foes struggle to move toward it, the dragon flies from perch to perch and destroys them with its freezing breath."
+								]
+							}
+						]
 					},
 					"images": {
 						"mode": "prependArr",

--- a/data/bestiary/fluff-bestiary-mpmm.json
+++ b/data/bestiary/fluff-bestiary-mpmm.json
@@ -1092,7 +1092,7 @@
 					"name": "Valuable Parts",
 					"type": "entries",
 					"entries": [
-						"Nearly every part of a cave fisher is useful after the creature has been dispatched. Cave fisher filaments can be woven into rope that is thin, tough, and nearly {@condition invisible}. The creature's shell is used in the manufacture of tools, armor, and jewelry. Its blood is alcoholic and tastes like strong liquor. Several dwarven spirits include cave fisher blood, and some dwarves, especially berserkers, drink the blood straight. Cave fisher meat is edible, tasting much like crab cooked in strong wine.",
+						"Nearly every part of a cave fisher is useful after the creature has been dispatched. Cave fisher filaments can be woven into rope that is thin, tough, and nearly invisible. The creature's shell is used in the manufacture of tools, armor, and jewelry. Its blood is alcoholic and tastes like strong liquor. Several dwarven spirits include cave fisher blood, and some dwarves, especially berserkers, drink the blood straight. Cave fisher meat is edible, tasting much like crab cooked in strong wine.",
 						"While some folk hunt cave fishers to kill them to harvest their filaments, shells, and blood, others capture cave fisher eggs and rear the hatchlings, which can be trained to guard passages or serve as beasts of war. Cave fishers have a natural aversion to fire, since their blood is flammable. As such, Underdark denizens often use the threat of fire when training them."
 					]
 				}

--- a/data/bestiary/fluff-bestiary-vgm.json
+++ b/data/bestiary/fluff-bestiary-vgm.json
@@ -2,7 +2,12 @@
 	"_meta": {
 		"internalCopies": [
 			"monsterFluff"
-		]
+		],
+		"dependencies": {
+			"monsterFluff": [
+				"MM"
+			]
+		}
 	},
 	"monsterFluff": [
 		{
@@ -44,7 +49,7 @@
 										{
 											"name": "Arcane Temptation",
 											"entries": [
-												" Elder brains forbid mind flayers from pursuing magic power aside from psionics, but it isn't an interdiction they must often enforce. Illithids brook no masters but members of their own kind, so it isn't in their nature to bow to any god or otherworldly patron. However, wizardry remains a rare temptation.",
+												"Elder brains forbid mind flayers from pursuing magic power aside from psionics, but it isn't an interdiction they must often enforce. Illithids brook no masters but members of their own kind, so it isn't in their nature to bow to any god or otherworldly patron. However, wizardry remains a rare temptation.",
 												"In the pages of a spellbook, an illithid sees a system to acquire authority. Through the writings of the wizard who penned it, the illithid perceives the workings of a highly intelligent mind. Most mind flayers who find a spellbook react with abhorrence or indifference, but for some a spellbook is a gateway to a new way of thinking.",
 												"For a time, the study of such forbidden texts can be hidden from other illithids and even from an elder brain. Understanding of wizardry eludes the mind like a living thing. Yet eventually, understanding comes, and a mind flayer arcanist must accept itself as deviant and flee the colony if it is to live.",
 												"Confronting this awful reality, a group of nine mind flayer deviants used their arcane magic and psionics to weave a new truth. These nine called themselves the alhoon, and ever afterward, all those who follow in their footsteps have been referred to by the same name.",
@@ -58,28 +63,28 @@
 										{
 											"name": "Existential Fear",
 											"entries": [
-												" Arcanist deviants that taste freedom from the colony react in a variety of ways. Some prize their privacy, others seek to commune with similar minds, and still others seek to dominate a colony, elevating themselves to the position of leadership normally held by an elder brain. Regardless of the arcanist's personal inclinations, it faces the same stark fact: When it dies, it will not join the host of minds in the elder brain. Deviant minds are never accepted as part of the collective. For it, death means oblivion."
+												"Arcanist deviants that taste freedom from the colony react in a variety of ways. Some prize their privacy, others seek to commune with similar minds, and still others seek to dominate a colony, elevating themselves to the position of leadership normally held by an elder brain. Regardless of the arcanist's personal inclinations, it faces the same stark fact: When it dies, it will not join the host of minds in the elder brain. Deviant minds are never accepted as part of the collective. For it, death means oblivion."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Dreadful Deliverance",
 											"entries": [
-												" Lichdom offers salvation and the prospect of being able to pursue knowledge indefinitely. Having feasted on the brains of people when alive, a mind flayer has no compunction about feeding souls to a phylactery. The only hindrance to a mind flayer becoming a lich is the means, which is a secret some mind flayer arcanists stop at nothing to discover. Yet lichdom requires an arcane spellcaster to be at the apex of power, something many mind flayers find is far from their grasps."
+												"Lichdom offers salvation and the prospect of being able to pursue knowledge indefinitely. Having feasted on the brains of people when alive, a mind flayer has no compunction about feeding souls to a phylactery. The only hindrance to a mind flayer becoming a lich is the means, which is a secret some mind flayer arcanists stop at nothing to discover. Yet lichdom requires an arcane spellcaster to be at the apex of power, something many mind flayers find is far from their grasps."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "A Psionic Secret",
 											"entries": [
-												" Alhoons can cooperate in the creation of a periapt of mind trapping, a fist-sized container made of silver, emerald, and amethyst. The process requires at least three mind flayer arcanists and the sacrifice of an equal number of souls from living victims in a three-day-long ritual of spellcasting and psionic communion. Upon its completion, free-willed undeath is conferred on the mind flayers, turning them into alhoons."
+												"Alhoons can cooperate in the creation of a periapt of mind trapping, a fist-sized container made of silver, emerald, and amethyst. The process requires at least three mind flayer arcanists and the sacrifice of an equal number of souls from living victims in a three-day-long ritual of spellcasting and psionic communion. Upon its completion, free-willed undeath is conferred on the mind flayers, turning them into alhoons."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Precarious Immortality",
 											"entries": [
-												" Unlike with true lichdom, the periapt of mind trapping doesn't restore the alhoons to undeath if they are destroyed. Instead, a destroyed alhoon's mind is transferred to the periapt where it remains in communion with any other trapped alhoon minds, as well as the souls of those sacrificed."
+												"Unlike with true lichdom, the periapt of mind trapping doesn't restore the alhoons to undeath if they are destroyed. Instead, a destroyed alhoon's mind is transferred to the periapt where it remains in communion with any other trapped alhoon minds, as well as the souls of those sacrificed."
 											],
 											"type": "entries"
 										}
@@ -117,7 +122,7 @@
 										{
 											"name": "Tormenting the Weak",
 											"entries": [
-												" Although annis hags can easily tear a grown man apart, they love hunting children, preferring their flesh above all others. They use the flayed skin of such victims to make supple leather, and a hag's lair often shows the signs of this industry.",
+												"Although annis hags can easily tear a grown man apart, they love hunting children, preferring their flesh above all others. They use the flayed skin of such victims to make supple leather, and a hag's lair often shows the signs of this industry.",
 												"Annis hags leave tokens of their cruelty at the edges of forests and other areas they claim. In this way, they provoke fear and paranoia in nearby villages and settlements. To an annis hag, nothing is sweeter than turning a vibrant community into a place paralyzed with terror, where folk never venture out at night, strangers are met with suspicion and anger, and parents warn their children to \"be good, or the annis will get you.\""
 											],
 											"type": "entries"
@@ -125,21 +130,21 @@
 										{
 											"name": "Child Corrupter",
 											"entries": [
-												" When an annis feels especially cruel, she disguises herself as a kindly-looking elderly woman, approaches a child in a remote place, and gives it an iron token that it can use to confide in her. Over time, \"Granny\" convinces the child that it's okay to have bad thoughts and do bad deeds-starting with breaking things or wandering outside without permission, then graduating to pushing someone down the stairs or setting a house on fire. Sooner or later, the child's family and community become terrified of the \"bad seed\" and must face the awful decision of whether the child should be punished or exiled."
+												"When an annis feels especially cruel, she disguises herself as a kindly-looking elderly woman, approaches a child in a remote place, and gives it an iron token that it can use to confide in her. Over time, \"Granny\" convinces the child that it's okay to have bad thoughts and do bad deeds-starting with breaking things or wandering outside without permission, then graduating to pushing someone down the stairs or setting a house on fire. Sooner or later, the child's family and community become terrified of the \"bad seed\" and must face the awful decision of whether the child should be punished or exiled."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Tribe Mother",
 											"entries": [
-												" Much in the way that they befriend children in order to corrupt them, annis hags have a tendency for adopting a group of ogres, trolls, or other loutish creatures, ruling them through brute strength, verbal abuse, and superstition."
+												"Much in the way that they befriend children in order to corrupt them, annis hags have a tendency for adopting a group of ogres, trolls, or other loutish creatures, ruling them through brute strength, verbal abuse, and superstition."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Covens",
 											"entries": [
-												" An annis hag that is part of a coven (see the \"Hag Covens\" sidebar in the Monster Manual) has a challenge rating of 8 (3,900 XP)."
+												"An annis hag that is part of a coven (see the \"Hag Covens\" sidebar in the Monster Manual) has a challenge rating of 8 (3,900 XP)."
 											],
 											"type": "entries"
 										}
@@ -340,7 +345,7 @@
 										{
 											"name": "Birthed by Hags",
 											"entries": [
-												" In the earliest days of the world, a coven of night hags devised a ritual that led to the creation of the first banderhobb. A hag that knows the ritual might be willing to teach it for the right price. Some other dark fey and powerful fiends also know of the process, as do a few mortal mages. Instructions might also be found in a tome devoted to debased wizardry.",
+												"In the earliest days of the world, a coven of night hags devised a ritual that led to the creation of the first banderhobb. A hag that knows the ritual might be willing to teach it for the right price. Some other dark fey and powerful fiends also know of the process, as do a few mortal mages. Instructions might also be found in a tome devoted to debased wizardry.",
 												"A banderhobb fulfills its duties until its existence ends. When it expires, usually several days after its birth, it leaves behind only tarry goo and wisps of shadow. Legends tell of a dark tower in the Shadowfell where the shadows sometimes reform, and banderhobbs roam."
 											],
 											"type": "entries"
@@ -348,14 +353,14 @@
 										{
 											"name": "Silent and Deadly",
 											"entries": [
-												" When the ritual to create a banderhobb is complete, flesh, spirit, and shadow combine to produce a creature as big as an ogre. The newly formed monstrosity has spindly limbs that belie great strength. Its broad maw holds a long tongue and rows of fangs, both of which it uses to grab and swallow a creature or perhaps an object the banderhobb intends to steal. Despite its size, a banderhobb makes little noise, moving as silently as the shadows that infuse it. A banderhobb isn't capable of speech, but it can understand orders given to it by its creator and communicates with nearby banderhobbs in a psychic manner."
+												"When the ritual to create a banderhobb is complete, flesh, spirit, and shadow combine to produce a creature as big as an ogre. The newly formed monstrosity has spindly limbs that belie great strength. Its broad maw holds a long tongue and rows of fangs, both of which it uses to grab and swallow a creature or perhaps an object the banderhobb intends to steal. Despite its size, a banderhobb makes little noise, moving as silently as the shadows that infuse it. A banderhobb isn't capable of speech, but it can understand orders given to it by its creator and communicates with nearby banderhobbs in a psychic manner."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Agents of Evil",
 											"entries": [
-												" During its brief existence, a banderhobb attempts to carry out the bidding of the one who birthed it. It accomplishes its mission with no concern for the harm it suffers or creates. Its only desire is to serve and succeed. A banderhobb that is assigned to track down a target is particularly dangerous when it is provided with a lock of hair, a personal belonging, or other object connected to the target. Possession of such an item allows it to sense the creature's location from as far as a mile away."
+												"During its brief existence, a banderhobb attempts to carry out the bidding of the one who birthed it. It accomplishes its mission with no concern for the harm it suffers or creates. Its only desire is to serve and succeed. A banderhobb that is assigned to track down a target is particularly dangerous when it is provided with a lock of hair, a personal belonging, or other object connected to the target. Possession of such an item allows it to sense the creature's location from as far as a mile away."
 											],
 											"type": "entries"
 										}
@@ -480,7 +485,7 @@
 										{
 											"name": "Cold Hearts",
 											"entries": [
-												" Bheur hags are attracted to selfish actions justified by deadly cold, such as murdering a traveler for a winter coat, chopping down a dryad's grove for firewood, and so on. These actions are especially sweet to a bheur if they are unwarranted, such as a greedy merchant hoarding more food for the winter than he could possibly eat while others starve. Bheurs love to seed such ideas and thoughts in mortals. They use their ability to manipulate weather to batter villages with snow and freezing cold, hoping to instill despair that turns the villagers against each other.",
+												"Bheur hags are attracted to selfish actions justified by deadly cold, such as murdering a traveler for a winter coat, chopping down a dryad's grove for firewood, and so on. These actions are especially sweet to a bheur if they are unwarranted, such as a greedy merchant hoarding more food for the winter than he could possibly eat while others starve. Bheurs love to seed such ideas and thoughts in mortals. They use their ability to manipulate weather to batter villages with snow and freezing cold, hoping to instill despair that turns the villagers against each other.",
 												"A bheur hag loves watching unprepared people suffer and die for their mistakes during the winter. She is delighted when mortals make petty, pathetic attempts to survive, such as eating boots and leather scraps when no real food is to be found."
 											],
 											"type": "entries"
@@ -488,14 +493,14 @@
 										{
 											"name": "Awful to Behold",
 											"entries": [
-												" When a bheur hag is fully in the throes of combat and has recently slain one of her foes, she often forgoes a direct attack on her remaining enemies and instead takes a moment to feed on the corpse, dismembering it and tearing meat from bone. The sight of this savagery is enough to render witnesses temporarily insane."
+												"When a bheur hag is fully in the throes of combat and has recently slain one of her foes, she often forgoes a direct attack on her remaining enemies and instead takes a moment to feed on the corpse, dismembering it and tearing meat from bone. The sight of this savagery is enough to render witnesses temporarily insane."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Covens",
 											"entries": [
-												" A bheur hag that is part of a coven (see the \"Hag Covens\" sidebar in the Monster Manual) has a challenge rating of 9 (5,000 XP)."
+												"A bheur hag that is part of a coven (see the \"Hag Covens\" sidebar in the Monster Manual) has a challenge rating of 9 (5,000 XP)."
 											],
 											"type": "entries"
 										}
@@ -571,7 +576,7 @@
 										{
 											"name": "Marked by Orcus",
 											"entries": [
-												" A worshiper of Orcus can take ritual vows while carving the demon lord's symbol on its chest over the heart. Orcus's power flays body, mind, and soul, leaving behind a sentient husk that sucks in all life energy near it. Most bodaks come into being in this way, then unleashed to spread death in Orcus's name.",
+												"A worshiper of Orcus can take ritual vows while carving the demon lord's symbol on its chest over the heart. Orcus's power flays body, mind, and soul, leaving behind a sentient husk that sucks in all life energy near it. Most bodaks come into being in this way, then unleashed to spread death in Orcus's name.",
 												"Orcus created the first bodaks in the Abyss from seven devotees, called the Hierophants of Annihilation. These figures, as mighty as balors, have free will but serve the Prince of Undeath directly. Any one of these bodaks can turn a slain mortal into a bodak with its gaze. Like each Hierophant of Annihilation, every bodak bears the mark of Orcus as a chest wound, an opening where a mortal humanoid's heart would be.",
 												"Orcus can recall anything a bodak sees or hears. If he so chooses, he can speak through a bodak to address his enemies and followers directly. Bodaks are extensions of Orcus's will outside the Abyss, serving the demon prince's aims and other minions.",
 												"Even nature despises bodaks. The sun burns away a bodak's tainted flesh. The creature's gaze lays waste to the living. Anyone a bodak slays with its gaze withers, its face frozen in a mask of terror. The monster's mere presence is so unnatural that it chills the soul. Animals untrained for war instinctively flee just before a bodak arrives."
@@ -581,21 +586,21 @@
 										{
 											"name": "Unhallowed Fragments",
 											"entries": [
-												" A bodak retains vague impressions of its past life. It seeks out both its former allies and its former enemies to destroy them, as its warped soul seeks to erase anything connected to its former life. Minions of Orcus are the one exception to this compulsion; a bodak recognizes them as kindred souls and spares them from its wrath. Anyone who knew the individual before its transformation into a bodak can recognize mannerisms or other subtle clues to its original identity."
+												"A bodak retains vague impressions of its past life. It seeks out both its former allies and its former enemies to destroy them, as its warped soul seeks to erase anything connected to its former life. Minions of Orcus are the one exception to this compulsion; a bodak recognizes them as kindred souls and spares them from its wrath. Anyone who knew the individual before its transformation into a bodak can recognize mannerisms or other subtle clues to its original identity."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Ravaged Soul",
 											"entries": [
-												" The soul of a creature that becomes a bodak is so damaged that it is unfit for most forms of magical resurrection. Only a {@spell wish} spell or similar magic can return a bodak to its former life."
+												"The soul of a creature that becomes a bodak is so damaged that it is unfit for most forms of magical resurrection. Only a {@spell wish} spell or similar magic can return a bodak to its former life."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Undead Nature",
 											"entries": [
-												" A bodak doesn't require air, food, drink, or sleep."
+												"A bodak doesn't require air, food, drink, or sleep."
 											],
 											"type": "entries"
 										}
@@ -634,28 +639,28 @@
 										{
 											"name": "Irksome Pests",
 											"entries": [
-												" Boggles engage in petty pranks to amuse themselves, passing the time at their hosts' expense. A boggle isn't above breaking dishes, hiding tools, making frightening sounds to startle cows and sour their milk, or hiding a baby in an attic. Although a boggle's antics might cause distress and unintentional harm, mischief-not mayhem-is usually its intent. If threatened, a boggle flees rather than stand and fight."
+												"Boggles engage in petty pranks to amuse themselves, passing the time at their hosts' expense. A boggle isn't above breaking dishes, hiding tools, making frightening sounds to startle cows and sour their milk, or hiding a baby in an attic. Although a boggle's antics might cause distress and unintentional harm, mischief-not mayhem-is usually its intent. If threatened, a boggle flees rather than stand and fight."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Oily Excretions",
 											"entries": [
-												" A boggle excretes an oil from its pores and can make its oil slippery or sticky. The oil dries up and disappears an hour later."
+												"A boggle excretes an oil from its pores and can make its oil slippery or sticky. The oil dries up and disappears an hour later."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Twisting Space",
 											"entries": [
-												" A boggle can create magical openings to travel short distances or to pilfer items that would otherwise be beyond its reach. To create such a rift in space, a boggle must be adjacent to a space defined by a frame, such as an open window or a doorway, a gap between the bars of a cage, or the opening between the feet of a bed and the floor. The rift is invisible and disappears after a few seconds-enough time for the boggle to step, reach, or attack through it."
+												"A boggle can create magical openings to travel short distances or to pilfer items that would otherwise be beyond its reach. To create such a rift in space, a boggle must be adjacent to a space defined by a frame, such as an open window or a doorway, a gap between the bars of a cage, or the opening between the feet of a bed and the floor. The rift is invisible and disappears after a few seconds-enough time for the boggle to step, reach, or attack through it."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Unreliable Allies",
 											"entries": [
-												" A boggle makes a decent servant for a strong-willed master, and wicked creatures such as fomorians and hags sometimes shelter boggles in their lairs. Warlocks who form pacts with archfey have also been known to command boggles, and charismatic individuals who make the right offers have enjoyed temporary alliances with these little tricksters. A bored boggle always finds some way to entertain itself."
+												"A boggle makes a decent servant for a strong-willed master, and wicked creatures such as fomorians and hags sometimes shelter boggles in their lairs. Warlocks who form pacts with archfey have also been known to command boggles, and charismatic individuals who make the right offers have enjoyed temporary alliances with these little tricksters. A bored boggle always finds some way to entertain itself."
 											],
 											"type": "entries"
 										}
@@ -883,7 +888,7 @@
 										{
 											"name": "Animalistic Nature",
 											"entries": [
-												" Despite their ungainly physiology, catoblepases resemble natural beasts. A catoblepas behaves much like an animal, too, ambling through its marshy home, munching choice vegetation, eating the occasional bit of carrion, and wallowing in mire. A catoblepas might be found with the one mate it chooses for life and, on occasion, a calf. Especially if it's guarding its young, a catoblepas attacks anyone that moves too close.",
+												"Despite their ungainly physiology, catoblepases resemble natural beasts. A catoblepas behaves much like an animal, too, ambling through its marshy home, munching choice vegetation, eating the occasional bit of carrion, and wallowing in mire. A catoblepas might be found with the one mate it chooses for life and, on occasion, a calf. Especially if it's guarding its young, a catoblepas attacks anyone that moves too close.",
 												"Sages say that gods of pestilence and rot created catoblepases as embodiments of their influence. Whatever the origin of the creature, stories link the catoblepas to misfortune, and many of these yarns have elements of truth. Some such tales claim that hags tend catoblepases like cattle, and that a swamp that contains a catoblepas might also be home to a hag that drinks the monster's milk. Although a particular catoblepas might not be linked to a hag, a coven of hags might keep one or more of these beasts as guardians or pets. Other legends say that those of impure heart can tame a catoblepas. Indeed, some tales have circulated of malevolent warlocks and dark knights who have discovered how to domesticate the beasts and use them as mounts."
 											],
 											"type": "entries"
@@ -891,21 +896,21 @@
 										{
 											"name": "Stench of Death",
 											"entries": [
-												" A catoblepas's stink, like that of death mixed with swamp gas and skunk musk, gives it away as being much more ghastly than its appearance suggests. When it is on the attack, a catoblepas reveals the extent of its horrific nature. The creature's serpentine neck has trouble lifting its head, but one glare from its bloodshot eyes can rot flesh. At the end of its tail is a club that can rattle body and soul if it strikes true, leaving a victim unable to act. If the target of its attacks dies, the catoblepas feasts on the fresh remains."
+												"A catoblepas's stink, like that of death mixed with swamp gas and skunk musk, gives it away as being much more ghastly than its appearance suggests. When it is on the attack, a catoblepas reveals the extent of its horrific nature. The creature's serpentine neck has trouble lifting its head, but one glare from its bloodshot eyes can rot flesh. At the end of its tail is a club that can rattle body and soul if it strikes true, leaving a victim unable to act. If the target of its attacks dies, the catoblepas feasts on the fresh remains."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Blighted Territory",
 											"entries": [
-												" A catoblepas's nature as a creature of disease and decay brings out similar characteristics in the creature's swampy habitat. Such a wetland becomes gloomy, tangled, and more fetid than it was before. Beneficial qualities of the environment, such as healing herbs and clean water, diminish when a catoblepas lives nearby. Swamp gases have a hint of the catoblepas's foulness to them. Animals in the area are more aggressive and liable to be diseased. Degenerate creatures are likely to take up residence near a catoblepas's territory, as are those seeking to avoid notice."
+												"A catoblepas's nature as a creature of disease and decay brings out similar characteristics in the creature's swampy habitat. Such a wetland becomes gloomy, tangled, and more fetid than it was before. Beneficial qualities of the environment, such as healing herbs and clean water, diminish when a catoblepas lives nearby. Swamp gases have a hint of the catoblepas's foulness to them. Animals in the area are more aggressive and liable to be diseased. Degenerate creatures are likely to take up residence near a catoblepas's territory, as are those seeking to avoid notice."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Sinister Folklore",
 											"entries": [
-												" Ordinary folk rarely see a catoblepas, but the creature has such a feared reputation that stories about it are ingrained in the popular culture. Any rumor of a catoblepas taking up residence nearby is taken to be a bad omen, even if the rumor is proven false. The silhouette of a catoblepas, with its tail extended over its body and its head held low, is a baleful heraldic figure signifying death or doom."
+												"Ordinary folk rarely see a catoblepas, but the creature has such a feared reputation that stories about it are ingrained in the popular culture. Any rumor of a catoblepas taking up residence nearby is taken to be a bad omen, even if the rumor is proven false. The silhouette of a catoblepas, with its tail extended over its body and its head held low, is a baleful heraldic figure signifying death or doom."
 											],
 											"type": "entries"
 										}
@@ -943,7 +948,7 @@
 										{
 											"name": "Ambushers",
 											"entries": [
-												" A cave fisher usually hunts small animals and is fond of bats, so it stretches its filament over an opening that such prey might travel through. It then climbs to a hiding spot and adheres itself to the surface to rest and wait. When prey blunders into the filament, the cave fisher reels in its meal. A group of cave fishers might work together to cover a large area with filaments, but as soon as one captures potential food, every cave fisher in the area competes for the prize. If a victim escapes from the initial ambush, a cave fisher can reclaim its prey by shooting a filament out to capture it again.",
+												"A cave fisher usually hunts small animals and is fond of bats, so it stretches its filament over an opening that such prey might travel through. It then climbs to a hiding spot and adheres itself to the surface to rest and wait. When prey blunders into the filament, the cave fisher reels in its meal. A group of cave fishers might work together to cover a large area with filaments, but as soon as one captures potential food, every cave fisher in the area competes for the prize. If a victim escapes from the initial ambush, a cave fisher can reclaim its prey by shooting a filament out to capture it again.",
 												"A cave fisher instinctively knows that larger targets such as humanoids are more difficult to overcome, so the creatures shy away from attacking such prey unless they come across a solitary target. They might try to pick off a scout moving ahead of a group of travelers or a straggler lagging behind, rather than attracting the attention of the entire group."
 											],
 											"type": "entries"
@@ -951,21 +956,21 @@
 										{
 											"name": "Moving Up in the World",
 											"entries": [
-												" Scarce food might draw a group of cave fishers up to the surface, into a shadowy canyon or a gloomy forest that features both native animal prey and creatures such as explorers or travelers occasionally moving through the area."
+												"Scarce food might draw a group of cave fishers up to the surface, into a shadowy canyon or a gloomy forest that features both native animal prey and creatures such as explorers or travelers occasionally moving through the area."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Valuable Innards",
 											"entries": [
-												" Nearly every part of a cave fisher is useful after the creature has been dispatched. Its blood is alcoholic and tastes like strong liquor. Several dwarven spirits include cave fisher blood as part of the recipe, and some dwarves, especially berserkers, drink the blood straight. If they are gathered after being extruded, cave fisher filaments can be woven into rope that is thin, tough, and nearly invisible. Cave fisher meat is edible, tasting much like crab cooked in strong wine. The creature's shell is used in the manufacture of tools, armor, and jewelry."
+												"Nearly every part of a cave fisher is useful after the creature has been dispatched. Its blood is alcoholic and tastes like strong liquor. Several dwarven spirits include cave fisher blood as part of the recipe, and some dwarves, especially berserkers, drink the blood straight. If they are gathered after being extruded, cave fisher filaments can be woven into rope that is thin, tough, and nearly invisible. Cave fisher meat is edible, tasting much like crab cooked in strong wine. The creature's shell is used in the manufacture of tools, armor, and jewelry."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Reluctant Servants",
 											"entries": [
-												" While some folk hunt cave fishers to kill them for their filaments and their blood, others capture cave fisher eggs and rear the hatchlings. Cave fishers have a natural aversion to fire, since their blood is flammable. As such, chitines and hobgoblins sometimes use the threat of fire to train cave fishers, then employ them to guard passages or as beasts of war."
+												"While some folk hunt cave fishers to kill them for their filaments and their blood, others capture cave fisher eggs and rear the hatchlings. Cave fishers have a natural aversion to fire, since their blood is flammable. As such, chitines and hobgoblins sometimes use the threat of fire to train cave fishers, then employ them to guard passages or as beasts of war."
 											],
 											"type": "entries"
 										}
@@ -1034,7 +1039,7 @@
 										{
 											"name": "Unnatural Origin",
 											"entries": [
-												" Long ago, the drow first subjected elf prisoners to horrible rituals that transformed the captives into creatures with both humanoid and spider traits, which their creators dubbed chitines. The dark elves' intention was to create slaves dedicated first of all to the drow and, by association with them, to Lolth. As the drow ultimately discovered, the goddess found this arrangement unacceptable.",
+												"Long ago, the drow first subjected elf prisoners to horrible rituals that transformed the captives into creatures with both humanoid and spider traits, which their creators dubbed chitines. The dark elves' intention was to create slaves dedicated first of all to the drow and, by association with them, to Lolth. As the drow ultimately discovered, the goddess found this arrangement unacceptable.",
 												"The creation process required cooperation between magical disciplines. Drow wizards and warlocks used arcane magic and demonic powers, and drow priestesses invoked Lolth's aid for the divine spark needed to ensure the subject's survival. Lolth watched, expecting at some part of the process to see these new abominations dedicated to her, but no such ritual was performed. In retribution for this lack of respect, the Spider Queen twisted the drow's creation rituals to serve her own purposes.",
 												"At first, the drow were unaware that the new creatures were signs of Lolth's displeasure with them. Instead, they were pleased, because choldriths could lay eggs that birthed more chitines (and the rare choldrith) and could direct the chitines in their work. But the dark elves came to realize their mistake-choldriths belonged to Lolth, body and soul. They whispered to the chitines of their adoration of the Spider Queen and their enmity of the drow, and the seeds of a rebellion took root and grew. The chitines and choldriths rose up against their would-be masters; soon afterward most of the creatures were free, and a number of the drow who helped breed and tend them were dead.",
 												"Nowadays, drow still create chitines when they have need to. Outside the presence of a choldrith, chitines make good workers for the drow, and they can be useful if the drow find an independent chitine colony and want to infiltrate it. If the creation process yields a choldrith, though, the drow destroy the creature immediately.",
@@ -1046,21 +1051,21 @@
 										{
 											"name": "Lolth's Revenge",
 											"entries": [
-												" As the drow continued to perform the rituals, the process usually transformed the subject into the spindly, stunted creature they expected. Occasionally, though, the elf changed into a monstrosity that was more spider than elf, resembling Lolth in her spider form, and more cunning than a chitine, that the drow dubbed a choldrith."
+												"As the drow continued to perform the rituals, the process usually transformed the subject into the spindly, stunted creature they expected. Occasionally, though, the elf changed into a monstrosity that was more spider than elf, resembling Lolth in her spider form, and more cunning than a chitine, that the drow dubbed a choldrith."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Lolth's Chosen",
 											"entries": [
-												" Choldriths are born with a fanatical devotion to Lolth, which leads them to develop some skill in divine magic. They preach that chitines are Lolth's favored people, and that choldriths are the Spider Queen's rightful worldly representatives sent to free the chitines from slavery. Although choldriths and chitines lack sexual characteristics, and choldriths need no mate to lay eggs, these creatures choose the gender identity of their goddess. Choldriths also believe and teach that Lolth's spider form, much like that of a choldrith, is her truest shape. Any idol to Lolth in a chitine colony depicts Lolth in this way."
+												"Choldriths are born with a fanatical devotion to Lolth, which leads them to develop some skill in divine magic. They preach that chitines are Lolth's favored people, and that choldriths are the Spider Queen's rightful worldly representatives sent to free the chitines from slavery. Although choldriths and chitines lack sexual characteristics, and choldriths need no mate to lay eggs, these creatures choose the gender identity of their goddess. Choldriths also believe and teach that Lolth's spider form, much like that of a choldrith, is her truest shape. Any idol to Lolth in a chitine colony depicts Lolth in this way."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Communal Spiders",
 											"entries": [
-												" Chitines and choldriths resemble spiders, but they behave more like social insects such as ants. Chitines are divided into worker and warrior castes, and choldriths occupy the top levels of a colony's hierarchy. Each chitine has a social position that comes with duties related to that rank, and all chitines are expected to willingly sacrifice themselves to protect the choldriths. Every chitine has spinnerets and slowly produces webbing that is used to build floors, walls, structures, objects, and traps that benefit and protect the colony. A warrior might be responsible for crafting web armor (which is as tough as hide or leather), while a group of workers might be tasked to dig a pit trap and cover it with fragile webbing disguised with loose dirt to appear as a solid surface."
+												"Chitines and choldriths resemble spiders, but they behave more like social insects such as ants. Chitines are divided into worker and warrior castes, and choldriths occupy the top levels of a colony's hierarchy. Each chitine has a social position that comes with duties related to that rank, and all chitines are expected to willingly sacrifice themselves to protect the choldriths. Every chitine has spinnerets and slowly produces webbing that is used to build floors, walls, structures, objects, and traps that benefit and protect the colony. A warrior might be responsible for crafting web armor (which is as tough as hide or leather), while a group of workers might be tasked to dig a pit trap and cover it with fragile webbing disguised with loose dirt to appear as a solid surface."
 											],
 											"type": "entries"
 										}
@@ -1098,7 +1103,7 @@
 										{
 											"name": "Unnatural Origin",
 											"entries": [
-												" Long ago, the drow first subjected elf prisoners to horrible rituals that transformed the captives into creatures with both humanoid and spider traits, which their creators dubbed chitines. The dark elves' intention was to create slaves dedicated first of all to the drow and, by association with them, to Lolth. As the drow ultimately discovered, the goddess found this arrangement unacceptable.",
+												"Long ago, the drow first subjected elf prisoners to horrible rituals that transformed the captives into creatures with both humanoid and spider traits, which their creators dubbed chitines. The dark elves' intention was to create slaves dedicated first of all to the drow and, by association with them, to Lolth. As the drow ultimately discovered, the goddess found this arrangement unacceptable.",
 												"The creation process required cooperation between magical disciplines. Drow wizards and warlocks used arcane magic and demonic powers, and drow priestesses invoked Lolth's aid for the divine spark needed to ensure the subject's survival. Lolth watched, expecting at some part of the process to see these new abominations dedicated to her, but no such ritual was performed. In retribution for this lack of respect, the Spider Queen twisted the drow's creation rituals to serve her own purposes.",
 												"At first, the drow were unaware that the new creatures were signs of Lolth's displeasure with them. Instead, they were pleased, because choldriths could lay eggs that birthed more chitines (and the rare choldrith) and could direct the chitines in their work. But the dark elves came to realize their mistake-choldriths belonged to Lolth, body and soul. They whispered to the chitines of their adoration of the Spider Queen and their enmity of the drow, and the seeds of a rebellion took root and grew. The chitines and choldriths rose up against their would-be masters; soon afterward most of the creatures were free, and a number of the drow who helped breed and tend them were dead.",
 												"Nowadays, drow still create chitines when they have need to. Outside the presence of a choldrith, chitines make good workers for the drow, and they can be useful if the drow find an independent chitine colony and want to infiltrate it. If the creation process yields a choldrith, though, the drow destroy the creature immediately.",
@@ -1110,21 +1115,21 @@
 										{
 											"name": "Lolth's Revenge",
 											"entries": [
-												" As the drow continued to perform the rituals, the process usually transformed the subject into the spindly, stunted creature they expected. Occasionally, though, the elf changed into a monstrosity that was more spider than elf, resembling Lolth in her spider form, and more cunning than a chitine, that the drow dubbed a choldrith."
+												"As the drow continued to perform the rituals, the process usually transformed the subject into the spindly, stunted creature they expected. Occasionally, though, the elf changed into a monstrosity that was more spider than elf, resembling Lolth in her spider form, and more cunning than a chitine, that the drow dubbed a choldrith."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Lolth's Chosen",
 											"entries": [
-												" Choldriths are born with a fanatical devotion to Lolth, which leads them to develop some skill in divine magic. They preach that chitines are Lolth's favored people, and that choldriths are the Spider Queen's rightful worldly representatives sent to free the chitines from slavery. Although choldriths and chitines lack sexual characteristics, and choldriths need no mate to lay eggs, these creatures choose the gender identity of their goddess. Choldriths also believe and teach that Lolth's spider form, much like that of a choldrith, is her truest shape. Any idol to Lolth in a chitine colony depicts Lolth in this way."
+												"Choldriths are born with a fanatical devotion to Lolth, which leads them to develop some skill in divine magic. They preach that chitines are Lolth's favored people, and that choldriths are the Spider Queen's rightful worldly representatives sent to free the chitines from slavery. Although choldriths and chitines lack sexual characteristics, and choldriths need no mate to lay eggs, these creatures choose the gender identity of their goddess. Choldriths also believe and teach that Lolth's spider form, much like that of a choldrith, is her truest shape. Any idol to Lolth in a chitine colony depicts Lolth in this way."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Communal Spiders",
 											"entries": [
-												" Chitines and choldriths resemble spiders, but they behave more like social insects such as ants. Chitines are divided into worker and warrior castes, and choldriths occupy the top levels of a colony's hierarchy. Each chitine has a social position that comes with duties related to that rank, and all chitines are expected to willingly sacrifice themselves to protect the choldriths. Every chitine has spinnerets and slowly produces webbing that is used to build floors, walls, structures, objects, and traps that benefit and protect the colony. A warrior might be responsible for crafting web armor (which is as tough as hide or leather), while a group of workers might be tasked to dig a pit trap and cover it with fragile webbing disguised with loose dirt to appear as a solid surface."
+												"Chitines and choldriths resemble spiders, but they behave more like social insects such as ants. Chitines are divided into worker and warrior castes, and choldriths occupy the top levels of a colony's hierarchy. Each chitine has a social position that comes with duties related to that rank, and all chitines are expected to willingly sacrifice themselves to protect the choldriths. Every chitine has spinnerets and slowly produces webbing that is used to build floors, walls, structures, objects, and traps that benefit and protect the colony. A warrior might be responsible for crafting web armor (which is as tough as hide or leather), while a group of workers might be tasked to dig a pit trap and cover it with fragile webbing disguised with loose dirt to appear as a solid surface."
 											],
 											"type": "entries"
 										}
@@ -1164,7 +1169,7 @@
 										{
 											"name": "Mysterious Masks",
 											"entries": [
-												" Smiling ones take their name from the strange two-faced masks they wear. The smiling half of the face often looks more like a smirk or a triumphant sneer than a pleasant grin. The frowning half represents the displeasure smiling ones feel about their place in the ordning-second to the storm giants. The masks serve as symbols of their devotion, but they also conceal their wearers' true facial expressions."
+												"Smiling ones take their name from the strange two-faced masks they wear. The smiling half of the face often looks more like a smirk or a triumphant sneer than a pleasant grin. The frowning half represents the displeasure smiling ones feel about their place in the ordning-second to the storm giants. The masks serve as symbols of their devotion, but they also conceal their wearers' true facial expressions."
 											],
 											"type": "entries"
 										}
@@ -1300,21 +1305,21 @@
 										{
 											"name": "The Killing Light",
 											"entries": [
-												" The Summer Queen's curse causes a darkling's body to absorb light, and doing so wizens the creature, much like the effect of rapid aging. For this reason, darklings cover every part of their body with clothing when exposure to light is a risk. The light a darkling absorbs over the course of its lifetime explodes outward when the darkling dies, incinerating the creature and much of its possessions."
+												"The Summer Queen's curse causes a darkling's body to absorb light, and doing so wizens the creature, much like the effect of rapid aging. For this reason, darklings cover every part of their body with clothing when exposure to light is a risk. The light a darkling absorbs over the course of its lifetime explodes outward when the darkling dies, incinerating the creature and much of its possessions."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Love of Art",
 											"entries": [
-												" Despite their curse, darklings retain a fondness for the beauty of art. A darkling might risk taking a peek at a sunset or lighting a tiny candle to glimpse the colors in a painting or a jewel."
+												"Despite their curse, darklings retain a fondness for the beauty of art. A darkling might risk taking a peek at a sunset or lighting a tiny candle to glimpse the colors in a painting or a jewel."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Elder Transformation",
 											"entries": [
-												" A wise and respected darkling can qualify to undergo a ritual to become an elder. Other elders mark the supplicant with glowing tattoos, channeling some of the darkling's absorbed light away from its body. If the ritual succeeds, the darkling grows into a tall and fair form, like that of a gray-skinned elf. The darkling perishes if the ritual fails."
+												"A wise and respected darkling can qualify to undergo a ritual to become an elder. Other elders mark the supplicant with glowing tattoos, channeling some of the darkling's absorbed light away from its body. If the ritual succeeds, the darkling grows into a tall and fair form, like that of a gray-skinned elf. The darkling perishes if the ritual fails."
 											],
 											"type": "entries"
 										}
@@ -1352,21 +1357,21 @@
 										{
 											"name": "The Killing Light",
 											"entries": [
-												" The Summer Queen's curse causes a darkling's body to absorb light, and doing so wizens the creature, much like the effect of rapid aging. For this reason, darklings cover every part of their body with clothing when exposure to light is a risk. The light a darkling absorbs over the course of its lifetime explodes outward when the darkling dies, incinerating the creature and much of its possessions."
+												"The Summer Queen's curse causes a darkling's body to absorb light, and doing so wizens the creature, much like the effect of rapid aging. For this reason, darklings cover every part of their body with clothing when exposure to light is a risk. The light a darkling absorbs over the course of its lifetime explodes outward when the darkling dies, incinerating the creature and much of its possessions."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Love of Art",
 											"entries": [
-												" Despite their curse, darklings retain a fondness for the beauty of art. A darkling might risk taking a peek at a sunset or lighting a tiny candle to glimpse the colors in a painting or a jewel."
+												"Despite their curse, darklings retain a fondness for the beauty of art. A darkling might risk taking a peek at a sunset or lighting a tiny candle to glimpse the colors in a painting or a jewel."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Elder Transformation",
 											"entries": [
-												" A wise and respected darkling can qualify to undergo a ritual to become an elder. Other elders mark the supplicant with glowing tattoos, channeling some of the darkling's absorbed light away from its body. If the ritual succeeds, the darkling grows into a tall and fair form, like that of a gray-skinned elf. The darkling perishes if the ritual fails."
+												"A wise and respected darkling can qualify to undergo a ritual to become an elder. Other elders mark the supplicant with glowing tattoos, channeling some of the darkling's absorbed light away from its body. If the ritual succeeds, the darkling grows into a tall and fair form, like that of a gray-skinned elf. The darkling perishes if the ritual fails."
 											],
 											"type": "entries"
 										}
@@ -1404,21 +1409,21 @@
 										{
 											"name": "Blood Drinker",
 											"entries": [
-												" A death kiss survives solely on ingested blood, which it uses to generate electrical energy inside its body. Paranoid about dying from starvation, it obsessively drains even little creatures such as rats in an effort to stave off this fate for as long as possible. After it drains its prey, it abandons the corpse to scavengers. A death kiss prefers to hunt alone. If it meets another death kiss, it might fight, flee, or team up, depending on its health and pride. When underground, it uses its tentacles as feelers, prodding and examining the environment in all directions. Above ground, it usually keeps its tentacles retracted when on the hunt, then lashes out and extends them to their full length to catch opponents off guard."
+												"A death kiss survives solely on ingested blood, which it uses to generate electrical energy inside its body. Paranoid about dying from starvation, it obsessively drains even little creatures such as rats in an effort to stave off this fate for as long as possible. After it drains its prey, it abandons the corpse to scavengers. A death kiss prefers to hunt alone. If it meets another death kiss, it might fight, flee, or team up, depending on its health and pride. When underground, it uses its tentacles as feelers, prodding and examining the environment in all directions. Above ground, it usually keeps its tentacles retracted when on the hunt, then lashes out and extends them to their full length to catch opponents off guard."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "False Tyrant",
 											"entries": [
-												" In poor lighting and with its tentacles extended, a death kiss can be mistaken for a true beholder. It might purposely present itself as a beholder to an ignorant creature, but this behavior is rare, since it usually is focused on hunting and lacks the self-importance and paranoia of a true beholder. It can speak through any of its tentacle-throats, and its voice sounds nasal and high-pitched. A true beholder has little to fear from a death kiss, since it can easily kill or subdue the death kiss long before the death kiss gets into melee range. Thus, out of self-preservation, a death kiss usually submits to the rule of a beholder that it encounters, though it might attempt to escape as soon as its master is preoccupied."
+												"In poor lighting and with its tentacles extended, a death kiss can be mistaken for a true beholder. It might purposely present itself as a beholder to an ignorant creature, but this behavior is rare, since it usually is focused on hunting and lacks the self-importance and paranoia of a true beholder. It can speak through any of its tentacle-throats, and its voice sounds nasal and high-pitched. A true beholder has little to fear from a death kiss, since it can easily kill or subdue the death kiss long before the death kiss gets into melee range. Thus, out of self-preservation, a death kiss usually submits to the rule of a beholder that it encounters, though it might attempt to escape as soon as its master is preoccupied."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Simple Tactics",
 											"entries": [
-												" A death kiss lacks the combat finesse and intelligence of a beholder. It might attempt an unusual maneuver to control its prey (such as flying up while grappling), but in most cases, it attaches one or more of its tentacles to a creature and drains blood until its prey collapses. If it is in a superior position and its opponent poses no threat, it might toy with its food, slowly squeezing and draining the life out of a creature."
+												"A death kiss lacks the combat finesse and intelligence of a beholder. It might attempt an unusual maneuver to control its prey (such as flying up while grappling), but in most cases, it attaches one or more of its tentacles to a creature and drains blood until its prey collapses. If it is in a superior position and its opponent poses no threat, it might toy with its food, slowly squeezing and draining the life out of a creature."
 											],
 											"type": "entries"
 										}
@@ -1464,7 +1469,7 @@
 										{
 											"name": "Spies from the Sea",
 											"entries": [
-												" A deep scion emerges from the depths in service to its underwater master, which is likely a kraken or some other ancient being of the deep. While wearing the mind and body of the person it once was as a sort of mask, the creature is bent on fulfilling its master's desires. Sometimes a deep scion returns to its former home and a hero's welcome-unexpectedly found alive when all hope was lost. At other times the deep scion takes on a new identity. In any case, it is the deep scion's duty to infiltrate the air-breathing world and report back to its master. When set to its task, a deep scion worms its way into the life of an unsuspecting enemy as a new best friend, an irresistible lover, the perfect candidate for a job, or in some other role that enables the minion to carry out its master's commands.",
+												"A deep scion emerges from the depths in service to its underwater master, which is likely a kraken or some other ancient being of the deep. While wearing the mind and body of the person it once was as a sort of mask, the creature is bent on fulfilling its master's desires. Sometimes a deep scion returns to its former home and a hero's welcome-unexpectedly found alive when all hope was lost. At other times the deep scion takes on a new identity. In any case, it is the deep scion's duty to infiltrate the air-breathing world and report back to its master. When set to its task, a deep scion worms its way into the life of an unsuspecting enemy as a new best friend, an irresistible lover, the perfect candidate for a job, or in some other role that enables the minion to carry out its master's commands.",
 												"If you meet a human and there's something fishy about them, they might be a deep scion. Or a crook, or just a fishmonger. Sometimes fish stink is just fish stink.",
 												"-Volo"
 											],
@@ -1473,7 +1478,7 @@
 										{
 											"name": "Cold-Hearted Killers",
 											"entries": [
-												" The training to which a deep scion is subjected rids it of empathy for those whom it spies on. Though one might behave as though infatuated, laugh at the joke of a friend, or appear incensed at some injustice, each of these acts is artificial to the deep scion, a means to an end. It believes that its true form is the shape it takes when it returns to the sea that it thinks of as home. Ironically, however, a deep scion that is killed when in its piscine form is stripped of the magic that robbed it of emotion, leaving behind the corpse of the person the deep scion once was."
+												"The training to which a deep scion is subjected rids it of empathy for those whom it spies on. Though one might behave as though infatuated, laugh at the joke of a friend, or appear incensed at some injustice, each of these acts is artificial to the deep scion, a means to an end. It believes that its true form is the shape it takes when it returns to the sea that it thinks of as home. Ironically, however, a deep scion that is killed when in its piscine form is stripped of the magic that robbed it of emotion, leaving behind the corpse of the person the deep scion once was."
 											],
 											"type": "entries"
 										}
@@ -1533,7 +1538,7 @@
 										{
 											"name": "Instruments of Orcus",
 											"entries": [
-												" A lesser demon that proves itself to Orcus might be granted the privilege of becoming a devourer. The Prince of Undeath transforms such a demon into an 8-foot-tall, desiccated humanoid with a hollowed-out ribcage, then fills the new creature with a hunger for souls. Orcus grants each new devourer the essence of a less fortunate demon to power the devourer's first foray into the planes. Most devourers remain in the Abyss, or on the Astral or Ethereal Plane, pursuing Orcus's schemes and interests in those realms. When Orcus sends devourers to the Material Plane, he often sets them on a mission to create, control, and lead a plague of undead. Skeletons, zombies, ghouls and ghasts, and shadows are particularly attracted to the presence of a devourer.",
+												"A lesser demon that proves itself to Orcus might be granted the privilege of becoming a devourer. The Prince of Undeath transforms such a demon into an 8-foot-tall, desiccated humanoid with a hollowed-out ribcage, then fills the new creature with a hunger for souls. Orcus grants each new devourer the essence of a less fortunate demon to power the devourer's first foray into the planes. Most devourers remain in the Abyss, or on the Astral or Ethereal Plane, pursuing Orcus's schemes and interests in those realms. When Orcus sends devourers to the Material Plane, he often sets them on a mission to create, control, and lead a plague of undead. Skeletons, zombies, ghouls and ghasts, and shadows are particularly attracted to the presence of a devourer.",
 												"I've heard of \"rib-sticking,\" but this is ridiculous.",
 												"-Volo"
 											],
@@ -1542,14 +1547,14 @@
 										{
 											"name": "Tormentors of Souls",
 											"entries": [
-												" Devourers hunt humanoids, with the intent of consuming them body and soul. After a devourer brings a target to the brink of death, it pulls the victim's body in and traps the creature within its own ribcage. As the victim tries to stave off death (usually without success), the devourer tortures its soul with telepathic noise. When the victim expires, it undergoes a horrible transformation, springing forth from the devourer's body to begin its new existence as an undead servitor of the monster that spawned it."
+												"Devourers hunt humanoids, with the intent of consuming them body and soul. After a devourer brings a target to the brink of death, it pulls the victim's body in and traps the creature within its own ribcage. As the victim tries to stave off death (usually without success), the devourer tortures its soul with telepathic noise. When the victim expires, it undergoes a horrible transformation, springing forth from the devourer's body to begin its new existence as an undead servitor of the monster that spawned it."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Fiendish Nature",
 											"entries": [
-												" A devourer doesn't require air, food (other than souls), drink, or sleep."
+												"A devourer doesn't require air, food (other than souls), drink, or sleep."
 											],
 											"type": "entries"
 										}
@@ -1654,7 +1659,7 @@
 										{
 											"name": "Blessing on the House",
 											"entries": [
-												" The ritual to create a draegloth succeeds only rarely, but when it does, it is a great event that is seen by the drow of the house as a sign of the demon lord Lolth's favor-and a sign of Lolth's disregard for the family's rivals, which were not thus gifted. The birth prompts the leaders of the house to begin crafting new plans to strike at its rivals when the draegloth is fully grown. These plans always use the draegloth in a significant role, because its abilities can turn the tide in a battle against a house that doesn't have a draegloth of its own.",
+												"The ritual to create a draegloth succeeds only rarely, but when it does, it is a great event that is seen by the drow of the house as a sign of the demon lord Lolth's favor-and a sign of Lolth's disregard for the family's rivals, which were not thus gifted. The birth prompts the leaders of the house to begin crafting new plans to strike at its rivals when the draegloth is fully grown. These plans always use the draegloth in a significant role, because its abilities can turn the tide in a battle against a house that doesn't have a draegloth of its own.",
 												"These drow house pets are as graceful and nimble as Waterdhavian stage dancers. Only they're slayers and enforcers, four-armed brutes built like an ogre. Life isn't fair.",
 												"-Volo"
 											],
@@ -1663,14 +1668,14 @@
 										{
 											"name": "Subservient Enforcers",
 											"entries": [
-												" Although it plays an important part in the welfare of its house, a draegloth can't rise above the status of a favored slave or a consort to a priestess. Before a draegloth is given any duties, it receives instruction in accepting the role set for it and not challenging authority. Draegloths instinctively resist this sort of treatment, but most of them take out their frustration on their house's enemies. A draegloth that can't suppress its ambitions might abandon its house and strike out on its own. Whether these rebellious draegloths are part of Lolth's plan for sowing even greater chaos is unclear."
+												"Although it plays an important part in the welfare of its house, a draegloth can't rise above the status of a favored slave or a consort to a priestess. Before a draegloth is given any duties, it receives instruction in accepting the role set for it and not challenging authority. Draegloths instinctively resist this sort of treatment, but most of them take out their frustration on their house's enemies. A draegloth that can't suppress its ambitions might abandon its house and strike out on its own. Whether these rebellious draegloths are part of Lolth's plan for sowing even greater chaos is unclear."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Brute Cunning and Dark Magic",
 											"entries": [
-												" A draegloth loves the feeling of tearing opponents apart with its claws and teeth and of wielding the magic that courses through its veins. Most are too impatient to bother with complicated tactics, but a few go on to learn more destructive magic."
+												"A draegloth loves the feeling of tearing opponents apart with its claws and teeth and of wielding the magic that courses through its veins. Most are too impatient to bother with complicated tactics, but a few go on to learn more destructive magic."
 											],
 											"type": "entries"
 										}
@@ -1708,7 +1713,7 @@
 										{
 											"name": "Psychic Infiltrators",
 											"entries": [
-												" When an elder brain infiltrates a mind, it alters the creature's perception and deceives its senses, causing it to see, hear, touch, taste, or feel reality according to the elder brain's intent. From across great distances, it implants subconscious suggestions or subtly influences dreams to compel creatures toward a course of action that benefits its grand plan.",
+												"When an elder brain infiltrates a mind, it alters the creature's perception and deceives its senses, causing it to see, hear, touch, taste, or feel reality according to the elder brain's intent. From across great distances, it implants subconscious suggestions or subtly influences dreams to compel creatures toward a course of action that benefits its grand plan.",
 												"When its insidious suggestions fail to take hold, an elder brain asserts its dominance more directly. It seizes control of a resistant mind and controls the creature's body as it would a puppet. Against the rare, strong-willed stalwart that defies it or attacks it, an elder brain sends a blast of overwhelming psychic force to crush the upstart's mind, rendering the creature a thoughtless, drooling shell.",
 												"When a mind flayer perishes, the elder brain's servants feed the contents of its skull to their master, which absorbs the illithid's brain and all the knowledge and experience contained therein. In this way the elder brain continually increases its knowledge, uniting the thoughts and experiences of the illithid colony into a unified whole. Mind flayers conceive of this \"oneness\" as a sacred state in the same way that a worshiper of a human deity might view an eternal afterlife in the heavens-for an elder brain can evoke the persona of any illithid it has ever absorbed.",
 												"The ambitions of an elder brain are always tempered by its relative immobility. Although its telepathic senses can reach for miles, moving anywhere is always a dangerous proposition. If forced outside its brine pool, an elder brain will swiftly expire, and transporting an elder brain in its pool through confining and tortuous subterranean tunnels frequently proves difficult or impossible."
@@ -1718,21 +1723,21 @@
 										{
 											"name": "Devourer of Thoughts",
 											"entries": [
-												" An elder brain sustains itself by consuming the brains of other creatures. When the mind flayer servants that guard and tend to an elder brain don't bring its meals directly to it, the elder brain reaches out with tendrils of thought, mentally compelling creatures to come to it so that it may feed upon them."
+												"An elder brain sustains itself by consuming the brains of other creatures. When the mind flayer servants that guard and tend to an elder brain don't bring its meals directly to it, the elder brain reaches out with tendrils of thought, mentally compelling creatures to come to it so that it may feed upon them."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Hive Mind",
 											"entries": [
-												" Non-illithids call this creature an elder brain because it acts as the central communication hub for an entire mind flayer colony just as a brain does for a living body. Linked to the elder brain, the colony acts like a single organism, acting in concert as if each illithid were the digit of a hand."
+												"Non-illithids call this creature an elder brain because it acts as the central communication hub for an entire mind flayer colony just as a brain does for a living body. Linked to the elder brain, the colony acts like a single organism, acting in concert as if each illithid were the digit of a hand."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Ego Unhindered",
 											"entries": [
-												" Each elder brain considers itself and its desires the most important things in the multiverse, the mind flayers in its colony nothing more than extensions of its will. But no two elder brains are alike, and each presides over its colony according to its own unique personality and storehouse of collected knowledge and experience. Some elder brains reign as domineering tyrants, while others serve more benignly as sages, counselors, and repositories of information and lore for the mind flayers that protect and nourish them."
+												"Each elder brain considers itself and its desires the most important things in the multiverse, the mind flayers in its colony nothing more than extensions of its will. But no two elder brains are alike, and each presides over its colony according to its own unique personality and storehouse of collected knowledge and experience. Some elder brains reign as domineering tyrants, while others serve more benignly as sages, counselors, and repositories of information and lore for the mind flayers that protect and nourish them."
 											],
 											"type": "entries"
 										}
@@ -1822,7 +1827,7 @@
 										{
 											"name": "Weapons of War",
 											"entries": [
-												" Dreadnoughts are massively powerful fire giants who wield two huge shields like plow blades. These shields bear spikes on their exterior and have hollow interiors into which the dreadnought pours hot coals at the first sign of danger. Armed with its two shields, the dreadnought can present a fiery wall to any attacker. When the dreadnought has finished, often all that is left of a foe is a smoking smear on the floor.",
+												"Dreadnoughts are massively powerful fire giants who wield two huge shields like plow blades. These shields bear spikes on their exterior and have hollow interiors into which the dreadnought pours hot coals at the first sign of danger. Armed with its two shields, the dreadnought can present a fiery wall to any attacker. When the dreadnought has finished, often all that is left of a foe is a smoking smear on the floor.",
 												"When not called on to fight, dreadnoughts maintain their strength by using their shields to shove huge quantities of coal, stone, or ore about the foundry. Occasionally, dreadnoughts are called on by their superiors to accompany a war or diplomatic delegation, The presence of the dreadnoughts presents a fierce face in either case."
 											],
 											"type": "entries"
@@ -1861,7 +1866,7 @@
 										{
 											"name": "Heat Seekers",
 											"entries": [
-												" Firenewts need hot water to live and breed. A firenewt becomes sluggish, mentally and physically, after spending a week away from an external source of moist heat. A prolonged lack of heat can shut down a firenewt community, as the creatures within go into hibernation and their eggs stop developing.",
+												"Firenewts need hot water to live and breed. A firenewt becomes sluggish, mentally and physically, after spending a week away from an external source of moist heat. A prolonged lack of heat can shut down a firenewt community, as the creatures within go into hibernation and their eggs stop developing.",
 												"Firenewts delve for sources of heat in the earth, such as boiling mud and hot springs, that make ideal places to settle. Through excavation and mining in the area, they fashion living space and obtain an ample supply of minerals for other uses, such as smelting, smithing, and alchemy. A firenewt lair features a network of channels and sluices to circulate hot liquid through the settlement.",
 												"The alchemy practiced by firenewts focuses on fire. One of their favorite mixtures is a paste of sulfur, mineral salts, and oil. Firenewts chew this blend habitually, because doing so produces a pleasant internal heat and it enables a firenewt to vomit forth a small ball of flame. Most firenewts carry a container with this mixture in it.",
 												"Warlocks of Imix command warriors to prove their worth by going on raids to bring back treasure and captives. The warlocks take the choicest loot as a tithe to Imix, and then those who participated in the raid divide the rest according to merit. Prisoners that have no apparent usefulness are sacrificed to Imix and then eaten. Those that are deemed capable of mining and performing other chores around the lair are kept as slaves for a while before meeting the same fate.",
@@ -1872,14 +1877,14 @@
 										{
 											"name": "Religious Militants",
 											"entries": [
-												" Firenewt society and culture are based on the worship of Imix, the Prince of Evil Fire. This veneration of Imix leads firenewts to be aggressive, wrathful, and cruel. Firenewt warlocks of Imix teach that by demonstrating these qualities, a firenewt warrior in combat can become \"touched by the Fire Lord,\" entering a nearly unstoppable battle rage."
+												"Firenewt society and culture are based on the worship of Imix, the Prince of Evil Fire. This veneration of Imix leads firenewts to be aggressive, wrathful, and cruel. Firenewt warlocks of Imix teach that by demonstrating these qualities, a firenewt warrior in combat can become \"touched by the Fire Lord,\" entering a nearly unstoppable battle rage."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Giant Striders",
 											"entries": [
-												" Firenewts have a close relationship with a type of monstrous beast they believe Imix sent to aid them-borne out by the creatures' ability to send a gout of flame against distant enemies. Called giant striders, these monsters appear birdlike and reptilian, but are truly neither. Firenewts provide shelter, food, and breeding grounds in their lairs for giant striders, and the striders voluntarily serve as mounts for elite fire newt soldiers."
+												"Firenewts have a close relationship with a type of monstrous beast they believe Imix sent to aid them-borne out by the creatures' ability to send a gout of flame against distant enemies. Called giant striders, these monsters appear birdlike and reptilian, but are truly neither. Firenewts provide shelter, food, and breeding grounds in their lairs for giant striders, and the striders voluntarily serve as mounts for elite fire newt soldiers."
 											],
 											"type": "entries"
 										}
@@ -1917,7 +1922,7 @@
 										{
 											"name": "Heat Seekers",
 											"entries": [
-												" Firenewts need hot water to live and breed. A firenewt becomes sluggish, mentally and physically, after spending a week away from an external source of moist heat. A prolonged lack of heat can shut down a firenewt community, as the creatures within go into hibernation and their eggs stop developing.",
+												"Firenewts need hot water to live and breed. A firenewt becomes sluggish, mentally and physically, after spending a week away from an external source of moist heat. A prolonged lack of heat can shut down a firenewt community, as the creatures within go into hibernation and their eggs stop developing.",
 												"Firenewts delve for sources of heat in the earth, such as boiling mud and hot springs, that make ideal places to settle. Through excavation and mining in the area, they fashion living space and obtain an ample supply of minerals for other uses, such as smelting, smithing, and alchemy. A firenewt lair features a network of channels and sluices to circulate hot liquid through the settlement.",
 												"The alchemy practiced by firenewts focuses on fire. One of their favorite mixtures is a paste of sulfur, mineral salts, and oil. Firenewts chew this blend habitually, because doing so produces a pleasant internal heat and it enables a firenewt to vomit forth a small ball of flame. Most firenewts carry a container with this mixture in it.",
 												"Warlocks of Imix command warriors to prove their worth by going on raids to bring back treasure and captives. The warlocks take the choicest loot as a tithe to Imix, and then those who participated in the raid divide the rest according to merit. Prisoners that have no apparent usefulness are sacrificed to Imix and then eaten. Those that are deemed capable of mining and performing other chores around the lair are kept as slaves for a while before meeting the same fate.",
@@ -1928,14 +1933,14 @@
 										{
 											"name": "Religious Militants",
 											"entries": [
-												" Firenewt society and culture are based on the worship of Imix, the Prince of Evil Fire. This veneration of Imix leads firenewts to be aggressive, wrathful, and cruel. Firenewt warlocks of Imix teach that by demonstrating these qualities, a firenewt warrior in combat can become \"touched by the Fire Lord,\" entering a nearly unstoppable battle rage."
+												"Firenewt society and culture are based on the worship of Imix, the Prince of Evil Fire. This veneration of Imix leads firenewts to be aggressive, wrathful, and cruel. Firenewt warlocks of Imix teach that by demonstrating these qualities, a firenewt warrior in combat can become \"touched by the Fire Lord,\" entering a nearly unstoppable battle rage."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Giant Striders",
 											"entries": [
-												" Firenewts have a close relationship with a type of monstrous beast they believe Imix sent to aid them-borne out by the creatures' ability to send a gout of flame against distant enemies. Called giant striders, these monsters appear birdlike and reptilian, but are truly neither. Firenewts provide shelter, food, and breeding grounds in their lairs for giant striders, and the striders voluntarily serve as mounts for elite fire newt soldiers."
+												"Firenewts have a close relationship with a type of monstrous beast they believe Imix sent to aid them-borne out by the creatures' ability to send a gout of flame against distant enemies. Called giant striders, these monsters appear birdlike and reptilian, but are truly neither. Firenewts provide shelter, food, and breeding grounds in their lairs for giant striders, and the striders voluntarily serve as mounts for elite fire newt soldiers."
 											],
 											"type": "entries"
 										}
@@ -1973,7 +1978,7 @@
 										{
 											"name": "Trail of Treasure",
 											"entries": [
-												" Left undisturbed, a flail snail moves slowly along the ground, consuming everything on the surface, including rocks, sand, and soil, stopping to relish crystal growths and other large mineral deposits. It leaves behind a shimmering trail that quickly solidifies into a thin layer of a nearly transparent substance inedible to the snail. This glassy residue can be harvested and cut to form window panes of varying clearness. It can also be heated and spun into glass objects of other sorts. Some humanoids make a living from trailing flail snails to collect this glass."
+												"Left undisturbed, a flail snail moves slowly along the ground, consuming everything on the surface, including rocks, sand, and soil, stopping to relish crystal growths and other large mineral deposits. It leaves behind a shimmering trail that quickly solidifies into a thin layer of a nearly transparent substance inedible to the snail. This glassy residue can be harvested and cut to form window panes of varying clearness. It can also be heated and spun into glass objects of other sorts. Some humanoids make a living from trailing flail snails to collect this glass."
 											],
 											"type": "entries"
 										}
@@ -2053,21 +2058,21 @@
 										{
 											"name": "Otherworldly Entities",
 											"entries": [
-												" Froghemoths are creatures not of this world. A journal purportedly written long ago by the wizard Lum the Mad describes strange, cylindrical chambers of metal buried in the ground from which froghemoths emerged, but no reliable reports of the location of such places exist."
+												"Froghemoths are creatures not of this world. A journal purportedly written long ago by the wizard Lum the Mad describes strange, cylindrical chambers of metal buried in the ground from which froghemoths emerged, but no reliable reports of the location of such places exist."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Hungry from Birth",
 											"entries": [
-												" Every few years, a froghemoth can lay a fertile egg without mating. The froghemoth cares nothing for its egg, and might eat the hatchling. A young froghemoth's survival is most often predicated on its parent leaving it behind in indifference. A newborn froghemoth grows to full size over a period of months by indiscriminately preying on other creatures in its swampy domain. It learns to hide its enormous body in murky pools, keeping only its eyestalk above water to watch for passing creatures. When food comes within reach, the froghemoth erupts from its pool, tentacles and tongue flailing. It can grab several targets at once, keeping them at bay while it wraps its tongue around another one and pulls it in to be devoured."
+												"Every few years, a froghemoth can lay a fertile egg without mating. The froghemoth cares nothing for its egg, and might eat the hatchling. A young froghemoth's survival is most often predicated on its parent leaving it behind in indifference. A newborn froghemoth grows to full size over a period of months by indiscriminately preying on other creatures in its swampy domain. It learns to hide its enormous body in murky pools, keeping only its eyestalk above water to watch for passing creatures. When food comes within reach, the froghemoth erupts from its pool, tentacles and tongue flailing. It can grab several targets at once, keeping them at bay while it wraps its tongue around another one and pulls it in to be devoured."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Revered by Bullywugs",
 											"entries": [
-												" If a bullywug tribe comes across a froghemoth, the bullywugs treat the froghemoth as a god and do all they can to coax the monster into their den. A froghemoth can be tamed (after a fashion) by offering it food, and bullywugs can communicate with it on a basic level, so the creature might eat only a few bullywugs before following the rest. Bullywugs gather food as tribute for it, provide it with a comfortable lair, fanatically protect it from harm, and try to ensure that any young froghemoth reaches maturity."
+												"If a bullywug tribe comes across a froghemoth, the bullywugs treat the froghemoth as a god and do all they can to coax the monster into their den. A froghemoth can be tamed (after a fashion) by offering it food, and bullywugs can communicate with it on a basic level, so the creature might eat only a few bullywugs before following the rest. Bullywugs gather food as tribute for it, provide it with a comfortable lair, fanatically protect it from harm, and try to ensure that any young froghemoth reaches maturity."
 											],
 											"type": "entries"
 										}
@@ -2105,14 +2110,14 @@
 										{
 											"name": "Troll Eater",
 											"entries": [
-												" Frost giants mainly turn to Vaprak, a rapacious god of strength and hunger worshiped by ogres and trolls, out of desperation. Vaprak likes to tempt frost giants with dreams of glory followed by nightmares of bloody cannibalism. Those who don't shrink from such visions or report them to priests of Thrym receive more of the same. If a frost giant comes to relish these dreams and nightmares, as some do, Vaprak sets a troll upon a sacred quest to find the frost giant and meet it in secret. The troll offers up its own body to be devoured in Vaprak's name. Only the boldest and most determined frost giants can finish such a gory feast."
+												"Frost giants mainly turn to Vaprak, a rapacious god of strength and hunger worshiped by ogres and trolls, out of desperation. Vaprak likes to tempt frost giants with dreams of glory followed by nightmares of bloody cannibalism. Those who don't shrink from such visions or report them to priests of Thrym receive more of the same. If a frost giant comes to relish these dreams and nightmares, as some do, Vaprak sets a troll upon a sacred quest to find the frost giant and meet it in secret. The troll offers up its own body to be devoured in Vaprak's name. Only the boldest and most determined frost giants can finish such a gory feast."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Vaprak's Blessing",
 											"entries": [
-												" After devouring the troll sent by Vaprak, bones and all, a frost giant becomes an everlasting one, gaining tremendous strength, an ill temper, and a troll's regenerative ability. With these gifts, the frost giant can swiftly claim the title of jarl and easily fend off rivals for decades. However, if the frost giant doesn't give enough honor to Vaprak or fails to heed Vaprak's visions, injuries the frost giant sustains heal wrong, often resulting in discolored skin, warty scars, and vestigial body parts, such as extra digits, limbs, and even extra heads. The touch of Vaprak can no longer be hidden then, and the everlasting one is either killed or exiled by its clan. Sometimes small communities of everlasting ones gather and even reproduce, passing the \"blessing\" and worship of Vaprak from one generation to the next."
+												"After devouring the troll sent by Vaprak, bones and all, a frost giant becomes an everlasting one, gaining tremendous strength, an ill temper, and a troll's regenerative ability. With these gifts, the frost giant can swiftly claim the title of jarl and easily fend off rivals for decades. However, if the frost giant doesn't give enough honor to Vaprak or fails to heed Vaprak's visions, injuries the frost giant sustains heal wrong, often resulting in discolored skin, warty scars, and vestigial body parts, such as extra digits, limbs, and even extra heads. The touch of Vaprak can no longer be hidden then, and the everlasting one is either killed or exiled by its clan. Sometimes small communities of everlasting ones gather and even reproduce, passing the \"blessing\" and worship of Vaprak from one generation to the next."
 											],
 											"type": "entries"
 										}
@@ -2150,21 +2155,21 @@
 										{
 											"name": "Magical Metabolism",
 											"entries": [
-												" A gauth can survive on meat but prefers to sustain itself with power drained from magic objects. If starved of magic for several weeks, it is forced back to its home plane, so it constantly seeks new items to drain. A gauth might employ creatures to serve it by bringing it items that provide it with sustenance."
+												"A gauth can survive on meat but prefers to sustain itself with power drained from magic objects. If starved of magic for several weeks, it is forced back to its home plane, so it constantly seeks new items to drain. A gauth might employ creatures to serve it by bringing it items that provide it with sustenance."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Accidental Summoning",
 											"entries": [
-												" When the ritual to summon a spectator goes wrong, a gauth might push itself through the flawed connection, arriving immediately or several minutes later. It might present itself as a beholder to ignorant creatures in an attempt to intimidate them, or as a spectator to its summoner in order to drain magic items it is expected to guard."
+												"When the ritual to summon a spectator goes wrong, a gauth might push itself through the flawed connection, arriving immediately or several minutes later. It might present itself as a beholder to ignorant creatures in an attempt to intimidate them, or as a spectator to its summoner in order to drain magic items it is expected to guard."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Inferior Tyrant",
 											"entries": [
-												" A beholder usually drives away or kills any gauths that enter its territory, but it might choose to enslave them and use them as lieutenants. Gauths are less xenophobic than beholders, so they might form small clusters and work together, though they're just as likely to ignore each other entirely."
+												"A beholder usually drives away or kills any gauths that enter its territory, but it might choose to enslave them and use them as lieutenants. Gauths are less xenophobic than beholders, so they might form small clusters and work together, though they're just as likely to ignore each other entirely."
 											],
 											"type": "entries"
 										}
@@ -2202,14 +2207,14 @@
 										{
 											"name": "Nuisance Pet",
 											"entries": [
-												" A gazer can't speak any languages but can approximate mimicking words and sentences in a high-pitched, mocking manner. Beholders find gazers amusing and tolerate their presence like spoiled pets. A gazer can't be tamed by anyone but its creator, except through the use of magic or by bonding with a spellcaster (see sidebar). Some beholders with wizard minions insist they take a gazer as a familiar because they can see through the eyes of these creatures."
+												"A gazer can't speak any languages but can approximate mimicking words and sentences in a high-pitched, mocking manner. Beholders find gazers amusing and tolerate their presence like spoiled pets. A gazer can't be tamed by anyone but its creator, except through the use of magic or by bonding with a spellcaster (see sidebar). Some beholders with wizard minions insist they take a gazer as a familiar because they can see through the eyes of these creatures."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Aggressive Vermin-Eater",
 											"entries": [
-												" A wild gazer (one living separately from a beholder) is territorial, eats bugs and small animals, and is known for playing with its food. A lone gazer avoids picking fights with creatures that are Medium or larger, but a pack of them might take on larger prey. A gazer might follow humanoids in its territory, noisily mimicking their speech and generally being a nuisance, until they leave the area, but it flees if confronted by something it can't kill."
+												"A wild gazer (one living separately from a beholder) is territorial, eats bugs and small animals, and is known for playing with its food. A lone gazer avoids picking fights with creatures that are Medium or larger, but a pack of them might take on larger prey. A gazer might follow humanoids in its territory, noisily mimicking their speech and generally being a nuisance, until they leave the area, but it flees if confronted by something it can't kill."
 											],
 											"type": "entries"
 										}
@@ -2223,7 +2228,7 @@
 										{
 											"name": "Familiar",
 											"entries": [
-												" The gazer can serve another creature as a familiar, forming a telepathic bond with its willing master, provided that the master is at least a 3rd-level spellcaster. While the two are bonded, the master can sense what the gazer senses as long as they are within 1 mile of each other. If its master causes it physical harm, the gazer will end its service as a familiar, breaking the telepathic bond."
+												"The gazer can serve another creature as a familiar, forming a telepathic bond with its willing master, provided that the master is at least a 3rd-level spellcaster. While the two are bonded, the master can sense what the gazer senses as long as they are within 1 mile of each other. If its master causes it physical harm, the gazer will end its service as a familiar, breaking the telepathic bond."
 											],
 											"type": "entries"
 										}
@@ -2261,7 +2266,7 @@
 										{
 											"name": "Heat Seekers",
 											"entries": [
-												" Firenewts need hot water to live and breed. A firenewt becomes sluggish, mentally and physically, after spending a week away from an external source of moist heat. A prolonged lack of heat can shut down a firenewt community, as the creatures within go into hibernation and their eggs stop developing.",
+												"Firenewts need hot water to live and breed. A firenewt becomes sluggish, mentally and physically, after spending a week away from an external source of moist heat. A prolonged lack of heat can shut down a firenewt community, as the creatures within go into hibernation and their eggs stop developing.",
 												"Firenewts delve for sources of heat in the earth, such as boiling mud and hot springs, that make ideal places to settle. Through excavation and mining in the area, they fashion living space and obtain an ample supply of minerals for other uses, such as smelting, smithing, and alchemy. A firenewt lair features a network of channels and sluices to circulate hot liquid through the settlement.",
 												"The alchemy practiced by firenewts focuses on fire. One of their favorite mixtures is a paste of sulfur, mineral salts, and oil. Firenewts chew this blend habitually, because doing so produces a pleasant internal heat and it enables a firenewt to vomit forth a small ball of flame. Most firenewts carry a container with this mixture in it.",
 												"Warlocks of Imix command warriors to prove their worth by going on raids to bring back treasure and captives. The warlocks take the choicest loot as a tithe to Imix, and then those who participated in the raid divide the rest according to merit. Prisoners that have no apparent usefulness are sacrificed to Imix and then eaten. Those that are deemed capable of mining and performing other chores around the lair are kept as slaves for a while before meeting the same fate.",
@@ -2272,14 +2277,14 @@
 										{
 											"name": "Religious Militants",
 											"entries": [
-												" Firenewt society and culture are based on the worship of Imix, the Prince of Evil Fire. This veneration of Imix leads firenewts to be aggressive, wrathful, and cruel. Firenewt warlocks of Imix teach that by demonstrating these qualities, a firenewt warrior in combat can become \"touched by the Fire Lord,\" entering a nearly unstoppable battle rage."
+												"Firenewt society and culture are based on the worship of Imix, the Prince of Evil Fire. This veneration of Imix leads firenewts to be aggressive, wrathful, and cruel. Firenewt warlocks of Imix teach that by demonstrating these qualities, a firenewt warrior in combat can become \"touched by the Fire Lord,\" entering a nearly unstoppable battle rage."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Giant Striders",
 											"entries": [
-												" Firenewts have a close relationship with a type of monstrous beast they believe Imix sent to aid them-borne out by the creatures' ability to send a gout of flame against distant enemies. Called giant striders, these monsters appear birdlike and reptilian, but are truly neither. Firenewts provide shelter, food, and breeding grounds in their lairs for giant striders, and the striders voluntarily serve as mounts for elite fire newt soldiers."
+												"Firenewts have a close relationship with a type of monstrous beast they believe Imix sent to aid them-borne out by the creatures' ability to send a gout of flame against distant enemies. Called giant striders, these monsters appear birdlike and reptilian, but are truly neither. Firenewts provide shelter, food, and breeding grounds in their lairs for giant striders, and the striders voluntarily serve as mounts for elite fire newt soldiers."
 											],
 											"type": "entries"
 										}
@@ -2317,7 +2322,7 @@
 										{
 											"name": "Forest Hunters",
 											"entries": [
-												" Girallons are most common in temperate or warm forest environments abundant with life. They share the ape's adeptness at climbing, although these half-ton creatures shy away from scaling trees that can't support their bulk. Instead, they stalk the forest floor, lurk in narrow ravines or shallow caves, or hide in ruined sites while waiting for prey to come near. A girallon is surprisingly stealthy, considering its size and its lack of camouflage.",
+												"Girallons are most common in temperate or warm forest environments abundant with life. They share the ape's adeptness at climbing, although these half-ton creatures shy away from scaling trees that can't support their bulk. Instead, they stalk the forest floor, lurk in narrow ravines or shallow caves, or hide in ruined sites while waiting for prey to come near. A girallon is surprisingly stealthy, considering its size and its lack of camouflage.",
 												"Girallons form loose bands of several individuals and their offspring, usually led by a dominant adult that also tends to be the oldest member of the group. When on the hunt away from their lair, girallons use roars and body language to communicate with one another over distance. Each individual typically hunts alone and widely separated from the others, to ensure that everyone gets adequate fodder. The leader might organize members to work together to make a big kill. If they succeed, everyone in the group shares the spoils, with the best parts going to mothers caring for their young.",
 												"In the time since then, numerous creatures have tried to tame, subjugate, or cooperate with the monsters. For instance, yuan-ti enslave girallons, turning them into border sentinels for their serpent kingdoms. Because girallons are known to be peaceful among their own kind, some humanoids have learned how to approach a group's leader, offering food and other gifts in hopes of establishing an alliance with the creatures.",
 												"Girallons that are well treated might be willing to serve as guards, though they lack the intelligence to take on tasks more complicated than attacking strangers that enter their domain. If one is taken young and properly trained, a girallon could end up in a seemingly unlikely place, such as guarding the entrance to a city's thieves' guild. Those who would keep a girallon as a pet must always be wary, because the creature could revert to its predatory nature at any time."
@@ -2327,14 +2332,14 @@
 										{
 											"name": "Wall Climbers",
 											"entries": [
-												" The ruins of humanoid habitations, especially those found in deep forests and jungles, seem to attract girallons. They move effortlessly along stairs and balconies, as well as on the sloped rooftops and buttresses of such formations. To a girallon, a city's buildings are just another sort of forest-and better yet, one whose uppermost \"branches\" can easily support the creatures. In such a setting, the girallons take full advantage of their skill in climbing. The creatures can easily scale walls and battlements, and they perch on tower tops and other high vantages to keep an eye on the surrounding area."
+												"The ruins of humanoid habitations, especially those found in deep forests and jungles, seem to attract girallons. They move effortlessly along stairs and balconies, as well as on the sloped rooftops and buttresses of such formations. To a girallon, a city's buildings are just another sort of forest-and better yet, one whose uppermost \"branches\" can easily support the creatures. In such a setting, the girallons take full advantage of their skill in climbing. The creatures can easily scale walls and battlements, and they perch on tower tops and other high vantages to keep an eye on the surrounding area."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Magical Origin",
 											"entries": [
-												" The social habits of wild girallons are unusual for apes, as is their instinctive attraction to humanoid structures. These facts, together with the girallon's appearance, lead sages to believe that girallons were created through magic to serve as guardians for some lost empire. When that empire fell ages ago, girallons turned feral and spread out across the world."
+												"The social habits of wild girallons are unusual for apes, as is their instinctive attraction to humanoid structures. These facts, together with the girallon's appearance, lead sages to believe that girallons were created through magic to serve as guardians for some lost empire. When that empire fell ages ago, girallons turned feral and spread out across the world."
 											],
 											"type": "entries"
 										}
@@ -2428,7 +2433,7 @@
 										{
 											"name": "Undead Nature",
 											"entries": [
-												" A gnoll witherling doesn't require air, food, drink, or sleep.",
+												"A gnoll witherling doesn't require air, food, drink, or sleep.",
 												"I heard a warlock sought to magically turn the last witherlings of a destroyed gnoll war band into his own strike force against foes. That worked well until Yeenoghu sent seven war bands after him.",
 												"-Volo"
 											],
@@ -2476,7 +2481,7 @@
 										{
 											"name": "Tree-Dwelling Amphibians",
 											"entries": [
-												" Grungs live in trees and prefer shade. A grung hatchery is maintained in well-guarded ground-level pools. About three months after hatching, a grung tadpole takes on the shape of an adult. It takes another six to nine months for a grung juvenile to reach maturity.",
+												"Grungs live in trees and prefer shade. A grung hatchery is maintained in well-guarded ground-level pools. About three months after hatching, a grung tadpole takes on the shape of an adult. It takes another six to nine months for a grung juvenile to reach maturity.",
 												"Green grungs are the tribe's warriors, hunters, and laborers, and blue grungs work as artisans and in other domestic roles. Supervising and guiding both groups are the purple grungs, which serve as administrators and commanders. (Use the grung stat block to represent members of the green, blue, and purple castes.)",
 												"Red grungs are the tribe's scholars and magic users. They are superior to purple, blue, and green grungs and given proper respect even by grungs of higher status. (Use the grung wildling stat block to represent members of the red caste.)",
 												"Higher castes include orange grungs, which are elite warriors that have authority over all lesser grungs, and gold grungs, which hold the highest leadership positions. A tribe's sovereign is always a gold grung. (Use the grung elite warrior stat block to represent members of the orange and gold castes.)",
@@ -2489,28 +2494,28 @@
 										{
 											"name": "Castes and Colors",
 											"entries": [
-												" Grung society is a caste system. Each caste lays eggs in a separate hatching pool, and juvenile grungs join their caste upon emergence from the hatchery. All grungs are a dull greenish gray when they are born, but each individual takes on the color of its caste as it grows to adulthood."
+												"Grung society is a caste system. Each caste lays eggs in a separate hatching pool, and juvenile grungs join their caste upon emergence from the hatchery. All grungs are a dull greenish gray when they are born, but each individual takes on the color of its caste as it grows to adulthood."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Naturally Toxic",
 											"entries": [
-												" All grungs secrete a substance that is harmless to them but poisonous to other creatures. A grung also uses venom to poison its weapons."
+												"All grungs secrete a substance that is harmless to them but poisonous to other creatures. A grung also uses venom to poison its weapons."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Slavers",
 											"entries": [
-												" Grungs are always on the lookout for creatures they can capture and enslave. Grungs use slaves for all manner of menial tasks, but mostly they just like bossing them around. Slaves are fed mildly {@condition poisoned} food to keep them lethargic and compliant. A creature afflicted in this way over a long period of time becomes a shell of its former self and can be restored to normalcy only by magic."
+												"Grungs are always on the lookout for creatures they can capture and enslave. Grungs use slaves for all manner of menial tasks, but mostly they just like bossing them around. Slaves are fed mildly {@condition poisoned} food to keep them lethargic and compliant. A creature afflicted in this way over a long period of time becomes a shell of its former self and can be restored to normalcy only by magic."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Water Dependency",
 											"entries": [
-												" A grung that fails to immerse itself in water for at least 1 hour during a day suffers one level of {@condition exhaustion} at the end of that day. A grung can recover from this {@condition exhaustion} only through magic or by immersing itself in water for at least 1 hour."
+												"A grung that fails to immerse itself in water for at least 1 hour during a day suffers one level of {@condition exhaustion} at the end of that day. A grung can recover from this {@condition exhaustion} only through magic or by immersing itself in water for at least 1 hour."
 											],
 											"type": "entries"
 										}
@@ -2525,42 +2530,42 @@
 										{
 											"name": "Green",
 											"entries": [
-												" The {@condition poisoned} creature can't move except to climb or make standing jumps. If the creature is flying, it can't take any actions or reactions unless it lands."
+												"The {@condition poisoned} creature can't move except to climb or make standing jumps. If the creature is flying, it can't take any actions or reactions unless it lands."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Blue",
 											"entries": [
-												" The {@condition poisoned} creature must shout loudly or otherwise make a loud noise at the start and end of its turn."
+												"The {@condition poisoned} creature must shout loudly or otherwise make a loud noise at the start and end of its turn."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Purple",
 											"entries": [
-												" The {@condition poisoned} creature feels a desperate need to soak itself in liquid or mud. It can't take actions or move except to do so or to reach a body of liquid or mud."
+												"The {@condition poisoned} creature feels a desperate need to soak itself in liquid or mud. It can't take actions or move except to do so or to reach a body of liquid or mud."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Red",
 											"entries": [
-												" The {@condition poisoned} creature must use its action to eat if food is within reach."
+												"The {@condition poisoned} creature must use its action to eat if food is within reach."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Orange",
 											"entries": [
-												" The {@condition poisoned} creature is {@condition frightened} of its allies."
+												"The {@condition poisoned} creature is {@condition frightened} of its allies."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Gold",
 											"entries": [
-												" The {@condition poisoned} creature is {@condition charmed} and can speak Grung."
+												"The {@condition poisoned} creature is {@condition charmed} and can speak Grung."
 											],
 											"type": "entries"
 										}
@@ -2598,7 +2603,7 @@
 										{
 											"name": "Tree-Dwelling Amphibians",
 											"entries": [
-												" Grungs live in trees and prefer shade. A grung hatchery is maintained in well-guarded ground-level pools. About three months after hatching, a grung tadpole takes on the shape of an adult. It takes another six to nine months for a grung juvenile to reach maturity.",
+												"Grungs live in trees and prefer shade. A grung hatchery is maintained in well-guarded ground-level pools. About three months after hatching, a grung tadpole takes on the shape of an adult. It takes another six to nine months for a grung juvenile to reach maturity.",
 												"Green grungs are the tribe's warriors, hunters, and laborers, and blue grungs work as artisans and in other domestic roles. Supervising and guiding both groups are the purple grungs, which serve as administrators and commanders. (Use the grung stat block to represent members of the green, blue, and purple castes.)",
 												"Red grungs are the tribe's scholars and magic users. They are superior to purple, blue, and green grungs and given proper respect even by grungs of higher status. (Use the grung wildling stat block to represent members of the red caste.)",
 												"Higher castes include orange grungs, which are elite warriors that have authority over all lesser grungs, and gold grungs, which hold the highest leadership positions. A tribe's sovereign is always a gold grung. (Use the grung elite warrior stat block to represent members of the orange and gold castes.)",
@@ -2611,28 +2616,28 @@
 										{
 											"name": "Castes and Colors",
 											"entries": [
-												" Grung society is a caste system. Each caste lays eggs in a separate hatching pool, and juvenile grungs join their caste upon emergence from the hatchery. All grungs are a dull greenish gray when they are born, but each individual takes on the color of its caste as it grows to adulthood."
+												"Grung society is a caste system. Each caste lays eggs in a separate hatching pool, and juvenile grungs join their caste upon emergence from the hatchery. All grungs are a dull greenish gray when they are born, but each individual takes on the color of its caste as it grows to adulthood."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Naturally Toxic",
 											"entries": [
-												" All grungs secrete a substance that is harmless to them but poisonous to other creatures. A grung also uses venom to poison its weapons."
+												"All grungs secrete a substance that is harmless to them but poisonous to other creatures. A grung also uses venom to poison its weapons."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Slavers",
 											"entries": [
-												" Grungs are always on the lookout for creatures they can capture and enslave. Grungs use slaves for all manner of menial tasks, but mostly they just like bossing them around. Slaves are fed mildly {@condition poisoned} food to keep them lethargic and compliant. A creature afflicted in this way over a long period of time becomes a shell of its former self and can be restored to normalcy only by magic."
+												"Grungs are always on the lookout for creatures they can capture and enslave. Grungs use slaves for all manner of menial tasks, but mostly they just like bossing them around. Slaves are fed mildly {@condition poisoned} food to keep them lethargic and compliant. A creature afflicted in this way over a long period of time becomes a shell of its former self and can be restored to normalcy only by magic."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Water Dependency",
 											"entries": [
-												" A grung that fails to immerse itself in water for at least 1 hour during a day suffers one level of {@condition exhaustion} at the end of that day. A grung can recover from this {@condition exhaustion} only through magic or by immersing itself in water for at least 1 hour."
+												"A grung that fails to immerse itself in water for at least 1 hour during a day suffers one level of {@condition exhaustion} at the end of that day. A grung can recover from this {@condition exhaustion} only through magic or by immersing itself in water for at least 1 hour."
 											],
 											"type": "entries"
 										}
@@ -2647,42 +2652,42 @@
 										{
 											"name": "Green",
 											"entries": [
-												" The {@condition poisoned} creature can't move except to climb or make standing jumps. If the creature is flying, it can't take any actions or reactions unless it lands."
+												"The {@condition poisoned} creature can't move except to climb or make standing jumps. If the creature is flying, it can't take any actions or reactions unless it lands."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Blue",
 											"entries": [
-												" The {@condition poisoned} creature must shout loudly or otherwise make a loud noise at the start and end of its turn."
+												"The {@condition poisoned} creature must shout loudly or otherwise make a loud noise at the start and end of its turn."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Purple",
 											"entries": [
-												" The {@condition poisoned} creature feels a desperate need to soak itself in liquid or mud. It can't take actions or move except to do so or to reach a body of liquid or mud."
+												"The {@condition poisoned} creature feels a desperate need to soak itself in liquid or mud. It can't take actions or move except to do so or to reach a body of liquid or mud."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Red",
 											"entries": [
-												" The {@condition poisoned} creature must use its action to eat if food is within reach."
+												"The {@condition poisoned} creature must use its action to eat if food is within reach."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Orange",
 											"entries": [
-												" The {@condition poisoned} creature is {@condition frightened} of its allies."
+												"The {@condition poisoned} creature is {@condition frightened} of its allies."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Gold",
 											"entries": [
-												" The {@condition poisoned} creature is {@condition charmed} and can speak Grung."
+												"The {@condition poisoned} creature is {@condition charmed} and can speak Grung."
 											],
 											"type": "entries"
 										}
@@ -2720,7 +2725,7 @@
 										{
 											"name": "Tree-Dwelling Amphibians",
 											"entries": [
-												" Grungs live in trees and prefer shade. A grung hatchery is maintained in well-guarded ground-level pools. About three months after hatching, a grung tadpole takes on the shape of an adult. It takes another six to nine months for a grung juvenile to reach maturity.",
+												"Grungs live in trees and prefer shade. A grung hatchery is maintained in well-guarded ground-level pools. About three months after hatching, a grung tadpole takes on the shape of an adult. It takes another six to nine months for a grung juvenile to reach maturity.",
 												"Green grungs are the tribe's warriors, hunters, and laborers, and blue grungs work as artisans and in other domestic roles. Supervising and guiding both groups are the purple grungs, which serve as administrators and commanders. (Use the grung stat block to represent members of the green, blue, and purple castes.)",
 												"Red grungs are the tribe's scholars and magic users. They are superior to purple, blue, and green grungs and given proper respect even by grungs of higher status. (Use the grung wildling stat block to represent members of the red caste.)",
 												"Higher castes include orange grungs, which are elite warriors that have authority over all lesser grungs, and gold grungs, which hold the highest leadership positions. A tribe's sovereign is always a gold grung. (Use the grung elite warrior stat block to represent members of the orange and gold castes.)",
@@ -2733,28 +2738,28 @@
 										{
 											"name": "Castes and Colors",
 											"entries": [
-												" Grung society is a caste system. Each caste lays eggs in a separate hatching pool, and juvenile grungs join their caste upon emergence from the hatchery. All grungs are a dull greenish gray when they are born, but each individual takes on the color of its caste as it grows to adulthood."
+												"Grung society is a caste system. Each caste lays eggs in a separate hatching pool, and juvenile grungs join their caste upon emergence from the hatchery. All grungs are a dull greenish gray when they are born, but each individual takes on the color of its caste as it grows to adulthood."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Naturally Toxic",
 											"entries": [
-												" All grungs secrete a substance that is harmless to them but poisonous to other creatures. A grung also uses venom to poison its weapons."
+												"All grungs secrete a substance that is harmless to them but poisonous to other creatures. A grung also uses venom to poison its weapons."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Slavers",
 											"entries": [
-												" Grungs are always on the lookout for creatures they can capture and enslave. Grungs use slaves for all manner of menial tasks, but mostly they just like bossing them around. Slaves are fed mildly {@condition poisoned} food to keep them lethargic and compliant. A creature afflicted in this way over a long period of time becomes a shell of its former self and can be restored to normalcy only by magic."
+												"Grungs are always on the lookout for creatures they can capture and enslave. Grungs use slaves for all manner of menial tasks, but mostly they just like bossing them around. Slaves are fed mildly {@condition poisoned} food to keep them lethargic and compliant. A creature afflicted in this way over a long period of time becomes a shell of its former self and can be restored to normalcy only by magic."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Water Dependency",
 											"entries": [
-												" A grung that fails to immerse itself in water for at least 1 hour during a day suffers one level of {@condition exhaustion} at the end of that day. A grung can recover from this {@condition exhaustion} only through magic or by immersing itself in water for at least 1 hour."
+												"A grung that fails to immerse itself in water for at least 1 hour during a day suffers one level of {@condition exhaustion} at the end of that day. A grung can recover from this {@condition exhaustion} only through magic or by immersing itself in water for at least 1 hour."
 											],
 											"type": "entries"
 										}
@@ -2769,42 +2774,42 @@
 										{
 											"name": "Green",
 											"entries": [
-												" The {@condition poisoned} creature can't move except to climb or make standing jumps. If the creature is flying, it can't take any actions or reactions unless it lands."
+												"The {@condition poisoned} creature can't move except to climb or make standing jumps. If the creature is flying, it can't take any actions or reactions unless it lands."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Blue",
 											"entries": [
-												" The {@condition poisoned} creature must shout loudly or otherwise make a loud noise at the start and end of its turn."
+												"The {@condition poisoned} creature must shout loudly or otherwise make a loud noise at the start and end of its turn."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Purple",
 											"entries": [
-												" The {@condition poisoned} creature feels a desperate need to soak itself in liquid or mud. It can't take actions or move except to do so or to reach a body of liquid or mud."
+												"The {@condition poisoned} creature feels a desperate need to soak itself in liquid or mud. It can't take actions or move except to do so or to reach a body of liquid or mud."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Red",
 											"entries": [
-												" The {@condition poisoned} creature must use its action to eat if food is within reach."
+												"The {@condition poisoned} creature must use its action to eat if food is within reach."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Orange",
 											"entries": [
-												" The {@condition poisoned} creature is {@condition frightened} of its allies."
+												"The {@condition poisoned} creature is {@condition frightened} of its allies."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Gold",
 											"entries": [
-												" The {@condition poisoned} creature is {@condition charmed} and can speak Grung."
+												"The {@condition poisoned} creature is {@condition charmed} and can speak Grung."
 											],
 											"type": "entries"
 										}
@@ -2842,7 +2847,7 @@
 										{
 											"name": "Gifts from Dragons",
 											"entries": [
-												" The ritual to create a guard drake was originally devised by the cult of Tiamat, but has spread to other groups that are skilled in arcana and associated with dragons. The cooperation of a dragon is necessary for the ritual to succeed, and a dragon typically provides its help when it wants to reward its allies or worshipers with a valuable servant.",
+												"The ritual to create a guard drake was originally devised by the cult of Tiamat, but has spread to other groups that are skilled in arcana and associated with dragons. The cooperation of a dragon is necessary for the ritual to succeed, and a dragon typically provides its help when it wants to reward its allies or worshipers with a valuable servant.",
 												"The ritual, which takes several days, requires 10 pounds of fresh dragon scales (donated by the dragon allied with the group), a large amount of fresh meat, and an iron cauldron. When the process is complete, a halfling-sized egg emerges from the cauldron and is ready to hatch within a few hours.",
 												"A guard drake resembles the type of dragon it was created from, but with a wingless, squat, muscular build. A drake can't reproduce, nor can its scales be used to make other guard drakes."
 											],
@@ -2851,7 +2856,7 @@
 										{
 											"name": "Eager to Learn",
 											"entries": [
-												" A newly hatched guard drake imprints upon the first creature that feeds it (usually the one planning to train it), establishing an aggressive but trusting bond with that individual. A guard drake is fully grown within two to three weeks and can be trained in the same length of time. One is the equivalent of a guard dog in terms of what it can be trained to do."
+												"A newly hatched guard drake imprints upon the first creature that feeds it (usually the one planning to train it), establishing an aggressive but trusting bond with that individual. A guard drake is fully grown within two to three weeks and can be trained in the same length of time. One is the equivalent of a guard dog in terms of what it can be trained to do."
 											],
 											"type": "entries"
 										}
@@ -2865,35 +2870,35 @@
 										{
 											"name": "Black Guard Drake",
 											"entries": [
-												" A black guard drake is amphibious (it can breathe air or water), has a swimming speed of 30 feet, and has resistance to acid damage."
+												"A black guard drake is amphibious (it can breathe air or water), has a swimming speed of 30 feet, and has resistance to acid damage."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Blue Guard Drake",
 											"entries": [
-												" A blue guard drake has a burrowing speed of 20 feet and resistance to lightning damage."
+												"A blue guard drake has a burrowing speed of 20 feet and resistance to lightning damage."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Green Guard Drake",
 											"entries": [
-												" A green guard drake is amphibious (it can breathe air or water), has a swimming speed of 30 feet, and has resistance to poison damage."
+												"A green guard drake is amphibious (it can breathe air or water), has a swimming speed of 30 feet, and has resistance to poison damage."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Red Guard Drake",
 											"entries": [
-												" A red guard drake has climbing speed of 30 feet and resistance to fire damage."
+												"A red guard drake has climbing speed of 30 feet and resistance to fire damage."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "White Guard Drake",
 											"entries": [
-												" A white guard drake has a burrowing speed of 20 feet, a climbing speed of 30 feet, and resistance to cold damage."
+												"A white guard drake has a burrowing speed of 20 feet, a climbing speed of 30 feet, and resistance to cold damage."
 											],
 											"type": "entries"
 										}
@@ -2953,7 +2958,7 @@
 										{
 											"name": "Into the Fray",
 											"entries": [
-												" While other cultures treat their wizards as cloistered academics, hobgoblins expect their spellcasters to fight. Devastators learn the basics of weapon use, and they measure their deeds by the enemies defeated though their magic.",
+												"While other cultures treat their wizards as cloistered academics, hobgoblins expect their spellcasters to fight. Devastators learn the basics of weapon use, and they measure their deeds by the enemies defeated though their magic.",
 												"Devastators have the respect of other members of the host, and they receive obedience and deference from many quarters. Their ability to lay waste to entire formations with a single use of magic allows them to gain far more glory in battle than a single warrior.",
 												"Other cultures might view the use of such abilities as a short cut to glory, but to hobgoblins a gift for magic is as valued and useful as a strong sword arm or brilliance in tactics. They are all boons from Maglubiyet that must be cultivated and unleashed upon the enemy.",
 												"The Academy of Devastation believes that an academic approach to magic is a sign of weakness and inefficiency. A warrior doesn't need to know about metallurgy to wield a blade, so why should a wizard care about where magic comes from? Devastators love to prove their superiority in battle by seeking out enemy spellcasters and destroying them."
@@ -2963,7 +2968,7 @@
 										{
 											"name": "Only Results Matter",
 											"entries": [
-												" Devastators study a simplified form of evocation magic. Their training lacks the theory and context that other folk study, making them skilled in battle but relatively illiterate on the finer points of how and why their magic works."
+												"Devastators study a simplified form of evocation magic. Their training lacks the theory and context that other folk study, making them skilled in battle but relatively illiterate on the finer points of how and why their magic works."
 											],
 											"type": "entries"
 										}
@@ -3001,7 +3006,7 @@
 										{
 											"name": "Trained in Secret",
 											"entries": [
-												" Iron Shadows are recruited from across the hobgoblin ranks. Each member keeps her eyes open for potential recruits, those whose agility and stamina are matched only by an ironclad commitment to Maglubiyet's will.",
+												"Iron Shadows are recruited from across the hobgoblin ranks. Each member keeps her eyes open for potential recruits, those whose agility and stamina are matched only by an ironclad commitment to Maglubiyet's will.",
 												"A candidate for admission undergoes a series of tests designed to reveal any potential for treachery. Those who fail are slain, while those who pass receive secret training in the magical and martial arts. This indoctrination is a slow and arduous process; many aspirants don't finish it, and years might go by during which the Iron Shadows welcome no new members into their ranks. While a recruit is in training, it serves the Iron Shadows by looking for and reporting suspicious behavior.",
 												"Their masks also signify the supposed origin of their fighting techniques. The priests of Maglubiyet teach that the Great One stole the secrets of shadows from an archdevil, allowing his followers to conceal their identities, walk between shadows, and craft illusions to confuse and confound their enemies."
 											],
@@ -3010,14 +3015,14 @@
 										{
 											"name": "Masters of Shadow and Fist",
 											"entries": [
-												" When a recruit's training is complete, she is ready to wield a deadly combination of unarmed fighting techniques and shadow magic to deceive and defeat her foes. She continues to spy on other hobgoblins, but is now also empowered to conduct assassinations and spy missions, both against enemies and among goblinoids. These missions are ordained by the clerics of Maglubiyet, who keep a careful eye on the goblinoid community to ensure that it functions according to Maglubiyet's will."
+												"When a recruit's training is complete, she is ready to wield a deadly combination of unarmed fighting techniques and shadow magic to deceive and defeat her foes. She continues to spy on other hobgoblins, but is now also empowered to conduct assassinations and spy missions, both against enemies and among goblinoids. These missions are ordained by the clerics of Maglubiyet, who keep a careful eye on the goblinoid community to ensure that it functions according to Maglubiyet's will."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Masked Devils",
 											"entries": [
-												" Iron Shadows on a secret mission wear masks crafted to resemble devils, both to conceal their identities and to strike fear into their foes."
+												"Iron Shadows on a secret mission wear masks crafted to resemble devils, both to conceal their identities and to strike fear into their foes."
 											],
 											"type": "entries"
 										}
@@ -3055,7 +3060,7 @@
 										{
 											"name": "Arcane Temptation",
 											"entries": [
-												" Elder brains forbid mind flayers from pursuing magic power aside from psionics, but it isn't an interdiction they must often enforce. Illithids brook no masters but members of their own kind, so it isn't in their nature to bow to any god or otherworldly patron. However, wizardry remains a rare temptation.",
+												"Elder brains forbid mind flayers from pursuing magic power aside from psionics, but it isn't an interdiction they must often enforce. Illithids brook no masters but members of their own kind, so it isn't in their nature to bow to any god or otherworldly patron. However, wizardry remains a rare temptation.",
 												"In the pages of a spellbook, an illithid sees a system to acquire authority. Through the writings of the wizard who penned it, the illithid perceives the workings of a highly intelligent mind. Most mind flayers who find a spellbook react with abhorrence or indifference, but for some a spellbook is a gateway to a new way of thinking.",
 												"For a time, the study of such forbidden texts can be hidden from other illithids and even from an elder brain. Understanding of wizardry eludes the mind like a living thing. Yet eventually, understanding comes, and a mind flayer arcanist must accept itself as deviant and flee the colony if it is to live.",
 												"Confronting this awful reality, a group of nine mind flayer deviants used their arcane magic and psionics to weave a new truth. These nine called themselves the alhoon, and ever afterward, all those who follow in their footsteps have been referred to by the same name.",
@@ -3069,28 +3074,28 @@
 										{
 											"name": "Existential Fear",
 											"entries": [
-												" Arcanist deviants that taste freedom from the colony react in a variety of ways. Some prize their privacy, others seek to commune with similar minds, and still others seek to dominate a colony, elevating themselves to the position of leadership normally held by an elder brain. Regardless of the arcanist's personal inclinations, it faces the same stark fact: When it dies, it will not join the host of minds in the elder brain. Deviant minds are never accepted as part of the collective. For it, death means oblivion."
+												"Arcanist deviants that taste freedom from the colony react in a variety of ways. Some prize their privacy, others seek to commune with similar minds, and still others seek to dominate a colony, elevating themselves to the position of leadership normally held by an elder brain. Regardless of the arcanist's personal inclinations, it faces the same stark fact: When it dies, it will not join the host of minds in the elder brain. Deviant minds are never accepted as part of the collective. For it, death means oblivion."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Dreadful Deliverance",
 											"entries": [
-												" Lichdom offers salvation and the prospect of being able to pursue knowledge indefinitely. Having feasted on the brains of people when alive, a mind flayer has no compunction about feeding souls to a phylactery. The only hindrance to a mind flayer becoming a lich is the means, which is a secret some mind flayer arcanists stop at nothing to discover. Yet lichdom requires an arcane spellcaster to be at the apex of power, something many mind flayers find is far from their grasps."
+												"Lichdom offers salvation and the prospect of being able to pursue knowledge indefinitely. Having feasted on the brains of people when alive, a mind flayer has no compunction about feeding souls to a phylactery. The only hindrance to a mind flayer becoming a lich is the means, which is a secret some mind flayer arcanists stop at nothing to discover. Yet lichdom requires an arcane spellcaster to be at the apex of power, something many mind flayers find is far from their grasps."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "A Psionic Secret",
 											"entries": [
-												" Alhoons can cooperate in the creation of a periapt of mind trapping, a fist-sized container made of silver, emerald, and amethyst. The process requires at least three mind flayer arcanists and the sacrifice of an equal number of souls from living victims in a three-day-long ritual of spellcasting and psionic communion. Upon its completion, free-willed undeath is conferred on the mind flayers, turning them into alhoons."
+												"Alhoons can cooperate in the creation of a periapt of mind trapping, a fist-sized container made of silver, emerald, and amethyst. The process requires at least three mind flayer arcanists and the sacrifice of an equal number of souls from living victims in a three-day-long ritual of spellcasting and psionic communion. Upon its completion, free-willed undeath is conferred on the mind flayers, turning them into alhoons."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Precarious Immortality",
 											"entries": [
-												" Unlike with true lichdom, the periapt of mind trapping doesn't restore the alhoons to undeath if they are destroyed. Instead, a destroyed alhoon's mind is transferred to the periapt where it remains in communion with any other trapped alhoon minds, as well as the souls of those sacrificed."
+												"Unlike with true lichdom, the periapt of mind trapping doesn't restore the alhoons to undeath if they are destroyed. Instead, a destroyed alhoon's mind is transferred to the periapt where it remains in communion with any other trapped alhoon minds, as well as the souls of those sacrificed."
 											],
 											"type": "entries"
 										}
@@ -3113,7 +3118,7 @@
 										{
 											"name": "Magic Resistance",
 											"entries": [
-												" The lich has advantage on saving throws against spells and other magical effects.",
+												"The lich has advantage on saving throws against spells and other magical effects.",
 												"At will: detect thoughts, levitate",
 												"1/day each: dominate monster, plane shift (self only)"
 											],
@@ -3122,7 +3127,7 @@
 										{
 											"name": "Innate Spellcasting (Psionics)",
 											"entries": [
-												" The lich's innate spellcasting ability is Intelligence (spell save DC 20). It can innately cast the following spells, requiring no components."
+												"The lich's innate spellcasting ability is Intelligence (spell save DC 20). It can innately cast the following spells, requiring no components."
 											],
 											"type": "entries"
 										}
@@ -3163,28 +3168,28 @@
 										{
 											"name": "Tentacles",
 											"entries": [
-												" The lich makes one attack with its tentacles."
+												"The lich makes one attack with its tentacles."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Extract Brain (Costs 2 Actions)",
 											"entries": [
-												" The lich uses Extract Brain."
+												"The lich uses Extract Brain."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Mind Blast (Costs 3 Actions)",
 											"entries": [
-												" The lich recharges its Mind Blast and uses it."
+												"The lich recharges its Mind Blast and uses it."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Cast Spell (Costs 1\u20133 Actions)",
 											"entries": [
-												" The lich uses a spell slot to cast a 1st-, 2nd-, or 3rd-level spell that it has prepared. Doing so costs 1 legendary action per level of the spell."
+												"The lich uses a spell slot to cast a 1st-, 2nd-, or 3rd-level spell that it has prepared. Doing so costs 1 legendary action per level of the spell."
 											],
 											"type": "entries"
 										}
@@ -3253,7 +3258,7 @@
 										{
 											"name": "Good Personified",
 											"entries": [
-												" Ki-rins are the embodiment of good, and simply beholding one can evoke fear or awe in an observer. A typical ki-rin looks like a muscular stag the size of an elephant, covered in golden scales lined in some places with golden fur. It has a dark gold mane and tail, coppery cloven hooves, and a spiral-shaped coppery horn just above and between its luminous violet eyes. In a breeze or when aloft, the creature's scales and hair can create the impression that the ki-rin is ablaze with a holy, golden fire.",
+												"Ki-rins are the embodiment of good, and simply beholding one can evoke fear or awe in an observer. A typical ki-rin looks like a muscular stag the size of an elephant, covered in golden scales lined in some places with golden fur. It has a dark gold mane and tail, coppery cloven hooves, and a spiral-shaped coppery horn just above and between its luminous violet eyes. In a breeze or when aloft, the creature's scales and hair can create the impression that the ki-rin is ablaze with a holy, golden fire.",
 												"Beyond their coloration, ki-rins vary in appearance, based on the deity each one reveres and the function it typically performs in service to that god. Some are horse-shaped, looking like gigantic unicorns, and are often used as guardians. Others have draconic features and tend to be aggressive foes of evil. One horn is most common, but a ki-rin of fierce demeanor might have two horns or a set of antlers like those of a great stag.",
 												"A ki-rin in the world claims a territory to watch over, and one ki-rin might safeguard an area that encompasses several nations. On other planes, ki-rins that serve good deities go wherever they are commanded, which could include coming to the Material Plane on a mission. A ki-rin disciple in the world usually serves its deity as a scout, a messenger, or a spy.",
 												"Ki-rins are attracted to the worship of deities of courage, loyalty, selflessness, and truth, as well as the advancement of just societies. For instance, in Faerûn, ki-rins rally mostly to Torm, although ki-rins also serve his allies Tyr and Ilmater.",
@@ -3264,14 +3269,14 @@
 										{
 											"name": "Bringers of Boons",
 											"entries": [
-												" Common folk consider ki-rins to be rare and remote heralds of good fortune. Seeing a ki-rin fly overhead is a blessing, and events that happen on such a day are especially auspicious. If a ki-rin alights during a ceremony, such as a birth announcement or a coronation, everyone present understands that the creature is telling them great good could be in the offing. The ki-rin conveys its gifts and omens, then rises back into the sky. Ki-rins have also been known to appear at the sites of great battles to inspire and strengthen the side of good, or to rescue heroes from certain death."
+												"Common folk consider ki-rins to be rare and remote heralds of good fortune. Seeing a ki-rin fly overhead is a blessing, and events that happen on such a day are especially auspicious. If a ki-rin alights during a ceremony, such as a birth announcement or a coronation, everyone present understands that the creature is telling them great good could be in the offing. The ki-rin conveys its gifts and omens, then rises back into the sky. Ki-rins have also been known to appear at the sites of great battles to inspire and strengthen the side of good, or to rescue heroes from certain death."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Objects of Adoration",
 											"entries": [
-												" Because a ki-rin is renowned for its wisdom, other creatures would naturally seek it out with questions and requests if they could. For that reason among others, the creature makes its lair atop a forbidding mountain peak or in some other equally inaccessible location. Only those that have the tenacity to complete the daunting journey to a ki-rin's lair can prove themselves worthy of speaking with its occupant."
+												"Because a ki-rin is renowned for its wisdom, other creatures would naturally seek it out with questions and requests if they could. For that reason among others, the creature makes its lair atop a forbidding mountain peak or in some other equally inaccessible location. Only those that have the tenacity to complete the daunting journey to a ki-rin's lair can prove themselves worthy of speaking with its occupant."
 											],
 											"type": "entries"
 										}
@@ -3316,7 +3321,7 @@
 										{
 											"name": "Uncommon Courage",
 											"entries": [
-												" A dragonshield knows that it has a place of honor in the tribe, but-being kobolds at heart-most of them feel unworthy of their status and thus desperate to prove themselves deserving of it. A dragonshield's natural kobold cowardice is still present in its makeup, and thus it might still run away from a threat. But it also has the ability to rally in the face of certain death, inspiring other kobolds to follow it in a charge against the invaders of their warren."
+												"A dragonshield knows that it has a place of honor in the tribe, but-being kobolds at heart-most of them feel unworthy of their status and thus desperate to prove themselves deserving of it. A dragonshield's natural kobold cowardice is still present in its makeup, and thus it might still run away from a threat. But it also has the ability to rally in the face of certain death, inspiring other kobolds to follow it in a charge against the invaders of their warren."
 											],
 											"type": "entries"
 										}
@@ -3354,7 +3359,7 @@
 										{
 											"name": "Good While They Last",
 											"entries": [
-												" An inventor's new weapons last for only one or two attacks before they break, but might be surprisingly effective in the meantime. Most inventors are skilled enough that their improvised weapons don't backfire on them, but other users might not be so lucky. The weapons don't have to be lethal-in many cases one serves its purpose if it distracts, scares, or confuses a creature long enough for other kobolds to kill the enemy. In any particular encounter, an inventor usually has one or two improvised weapons at its disposal."
+												"An inventor's new weapons last for only one or two attacks before they break, but might be surprisingly effective in the meantime. Most inventors are skilled enough that their improvised weapons don't backfire on them, but other users might not be so lucky. The weapons don't have to be lethal-in many cases one serves its purpose if it distracts, scares, or confuses a creature long enough for other kobolds to kill the enemy. In any particular encounter, an inventor usually has one or two improvised weapons at its disposal."
 											],
 											"type": "entries"
 										}
@@ -3392,7 +3397,7 @@
 										{
 											"name": "Duty-Bound to a Dragon",
 											"entries": [
-												" In a kobold tribe associated with a dragon, typically one that resides in or near the dragon's lair, the scale sorcerer also serves as diplomat and mouthpiece-anticipating the dragon's needs, issuing commands to other kobolds on the dragon's behalf, and reporting information back to the dragon. The sorcerer is just as awed by and respectful of dragons as common kobolds are, but it knows that its duty requires it not to fawn over its master at all times. It also understands that its frequent proximity to the dragon means it would probably be the first to die if its master became angry or displeased, and so it frantically maintains a balance between adoration and terror in its behavior toward the dragon.",
+												"In a kobold tribe associated with a dragon, typically one that resides in or near the dragon's lair, the scale sorcerer also serves as diplomat and mouthpiece-anticipating the dragon's needs, issuing commands to other kobolds on the dragon's behalf, and reporting information back to the dragon. The sorcerer is just as awed by and respectful of dragons as common kobolds are, but it knows that its duty requires it not to fawn over its master at all times. It also understands that its frequent proximity to the dragon means it would probably be the first to die if its master became angry or displeased, and so it frantically maintains a balance between adoration and terror in its behavior toward the dragon.",
 												"Never make the mistake of thinking kobolds are stupid or backward just because they're small. Size has nothing to do with it.",
 												"-Volo"
 											],
@@ -3432,7 +3437,7 @@
 										{
 											"name": "Earthy Fey",
 											"entries": [
-												" Korreds prefer to keep their own company and occasionally consort with creatures of elemental earth such as galeb duhr. A tribe of korreds gathers weekly to perform ceremonial dances, beating out rhythms on stone with their hooves and clubs. In the depths of the Material Plane, korreds typically flee from other creatures but become aggressive when they feel insulted or are annoyed by the sounds of mining.",
+												"Korreds prefer to keep their own company and occasionally consort with creatures of elemental earth such as galeb duhr. A tribe of korreds gathers weekly to perform ceremonial dances, beating out rhythms on stone with their hooves and clubs. In the depths of the Material Plane, korreds typically flee from other creatures but become aggressive when they feel insulted or are annoyed by the sounds of mining.",
 												"Korreds can hurl boulders far larger than it seems they should be able to, shape stone as though it were clay, swim through rock, and summon earth elementals and other creatures. They also gain supernatural strength just from standing on the ground.",
 												"There's a legend about a merchant who tried to cut a korred's hair with golden shears. The korred fed him those shears, from his swallow to his sitter.",
 												"-Volo"
@@ -3442,14 +3447,14 @@
 										{
 											"name": "Stone Sympathy",
 											"entries": [
-												" No one knows the ways of stone and earth better than a korred. Korreds can seemingly smell veins of metal or gems. A korred on the surface can feel the rise and fall of bedrock under the earth and where caves lie, and underground it knows the pathways through the stone for miles. Secret doors that lead through stone are as obvious as windows to a korred."
+												"No one knows the ways of stone and earth better than a korred. Korreds can seemingly smell veins of metal or gems. A korred on the surface can feel the rise and fall of bedrock under the earth and where caves lie, and underground it knows the pathways through the stone for miles. Secret doors that lead through stone are as obvious as windows to a korred."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Enchanted Hair",
 											"entries": [
-												" Korreds have hair all over their bodies, but the hair that grows from their heads is magical. When cut, it transforms into whatever material was used to cut it. Korreds use iron shears to cut lengths of their hair, then weave the strands together to create iron ropes that they can manipulate, animating them to bind or snake around creatures and objects. Korreds take great pride in their hair, and equally great offense at any one who attempts to cut it without permission."
+												"Korreds have hair all over their bodies, but the hair that grows from their heads is magical. When cut, it transforms into whatever material was used to cut it. Korreds use iron shears to cut lengths of their hair, then weave the strands together to create iron ropes that they can manipulate, animating them to bind or snake around creatures and objects. Korreds take great pride in their hair, and equally great offense at any one who attempts to cut it without permission."
 											],
 											"type": "entries"
 										}
@@ -3520,7 +3525,7 @@
 										{
 											"name": "Spawn of Yeenoghu",
 											"entries": [
-												" The first leucrottas came into being alongside the gnolls during Yeenoghu's rampages on the Material Plane. Some of the hyenas that ate Yeenoghu's kills went through different transformations rather than turning into gnolls. Among these bizarre results, leucrottas were the most numerous.",
+												"The first leucrottas came into being alongside the gnolls during Yeenoghu's rampages on the Material Plane. Some of the hyenas that ate Yeenoghu's kills went through different transformations rather than turning into gnolls. Among these bizarre results, leucrottas were the most numerous.",
 												"As clever as it is cruel, a leucrotta loves to deceive, torture, and kill. Because leucrottas are smarter and tougher than most gnolls, one could occupy an elevated position within a gnoll tribe. Although a leucrotta is unlikely to lead a group of gnolls, it can influence the leader, and it might even agree to carry a leader into battle and offer advice during the fight.",
 												"Gnolls see leucrottas as a form of entertainment, partly because a leucrotta can mimic the squeals of a suffering victim-a sound that always gives gnolls pleasure-even when no victims are to be had. Further, a gnoll is bloodthirsty and sadistic, but unable by its nature to prolong the fun of killing. Most leucrottas are consciously cruel, to the point of being meticulous about their savagery to draw out a kill into better and longer sport. Gnolls enjoy watching a leucrotta work almost as much as they like doing their own killing.",
 												"A leucrotta's stench would normally warn away prey long before the creature could attack. It has two natural capabilities, however, that give it an advantage. First, a leucrotta's tracks are nearly impossible to distinguish from those of common deer. Second, it can duplicate the call or the vocal expressions of just about any creature it has heard. The monster uses its mimicry to lure in potential victims, then attacks when they are confused or unaware of the actual threat."
@@ -3530,7 +3535,7 @@
 										{
 											"name": "Foulness Embodied",
 											"entries": [
-												" The leucrotta is so loathsome that only gnolls and others of its kind can stand to be around one for long. Its horrific, hodgepodge body oozes a foul stench that pollutes anywhere the creature lairs. This reek is outdone only by the creature's breath, which issues from a maw that drips fluid corrupted with rot and digestive juices. In place of fangs, a leucrotta has bony ridges as hard as steel that can crush bones and lacerate flesh. These plates are so tough that a leucrotta can use them to peel plate armor away from the body of a slain knight."
+												"The leucrotta is so loathsome that only gnolls and others of its kind can stand to be around one for long. Its horrific, hodgepodge body oozes a foul stench that pollutes anywhere the creature lairs. This reek is outdone only by the creature's breath, which issues from a maw that drips fluid corrupted with rot and digestive juices. In place of fangs, a leucrotta has bony ridges as hard as steel that can crush bones and lacerate flesh. These plates are so tough that a leucrotta can use them to peel plate armor away from the body of a slain knight."
 											],
 											"type": "entries"
 										}
@@ -3660,7 +3665,7 @@
 										{
 											"name": "Fear Incarnate",
 											"entries": [
-												" Meenlocks are spawned by fear. Whenever fear overwhelms a creature in the Feywild, or in any other location where the Feywild's influence is strong, one or more meenlocks might spontaneously arise in the shadows or darkness nearby. If more than one meenlock is born, a lair also magically forms. The earth creaks and moans as narrow, twisting tunnels open up within it. One of these newly formed passageways serves as the lair's only entrance and exit.",
+												"Meenlocks are spawned by fear. Whenever fear overwhelms a creature in the Feywild, or in any other location where the Feywild's influence is strong, one or more meenlocks might spontaneously arise in the shadows or darkness nearby. If more than one meenlock is born, a lair also magically forms. The earth creaks and moans as narrow, twisting tunnels open up within it. One of these newly formed passageways serves as the lair's only entrance and exit.",
 												"Meenlocks give other creatures the creeps and project a supernatural aura that instills terror in those nearby. So evil and twisted are they that a palpable sense of foreboding haunts those who intrude upon a meenlock lair. Inside the warren, black moss covers every surface, muffling sound. A large central chamber serves as the meenlocks' den, where they torment captives.",
 												"During the day, meenlocks confine themselves to their dark warrens. At night, they crawl out of their tunnels to torment sleeping prey, particularly those who seem to embody all that is good in the world. Meenlocks like to paralyze creatures with their claws, drag them back to their hidden den, beat them unconscious, and telepathically torture them over a period of hours. A humanoid that succumbs to this psychic torment undergoes a transformation into an evil, full-grown meenlock (see the \"Telepathic Torment\" sidebar)."
 											],
@@ -3669,14 +3674,14 @@
 										{
 											"name": "Dark Dwellers",
 											"entries": [
-												" A meenlock shuns bright light. It can supernaturally sense areas of darkness and shadow in its vicinity and thus is able to teleport from one darkened space to another-enabling it to sneak up on its prey or run away when outmatched."
+												"A meenlock shuns bright light. It can supernaturally sense areas of darkness and shadow in its vicinity and thus is able to teleport from one darkened space to another-enabling it to sneak up on its prey or run away when outmatched."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Telepathic Tormentors",
 											"entries": [
-												" Meenlocks have no form of communication other than telepathy. They can use it to project unsettling hallucinations into the minds of their prey. These hallucinations take the form of terrible whispers or fleeting movements just at the edges of one's peripheral vision."
+												"Meenlocks have no form of communication other than telepathy. They can use it to project unsettling hallucinations into the minds of their prey. These hallucinations take the form of terrible whispers or fleeting movements just at the edges of one's peripheral vision."
 											],
 											"type": "entries"
 										}
@@ -3731,7 +3736,7 @@
 										{
 											"name": "Hive Mind Colonies",
 											"entries": [
-												" Solitary mind flayers are likely rogues and outcasts. Most illithids belong to a colony of sibling mind flayers devoted to an elder brain-a massive brain-like being that resides in a briny pool near the center of a mind flayer community. From its pool, an elder brain telepathically dictates its desires to each individual mind flayer within 5 miles of it, for it is able to hold multiple mental conversations at once.",
+												"Solitary mind flayers are likely rogues and outcasts. Most illithids belong to a colony of sibling mind flayers devoted to an elder brain-a massive brain-like being that resides in a briny pool near the center of a mind flayer community. From its pool, an elder brain telepathically dictates its desires to each individual mind flayer within 5 miles of it, for it is able to hold multiple mental conversations at once.",
 												"An illithid experiences euphoria as it devours the brain of a humanoid, along with its memories, personality, and innermost fears. Mind flayers will sometimes harvest a brain rather than devour it, using it as part of some alien experiment or transforming it into an intellect devourer.",
 												"Qualith",
 												"On the rare occasion that mind flayers need to write something down, they do so in Qualith. This system of tactile writing (similar to braille) is read by an illithid's tentacles. Qualith is written in four-line stanzas and is so alien in construction that non-illithids must resort to magic to discern its meaning. Though Qualith can be used to keep records, illithids most often use it to mark portals or other surfaces with warnings or instructions."
@@ -3741,7 +3746,7 @@
 										{
 											"name": "Hunger of the Mind",
 											"entries": [
-												" Illithids subsist on the brains of humanoids. The brains provide enzymes, hormones, and psychic energy necessary for their survival. An illithid healthy from a brain-rich diet secretes a thin glaze of mucus that coats its mauve skin."
+												"Illithids subsist on the brains of humanoids. The brains provide enzymes, hormones, and psychic energy necessary for their survival. An illithid healthy from a brain-rich diet secretes a thin glaze of mucus that coats its mauve skin."
 											],
 											"type": "entries"
 										}
@@ -3780,14 +3785,14 @@
 										{
 											"name": "Telepathic Hub",
 											"entries": [
-												" The primary function of a mindwitness is to improve telepathic communication in a mind flayer colony. A creature in telepathic communication with a mindwitness can converse telepathically through it to as many as seven other creatures the mindwitness can see, allowing the rapid spread of commands and other information."
+												"The primary function of a mindwitness is to improve telepathic communication in a mind flayer colony. A creature in telepathic communication with a mindwitness can converse telepathically through it to as many as seven other creatures the mindwitness can see, allowing the rapid spread of commands and other information."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Solitary Seekers",
 											"entries": [
-												" If separated from its illithid masters, a mindwitness seeks out other telepathic creatures to tell it what to do. Mindwitnesses have been known to ally with flumphs and telepathic planar beings such as demons, shifting their worldview and changing their alignment to match that of their new masters."
+												"If separated from its illithid masters, a mindwitness seeks out other telepathic creatures to tell it what to do. Mindwitnesses have been known to ally with flumphs and telepathic planar beings such as demons, shifting their worldview and changing their alignment to match that of their new masters."
 											],
 											"type": "entries"
 										}
@@ -3825,7 +3830,7 @@
 										{
 											"name": "Spawned by a God",
 											"entries": [
-												" Long ago, a deity of greed and strife perished in the battles among the immortals. Its body drifted through the Astral Plane, eventually becoming a petrified husk. This corpse floated up against a pearlescent remnant of celestial matter imbued with life and life-giving magic. The collision shattered both objects and released a storm of chaotic energy. Countless islands of mixed matter spun away into the silvery void. Within some of them, a vein of pearl-like material held a bit of the deity's rejuvenated supernatural vitality, which spontaneously created a habitable environment. On those same islands, bits of the god's petrified flesh came back to life, in the form of tentacled monstrosities brimming with malice and greed. Ever since that time, each morkoth has had an extraplanar island to call home.",
+												"Long ago, a deity of greed and strife perished in the battles among the immortals. Its body drifted through the Astral Plane, eventually becoming a petrified husk. This corpse floated up against a pearlescent remnant of celestial matter imbued with life and life-giving magic. The collision shattered both objects and released a storm of chaotic energy. Countless islands of mixed matter spun away into the silvery void. Within some of them, a vein of pearl-like material held a bit of the deity's rejuvenated supernatural vitality, which spontaneously created a habitable environment. On those same islands, bits of the god's petrified flesh came back to life, in the form of tentacled monstrosities brimming with malice and greed. Ever since that time, each morkoth has had an extraplanar island to call home.",
 												"The pearly matter inside an island enables it to glide on planar currents, maintains the island's environment, and keeps the place safe from harmful external effects. A morkoth's island might be found anywhere from the bottom of the ocean to the void of the Astral Plane. One could float in the skies of Avernus in the Nine Hells without being destroyed and without causing harm to its residents. Whatever is on or within a certain distance of a morkoth's isle travels with it in its journey through the planes. Thus, people from lost civilizations and creatures or objects from bygone ages might be found within a morkoth's dominion.",
 												"Some islands travel a specific route, arriving at the same destinations regularly over a cycle of years. Others are tied to a particular place or group of locales, and still others move erratically through the cosmos. Rarely, a morkoth learns to control its island's movement, so the island goes wherever its master wishes.",
 												"A morkoth spends its time watching over its collection and plotting to acquire more possessions. The monster hoards vast stores of treasure and knowledge. Its island holds numerous captives, which it considers part of its collection. Some inhabitants, such as descendants of original prisoners, might view the morkoth as a ruler or a god. A morkoth's storehouse of wealth and lore attracts would-be plunderers, of course, as well as those seeking something specific the morkoth has or knows. The creature shows no mercy to those that try to steal from it, but it can be bargained with by a visitor that offers the morkoth something it desires.",
@@ -3839,14 +3844,14 @@
 										{
 											"name": "No Rhyme or Reason",
 											"entries": [
-												" A morkoth's island has the qualities of a dreamscape in which nature and predictability take a back seat to strangeness and chaos. Upon it is a jumble of objects and a mixture of creatures, some of which date from forgotten times. An island might have natural-looking illumination, but most are shrouded in twilight, and on any of them, mists and shadows can appear without notice. The environment is warm and wet, a subtropical or tropical climate that keeps the morkoth and its \"guests\" comfortable."
+												"A morkoth's island has the qualities of a dreamscape in which nature and predictability take a back seat to strangeness and chaos. Upon it is a jumble of objects and a mixture of creatures, some of which date from forgotten times. An island might have natural-looking illumination, but most are shrouded in twilight, and on any of them, mists and shadows can appear without notice. The environment is warm and wet, a subtropical or tropical climate that keeps the morkoth and its \"guests\" comfortable."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Primeval Hoarders",
 											"entries": [
-												" Morkoths are driven by greed and selfishness, mixed with a yearning for conflict. They desire anything they don't possess, have no scruples about taking what they crave, and endeavor to keep everything they collect."
+												"Morkoths are driven by greed and selfishness, mixed with a yearning for conflict. They desire anything they don't possess, have no scruples about taking what they crave, and endeavor to keep everything they collect."
 											],
 											"type": "entries"
 										}
@@ -3893,7 +3898,7 @@
 										{
 											"name": "Starved and Insane",
 											"entries": [
-												" A mouth of Grolantor is so disgraced that it ceases to be an individual and becomes an object. Paradoxically, that object is revered as a holy embodiment of Grolantor's eternal, aching hunger. Unlike a typical thick, sluggish, half-asleep hill giant, a mouth of Grolantor is thin as a whippet, alert like a bird, and constantly twitching around the edges. A mouth of Grolantor is kept perpetually imprisoned or shackled; if it breaks free, it's sure to kill a few hill giants before it's brought down or it sprints away on a killing spree. The only time a mouth of Grolantor is set loose is during a war, a raid against an enemy settlement, or in a last-ditch defense of the tribe's home. When the mouth of Grolantor has slaughtered and eaten its fill of the tribe's enemies, it passes out amid the gory remains of its victims, making it easy to recapture."
+												"A mouth of Grolantor is so disgraced that it ceases to be an individual and becomes an object. Paradoxically, that object is revered as a holy embodiment of Grolantor's eternal, aching hunger. Unlike a typical thick, sluggish, half-asleep hill giant, a mouth of Grolantor is thin as a whippet, alert like a bird, and constantly twitching around the edges. A mouth of Grolantor is kept perpetually imprisoned or shackled; if it breaks free, it's sure to kill a few hill giants before it's brought down or it sprints away on a killing spree. The only time a mouth of Grolantor is set loose is during a war, a raid against an enemy settlement, or in a last-ditch defense of the tribe's home. When the mouth of Grolantor has slaughtered and eaten its fill of the tribe's enemies, it passes out amid the gory remains of its victims, making it easy to recapture."
 											],
 											"type": "entries"
 										}
@@ -3953,7 +3958,7 @@
 										{
 											"name": "Alien Tyrants",
 											"entries": [
-												" Neogi usually dwell in far-flung locations on the Material Plane, as well as in the Feywild, the Shadowfell, and the Astral and Ethereal Planes. They invaded the world long ago from a remote location on the Material Plane, abandoning their home to conquer and devour creatures in other realms. To meet their need to navigate great distances, the neogi first dominated and assimilated the umber hulks of another lost world. Then, with these slaves providing the physical labor, the neogi designed and built sleek vessels, some capable of traversing the planes, to carry them to their new frontiers. Some neogi groups still create and use such vehicles, which have a distinct spidery aspect.",
+												"Neogi usually dwell in far-flung locations on the Material Plane, as well as in the Feywild, the Shadowfell, and the Astral and Ethereal Planes. They invaded the world long ago from a remote location on the Material Plane, abandoning their home to conquer and devour creatures in other realms. To meet their need to navigate great distances, the neogi first dominated and assimilated the umber hulks of another lost world. Then, with these slaves providing the physical labor, the neogi designed and built sleek vessels, some capable of traversing the planes, to carry them to their new frontiers. Some neogi groups still create and use such vehicles, which have a distinct spidery aspect.",
 												"Some neogi use magic-the result of a pact between the neogi and aberrant entities they met during their journey from their home world. These entities look like stars and embody the essence of evil. They are known by such names as Acamar, Caiphon, Gibbeth, and Hadar.",
 												"Nothing about the neogi is more unfathomable than their mentality. Because they have the power to control minds, neogi consider doing so to be entirely appropriate. Their society makes no distinction between individuals, aside from the ability that a given creature has to control others, and they don't comprehend the emotional aspects of existence that humans and similar beings experience. To a neogi, hatred is as foreign a sensation as love, and showing loyalty in the absence of authority is foolishness.",
 												"Neogi mark themselves and their slaves through the use of dyes, transformational magic, and tattoos intended to signify rank, achievements, and ownership. By these signs, each neogi can identify its betters-and it must defer to those of higher station or risk harsh punishment.",
@@ -3966,14 +3971,14 @@
 										{
 											"name": "Cycle of Death and Life",
 											"entries": [
-												" A neogi lives about as long as a human, and like a human it faces physical and mental infirmity as it ages. When an individual is rendered weak by advanced age, the other neogi in the group overpower it and inject it with a special poison. The toxin transforms the old neogi into a bloated, helpless mass of flesh called a great old master. Young neogi lay their eggs atop it, and when the hatchlings emerge, they devour the great old master and one another, until only a few of the strongest newborns are left."
+												"A neogi lives about as long as a human, and like a human it faces physical and mental infirmity as it ages. When an individual is rendered weak by advanced age, the other neogi in the group overpower it and inject it with a special poison. The toxin transforms the old neogi into a bloated, helpless mass of flesh called a great old master. Young neogi lay their eggs atop it, and when the hatchlings emerge, they devour the great old master and one another, until only a few of the strongest newborns are left."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Hierarchy of Ownership",
 											"entries": [
-												" Surviving neogi hatchlings begin their lives under the control of adult neogi. They must learn about their society and earn a place in it, and each one starts its training by gaining mastery over a young umber hulk."
+												"Surviving neogi hatchlings begin their lives under the control of adult neogi. They must learn about their society and earn a place in it, and each one starts its training by gaining mastery over a young umber hulk."
 											],
 											"type": "entries"
 										}
@@ -4011,7 +4016,7 @@
 										{
 											"name": "Alien Tyrants",
 											"entries": [
-												" Neogi usually dwell in far-flung locations on the Material Plane, as well as in the Feywild, the Shadowfell, and the Astral and Ethereal Planes. They invaded the world long ago from a remote location on the Material Plane, abandoning their home to conquer and devour creatures in other realms. To meet their need to navigate great distances, the neogi first dominated and assimilated the umber hulks of another lost world. Then, with these slaves providing the physical labor, the neogi designed and built sleek vessels, some capable of traversing the planes, to carry them to their new frontiers. Some neogi groups still create and use such vehicles, which have a distinct spidery aspect.",
+												"Neogi usually dwell in far-flung locations on the Material Plane, as well as in the Feywild, the Shadowfell, and the Astral and Ethereal Planes. They invaded the world long ago from a remote location on the Material Plane, abandoning their home to conquer and devour creatures in other realms. To meet their need to navigate great distances, the neogi first dominated and assimilated the umber hulks of another lost world. Then, with these slaves providing the physical labor, the neogi designed and built sleek vessels, some capable of traversing the planes, to carry them to their new frontiers. Some neogi groups still create and use such vehicles, which have a distinct spidery aspect.",
 												"Some neogi use magic-the result of a pact between the neogi and aberrant entities they met during their journey from their home world. These entities look like stars and embody the essence of evil. They are known by such names as Acamar, Caiphon, Gibbeth, and Hadar.",
 												"Nothing about the neogi is more unfathomable than their mentality. Because they have the power to control minds, neogi consider doing so to be entirely appropriate. Their society makes no distinction between individuals, aside from the ability that a given creature has to control others, and they don't comprehend the emotional aspects of existence that humans and similar beings experience. To a neogi, hatred is as foreign a sensation as love, and showing loyalty in the absence of authority is foolishness.",
 												"Neogi mark themselves and their slaves through the use of dyes, transformational magic, and tattoos intended to signify rank, achievements, and ownership. By these signs, each neogi can identify its betters-and it must defer to those of higher station or risk harsh punishment.",
@@ -4024,14 +4029,14 @@
 										{
 											"name": "Cycle of Death and Life",
 											"entries": [
-												" A neogi lives about as long as a human, and like a human it faces physical and mental infirmity as it ages. When an individual is rendered weak by advanced age, the other neogi in the group overpower it and inject it with a special poison. The toxin transforms the old neogi into a bloated, helpless mass of flesh called a great old master. Young neogi lay their eggs atop it, and when the hatchlings emerge, they devour the great old master and one another, until only a few of the strongest newborns are left."
+												"A neogi lives about as long as a human, and like a human it faces physical and mental infirmity as it ages. When an individual is rendered weak by advanced age, the other neogi in the group overpower it and inject it with a special poison. The toxin transforms the old neogi into a bloated, helpless mass of flesh called a great old master. Young neogi lay their eggs atop it, and when the hatchlings emerge, they devour the great old master and one another, until only a few of the strongest newborns are left."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Hierarchy of Ownership",
 											"entries": [
-												" Surviving neogi hatchlings begin their lives under the control of adult neogi. They must learn about their society and earn a place in it, and each one starts its training by gaining mastery over a young umber hulk."
+												"Surviving neogi hatchlings begin their lives under the control of adult neogi. They must learn about their society and earn a place in it, and each one starts its training by gaining mastery over a young umber hulk."
 											],
 											"type": "entries"
 										}
@@ -4069,7 +4074,7 @@
 										{
 											"name": "Alien Tyrants",
 											"entries": [
-												" Neogi usually dwell in far-flung locations on the Material Plane, as well as in the Feywild, the Shadowfell, and the Astral and Ethereal Planes. They invaded the world long ago from a remote location on the Material Plane, abandoning their home to conquer and devour creatures in other realms. To meet their need to navigate great distances, the neogi first dominated and assimilated the umber hulks of another lost world. Then, with these slaves providing the physical labor, the neogi designed and built sleek vessels, some capable of traversing the planes, to carry them to their new frontiers. Some neogi groups still create and use such vehicles, which have a distinct spidery aspect.",
+												"Neogi usually dwell in far-flung locations on the Material Plane, as well as in the Feywild, the Shadowfell, and the Astral and Ethereal Planes. They invaded the world long ago from a remote location on the Material Plane, abandoning their home to conquer and devour creatures in other realms. To meet their need to navigate great distances, the neogi first dominated and assimilated the umber hulks of another lost world. Then, with these slaves providing the physical labor, the neogi designed and built sleek vessels, some capable of traversing the planes, to carry them to their new frontiers. Some neogi groups still create and use such vehicles, which have a distinct spidery aspect.",
 												"Some neogi use magic-the result of a pact between the neogi and aberrant entities they met during their journey from their home world. These entities look like stars and embody the essence of evil. They are known by such names as Acamar, Caiphon, Gibbeth, and Hadar.",
 												"Nothing about the neogi is more unfathomable than their mentality. Because they have the power to control minds, neogi consider doing so to be entirely appropriate. Their society makes no distinction between individuals, aside from the ability that a given creature has to control others, and they don't comprehend the emotional aspects of existence that humans and similar beings experience. To a neogi, hatred is as foreign a sensation as love, and showing loyalty in the absence of authority is foolishness.",
 												"Neogi mark themselves and their slaves through the use of dyes, transformational magic, and tattoos intended to signify rank, achievements, and ownership. By these signs, each neogi can identify its betters-and it must defer to those of higher station or risk harsh punishment.",
@@ -4082,14 +4087,14 @@
 										{
 											"name": "Cycle of Death and Life",
 											"entries": [
-												" A neogi lives about as long as a human, and like a human it faces physical and mental infirmity as it ages. When an individual is rendered weak by advanced age, the other neogi in the group overpower it and inject it with a special poison. The toxin transforms the old neogi into a bloated, helpless mass of flesh called a great old master. Young neogi lay their eggs atop it, and when the hatchlings emerge, they devour the great old master and one another, until only a few of the strongest newborns are left."
+												"A neogi lives about as long as a human, and like a human it faces physical and mental infirmity as it ages. When an individual is rendered weak by advanced age, the other neogi in the group overpower it and inject it with a special poison. The toxin transforms the old neogi into a bloated, helpless mass of flesh called a great old master. Young neogi lay their eggs atop it, and when the hatchlings emerge, they devour the great old master and one another, until only a few of the strongest newborns are left."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Hierarchy of Ownership",
 											"entries": [
-												" Surviving neogi hatchlings begin their lives under the control of adult neogi. They must learn about their society and earn a place in it, and each one starts its training by gaining mastery over a young umber hulk."
+												"Surviving neogi hatchlings begin their lives under the control of adult neogi. They must learn about their society and earn a place in it, and each one starts its training by gaining mastery over a young umber hulk."
 											],
 											"type": "entries"
 										}
@@ -4127,14 +4132,14 @@
 										{
 											"name": "Abhorrent to Illithids",
 											"entries": [
-												" Among the strongest taboos in illithid society is the idea of allowing a mature tadpole to survive without implanting it into a donor brain. Under normal circumstances, any tadpole that grows larger than a few inches in length is killed by the elder brain to be food for it or for less mature tadpoles. Any tadpole that survives beyond that state is perceived as a threat to the colony, and the mind flayers organize hunting parties to exterminate the abomination. Lacking enough intelligence to be detected by an elder brain's power to sense thoughts, neothelids warrant such precautions."
+												"Among the strongest taboos in illithid society is the idea of allowing a mature tadpole to survive without implanting it into a donor brain. Under normal circumstances, any tadpole that grows larger than a few inches in length is killed by the elder brain to be food for it or for less mature tadpoles. Any tadpole that survives beyond that state is perceived as a threat to the colony, and the mind flayers organize hunting parties to exterminate the abomination. Lacking enough intelligence to be detected by an elder brain's power to sense thoughts, neothelids warrant such precautions."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Savage Behemoth",
 											"entries": [
-												" As a feral thing, a neothelid knows nothing beyond the predatory existence it has lived so far and struggles to comprehend its new psionic abilities. Neothelids prowl subterranean passages in search of more brains to sate their constant hunger, growing ever more vicious. These creatures can spray tissue-dissolving enzymes from their tentacle ducts, reducing victims to a puddle of slime and leaving only the pulsing brain unharmed. They have no knowledge of their link to illithids, so they're just as likely to prey on mind flayers as on anything else."
+												"As a feral thing, a neothelid knows nothing beyond the predatory existence it has lived so far and struggles to comprehend its new psionic abilities. Neothelids prowl subterranean passages in search of more brains to sate their constant hunger, growing ever more vicious. These creatures can spray tissue-dissolving enzymes from their tentacle ducts, reducing victims to a puddle of slime and leaving only the pulsing brain unharmed. They have no knowledge of their link to illithids, so they're just as likely to prey on mind flayers as on anything else."
 											],
 											"type": "entries"
 										}
@@ -4172,14 +4177,14 @@
 										{
 											"name": "Goblins' Revenge",
 											"entries": [
-												" When goblinoids form a host, there is a chance that a goblin will become possessed by a nilbog, particularly if the goblin has been mistreated by its betters. This possession turns the goblin into a wisecracking, impish creature fearless of reprisal. It gives the goblin strange powers that drive others to do the opposite of what they desire. Attacking a goblin possessed by a nilbog is foolhardy, and killing the creature just prompts the spirit to possess another goblin. The only way to keep a nilbog from wreaking havoc is to treat it well and give it respect and praise."
+												"When goblinoids form a host, there is a chance that a goblin will become possessed by a nilbog, particularly if the goblin has been mistreated by its betters. This possession turns the goblin into a wisecracking, impish creature fearless of reprisal. It gives the goblin strange powers that drive others to do the opposite of what they desire. Attacking a goblin possessed by a nilbog is foolhardy, and killing the creature just prompts the spirit to possess another goblin. The only way to keep a nilbog from wreaking havoc is to treat it well and give it respect and praise."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "No Joking Matter",
 											"entries": [
-												" The possible presence of a nilbog in a host has given rise to a practice among goblinoids that each host include at least one goblin jester. This jester is allowed to go anywhere and do whatever it pleases. The position of jester is a much sought-after one among the goblins, because even if the jester is obviously not a nilbog, hobgoblins and bugbears indulge its manic behavior."
+												"The possible presence of a nilbog in a host has given rise to a practice among goblinoids that each host include at least one goblin jester. This jester is allowed to go anywhere and do whatever it pleases. The position of jester is a much sought-after one among the goblins, because even if the jester is obviously not a nilbog, hobgoblins and bugbears indulge its manic behavior."
 											],
 											"type": "entries"
 										}
@@ -4459,7 +4464,7 @@
 										{
 											"name": "Live Fast, Die Young",
 											"entries": [
-												" Quicklings owe their existence-and their plight-to the Queen of Air and Darkness, the dread ruler of the Gloaming Court. Once a race of lazy and egotistical fey, the creatures that would become the quicklings were late in answering the queen's summons one time too many. To hasten their pace and teach them to mind her will, the queen shrank their stature and sped up their internal clocks. The queen's curse gave quicklings their amazing speed but also accelerated their passage through life-no quickling lives longer than fifteen years.",
+												"Quicklings owe their existence-and their plight-to the Queen of Air and Darkness, the dread ruler of the Gloaming Court. Once a race of lazy and egotistical fey, the creatures that would become the quicklings were late in answering the queen's summons one time too many. To hasten their pace and teach them to mind her will, the queen shrank their stature and sped up their internal clocks. The queen's curse gave quicklings their amazing speed but also accelerated their passage through life-no quickling lives longer than fifteen years.",
 												"To other creatures, a quickling seems blindingly fast, vanishing into an indistinct blur as it moves. Its cruel laughter is a burst of rapid staccato sounds, its speech a shrill squeal. Only when a quickling deliberately slows down, which it prefers not to do, can other beings properly see, hear, and comprehend it. Never truly at rest, a \"stationary\" quickling constantly paces and shifts in place, as though it can't wait to be off again.",
 												"Tricks of that sort are hardly the limit of their artful malice, however. They don't commit outright murder, but quicklings can ruin lives in plenty of other ways: stealing an important letter, swiping coins collected for the poor, planting a stolen item in someone's bag. Quicklings enjoy causing suffering that transcends mere mis chief, especially when the blame for their actions falls on other creatures and creates discord."
 											],
@@ -4468,14 +4473,14 @@
 										{
 											"name": "Too Fast for Words",
 											"entries": [
-												" The mortal realm is a ponderous place to a quickling's eye: a hurricane creeps gradually across the sky, a torrent of rain drifts earthward like lazy snowflakes, lightning crawls in a meandering path from cloud to cloud. The slow and boring world seems to be populated by torpid creatures whose deep, mooing speech lacks meaning."
+												"The mortal realm is a ponderous place to a quickling's eye: a hurricane creeps gradually across the sky, a torrent of rain drifts earthward like lazy snowflakes, lightning crawls in a meandering path from cloud to cloud. The slow and boring world seems to be populated by torpid creatures whose deep, mooing speech lacks meaning."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Mischief, Not Murder",
 											"entries": [
-												" Quicklings have a capricious nature that goes well with their energy level: they think as fast as they run, and they are always up to something. A quickling spends most of its time perpetrating acts of mischief on slower creatures. One rarely passes up an opportunity to tie a person's bootlaces together, move the stool a creature is about to sit on, or unbuckle a saddle while no one's looking."
+												"Quicklings have a capricious nature that goes well with their energy level: they think as fast as they run, and they are always up to something. A quickling spends most of its time perpetrating acts of mischief on slower creatures. One rarely passes up an opportunity to tie a person's bootlaces together, move the stool a creature is about to sit on, or unbuckle a saddle while no one's looking."
 											],
 											"type": "entries"
 										}
@@ -4521,7 +4526,7 @@
 										{
 											"name": "Blood Lust Personified",
 											"entries": [
-												" In the Feywild, or where that plane touches the world at a fey crossing, if a sentient creature acts on an intense desire for bloodshed, one or more redcaps might appear where the blood of a slain person soaks the ground. At first, new red caps look like tiny bloodstained mushrooms just pushing their caps out of the soil. When moonlight shines on one of these caps, a creature that looks like a wizened and undersized gnome with a hunched back and a sinewy frame springs from the earth. The creature has a pointed leather cap, pants of similar material, heavy iron boots, and a heavy bladed weapon. From the moment it awakens, a redcap desires only murder and carnage, and it sets out to satisfy these cravings.",
+												"In the Feywild, or where that plane touches the world at a fey crossing, if a sentient creature acts on an intense desire for bloodshed, one or more redcaps might appear where the blood of a slain person soaks the ground. At first, new red caps look like tiny bloodstained mushrooms just pushing their caps out of the soil. When moonlight shines on one of these caps, a creature that looks like a wizened and undersized gnome with a hunched back and a sinewy frame springs from the earth. The creature has a pointed leather cap, pants of similar material, heavy iron boots, and a heavy bladed weapon. From the moment it awakens, a redcap desires only murder and carnage, and it sets out to satisfy these cravings.",
 												"Redcaps lack subtlety. They live for direct confrontation and the mayhem of mortal combat. Even if a redcap wanted to be stealthy, its iron boots force it to take ponderous, thunderous steps. When a redcap is near to potential prey, though, it can close the distance quickly and get in a vicious swing of its weapon before the target can react.",
 												"Also, some redcaps can sense the being whose murderous acts led to their birth. A redcap might use this innate connection to find its creator and make that creature its first victim. Others seek out their maker to enjoy proximity to a kindred spirit. An individual responsible for the creation of multiple redcaps at the same site could attract the entire group to serve as cohorts, emulating that creature's murderous handiwork.",
 												"In any case, if a redcap works with another being, the redcap demands to be paid in victims. A patron who tries to stifle a redcap's natural and necessary urge for blood risks becoming the redcap's next target.",
@@ -4533,14 +4538,14 @@
 										{
 											"name": "Steeped in Slaughter",
 											"entries": [
-												" To sustain its unnatural existence, a redcap has to soak its hat in the fresh blood of its victims. When a redcap is born, its hat is coated with wet blood, and it knows that if the blood isn't replenished at least once every three days, the redcap vanishes as if it had never been. A redcap's desire to slay is rooted in its will to survive."
+												"To sustain its unnatural existence, a redcap has to soak its hat in the fresh blood of its victims. When a redcap is born, its hat is coated with wet blood, and it knows that if the blood isn't replenished at least once every three days, the redcap vanishes as if it had never been. A redcap's desire to slay is rooted in its will to survive."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Bloodthirsty Mercenaries",
 											"entries": [
-												" Redcaps don't usually operate in groups, but in some circumstances they might be fond in the employ of hags and dark mages that know methods to call redcaps out of the Feywild and put them to work as grisly servants."
+												"Redcaps don't usually operate in groups, but in some circumstances they might be fond in the employ of hags and dark mages that know methods to call redcaps out of the Feywild and put them to work as grisly servants."
 											],
 											"type": "entries"
 										}
@@ -4645,14 +4650,14 @@
 										{
 											"name": "Deep Thralls",
 											"entries": [
-												" Krakens, morkoths, sea hags, marids, storm giants, dragon turtles-all of these sea creatures and more can mark mortals as their own and claim them as minions. Such people might become beholden to their master through a bleak bargain, or they might find themselves cursed by such creatures. Once warped into a fishlike form, the person can't leave the sea for long without courting death."
+												"Krakens, morkoths, sea hags, marids, storm giants, dragon turtles-all of these sea creatures and more can mark mortals as their own and claim them as minions. Such people might become beholden to their master through a bleak bargain, or they might find themselves cursed by such creatures. Once warped into a fishlike form, the person can't leave the sea for long without courting death."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Anatomical Diversity",
 											"entries": [
-												" Sea spawn come in a wide variety of forms. An individual might have a tentacle for an arm, the jaws of a shark, a sea urchin's spines, a whale's fin, octopus eyes, seaweed hair, or any combination of such qualities. Some sea spawn have piscine body parts that provide them with special abilities beyond those of an ordinary humanoid."
+												"Sea spawn come in a wide variety of forms. An individual might have a tentacle for an arm, the jaws of a shark, a sea urchin's spines, a whale's fin, octopus eyes, seaweed hair, or any combination of such qualities. Some sea spawn have piscine body parts that provide them with special abilities beyond those of an ordinary humanoid."
 											],
 											"type": "entries"
 										}
@@ -4698,7 +4703,7 @@
 										{
 											"name": "Ravenous Lurkers",
 											"entries": [
-												" Shadow mastiffs hunt in packs on the Shadowfell, so when one of them enters a rift between the planes, several more are sure to follow. Each pack is led by an alpha (male or female) that is the smartest and toughest one of the group. The alpha must remain sharp to keep the rest of the pack in line, lest it be killed and replaced.",
+												"Shadow mastiffs hunt in packs on the Shadowfell, so when one of them enters a rift between the planes, several more are sure to follow. Each pack is led by an alpha (male or female) that is the smartest and toughest one of the group. The alpha must remain sharp to keep the rest of the pack in line, lest it be killed and replaced.",
 												"When a shadow mastiff pack is hungry and senses prey nearby, the alpha lets loose a howl that strikes fear into the hearts of nearby beasts and humanoids. Its howl is also a signal to the rest of the pack to move in for the kill. Gloom provides a shadow mastiff with supernatural protection, granting it resistance to nonmagical weapons while in dim light or darkness. Shadow mastiffs can tolerate bright light, but they shun sunlight."
 											],
 											"type": "entries"
@@ -4706,14 +4711,14 @@
 										{
 											"name": "Summoned for Service",
 											"entries": [
-												" Some faiths devoted to deities of gloom and night, such as Shar in the Forgotten Realms, perform unholy rites to summon shadow mastiffs from the Shadowfell and then put them to work as temple sentinels, bodyguards, and punishers of nonbelievers, heretics, and apostates. The method for bringing shadow mastiffs into the world is also known by other strong-willed and evil-minded individuals, who find use for the hounds as guards in their strongholds."
+												"Some faiths devoted to deities of gloom and night, such as Shar in the Forgotten Realms, perform unholy rites to summon shadow mastiffs from the Shadowfell and then put them to work as temple sentinels, bodyguards, and punishers of nonbelievers, heretics, and apostates. The method for bringing shadow mastiffs into the world is also known by other strong-willed and evil-minded individuals, who find use for the hounds as guards in their strongholds."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Ethereal Sight",
 											"entries": [
-												" In addition to its other capabilities, a shadow mastiff can see creatures and objects on the Ethereal Plane. This extraplanar perception makes a mastiff an especially skilled guardian, especially in situations when magical or spiritual incursion is likely."
+												"In addition to its other capabilities, a shadow mastiff can see creatures and objects on the Ethereal Plane. This extraplanar perception makes a mastiff an especially skilled guardian, especially in situations when magical or spiritual incursion is likely."
 											],
 											"type": "entries"
 										}
@@ -4790,21 +4795,21 @@
 										{
 											"name": "Vengeance at Any Cost",
 											"entries": [
-												" The ritual for creating a slithering tracker is known to hags, liches, and priests who worship gods of vengeance. It can only be performed on a willing creature that hungers for revenge. The ritual sucks all the moisture from the person's body, killing it. Yet the mind lives on in the puddle of liquid that issues forth from the remains, and so too does the subject's insatiable need for retribution."
+												"The ritual for creating a slithering tracker is known to hags, liches, and priests who worship gods of vengeance. It can only be performed on a willing creature that hungers for revenge. The ritual sucks all the moisture from the person's body, killing it. Yet the mind lives on in the puddle of liquid that issues forth from the remains, and so too does the subject's insatiable need for retribution."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Stealthy Assassins",
 											"entries": [
-												" A slithering tracker tastes the ground it courses over, seeking any trace of its prey. To kill, a slithering tracker rises up and enshrouds a creature, attempting to drown the prey while also draining it of blood. A slithering tracker that has killed in this fashion becomes much easier to locate for a time, since its liquid form becomes tinged with blood and its body leaves a visible trail of the stuff behind it."
+												"A slithering tracker tastes the ground it courses over, seeking any trace of its prey. To kill, a slithering tracker rises up and enshrouds a creature, attempting to drown the prey while also draining it of blood. A slithering tracker that has killed in this fashion becomes much easier to locate for a time, since its liquid form becomes tinged with blood and its body leaves a visible trail of the stuff behind it."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Descent into Madness",
 											"entries": [
-												" Achieving revenge against its target doesn't end a slithering tracker's existence, nor its hunger for blood. Some slithering trackers remain aware of their purpose and extend their quest for vengeance to others, such as anyone who supported or befriended the original target. Most of the time, though, a tracker's mind can't cope with being trapped in liquid form, unable to communicate, and driven by the desire for blood: after a tracker fulfills its duty, insanity takes over the creature, and it attacks indiscriminately until it is destroyed."
+												"Achieving revenge against its target doesn't end a slithering tracker's existence, nor its hunger for blood. Some slithering trackers remain aware of their purpose and extend their quest for vengeance to others, such as anyone who supported or befriended the original target. Most of the time, though, a tracker's mind can't cope with being trapped in liquid form, unable to communicate, and driven by the desire for blood: after a tracker fulfills its duty, insanity takes over the creature, and it attacks indiscriminately until it is destroyed."
 											],
 											"type": "entries"
 										}
@@ -4842,21 +4847,21 @@
 										{
 											"name": "Plague of Worms",
 											"entries": [
-												" From a distance or in poor light, a spawn of Kyuss looks like an ordinary zombie. As it comes into clearer view, one can see scores of little green worms crawling in and out of it. These worms jump onto nearby humanoids and burrow into their flesh. A worm that penetrates a humanoid body makes its way to the creature's brain. Once inside the brain, the worm kills its host and animates the corpse, transforming it into a spawn of Kyuss that breeds more worms. The dead humanoid's soul remains trapped inside the corpse, preventing the individual from being raised or resurrected until the undead body is destroyed. The horror of being a soul imprisoned in an undead body drives a spawn of Kyuss insane."
+												"From a distance or in poor light, a spawn of Kyuss looks like an ordinary zombie. As it comes into clearer view, one can see scores of little green worms crawling in and out of it. These worms jump onto nearby humanoids and burrow into their flesh. A worm that penetrates a humanoid body makes its way to the creature's brain. Once inside the brain, the worm kills its host and animates the corpse, transforming it into a spawn of Kyuss that breeds more worms. The dead humanoid's soul remains trapped inside the corpse, preventing the individual from being raised or resurrected until the undead body is destroyed. The horror of being a soul imprisoned in an undead body drives a spawn of Kyuss insane."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Corruption Without End",
 											"entries": [
-												" Spawn of Kyuss are expressions of Orcus's intent to replace all life with undeath. Left to its own devices, a solitary spawn of Kyuss travels aimlessly. If it stumbles across a living creature, the spawn attacks with the sole intent of creating more spawn. Whether they are dispersed or clustered, spawn reproduce exponentially if nothing stops them."
+												"Spawn of Kyuss are expressions of Orcus's intent to replace all life with undeath. Left to its own devices, a solitary spawn of Kyuss travels aimlessly. If it stumbles across a living creature, the spawn attacks with the sole intent of creating more spawn. Whether they are dispersed or clustered, spawn reproduce exponentially if nothing stops them."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Undead Nature",
 											"entries": [
-												" Spawn of Kyuss require no air, food, drink, or sleep."
+												"Spawn of Kyuss require no air, food, drink, or sleep."
 											],
 											"type": "entries"
 										}
@@ -4947,7 +4952,7 @@
 										{
 											"name": "Dream Dwellers",
 											"entries": [
-												" Stone giants sometimes go on dream quests in the surface world, seeking inspiration for their art, to break a decades-long ennui, or out of simple curiosity. Some who go on these quests let themselves become lost in the dream. Other stone giants are banished to the surface as punishment. Regardless of the reason, if they don't take shelter under stone, such individuals can become dreamwalkers.",
+												"Stone giants sometimes go on dream quests in the surface world, seeking inspiration for their art, to break a decades-long ennui, or out of simple curiosity. Some who go on these quests let themselves become lost in the dream. Other stone giants are banished to the surface as punishment. Regardless of the reason, if they don't take shelter under stone, such individuals can become dreamwalkers.",
 												"Dreamwalkers occupy an odd place of respect outside of stone giant ordning. They are considered outcasts, but their familiarity with the surface world makes them valuable guides, and their insights can help other stone giants grasp the dangers of living in a dream."
 											],
 											"type": "entries"
@@ -4955,7 +4960,7 @@
 										{
 											"name": "Mad Wanderers",
 											"entries": [
-												" Dreamwalkers are driven mad by isolation, shame, and their unendingly alien surroundings, and this madness leeches out into the world around them, affecting other creatures that get too close. Believing that they're living in a dream and that their actions have no real consequences, dreamwalkers act as they please, becoming forces of chaos. As they travel the world, they collect objects and creatures that seem especially significant in their mad minds. Over time, the collected things accrete to their bodies, becoming encased in stone."
+												"Dreamwalkers are driven mad by isolation, shame, and their unendingly alien surroundings, and this madness leeches out into the world around them, affecting other creatures that get too close. Believing that they're living in a dream and that their actions have no real consequences, dreamwalkers act as they please, becoming forces of chaos. As they travel the world, they collect objects and creatures that seem especially significant in their mad minds. Over time, the collected things accrete to their bodies, becoming encased in stone."
 											],
 											"type": "entries"
 										}
@@ -4993,14 +4998,14 @@
 										{
 											"name": "Elemental Weapons",
 											"entries": [
-												" A storm giant quintessent sheds its armor and weapons, but gains the power to form makeshift weapons out of thin air. When the giant has no further use of them, or when the giant dies, its elemental weapons disappear."
+												"A storm giant quintessent sheds its armor and weapons, but gains the power to form makeshift weapons out of thin air. When the giant has no further use of them, or when the giant dies, its elemental weapons disappear."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Forsaken Form",
 											"entries": [
-												" A storm giant quintessent can revert to its true giant form on a whim. The change is temporary but can be maintained long enough for the giant to communicate with a mortal, carry out a short task, or defend its home against aggressors."
+												"A storm giant quintessent can revert to its true giant form on a whim. The change is temporary but can be maintained long enough for the giant to communicate with a mortal, carry out a short task, or defend its home against aggressors."
 											],
 											"type": "entries"
 										}
@@ -5150,7 +5155,7 @@
 										{
 											"name": "Primitive Plants",
 											"entries": [
-												" Vegepygmies, also called mold folk or moldies, inhabit dark areas that are warm and wet, so they are most commonly found underground or in dense forests where little sunlight penetrates. A vegepygmy instinctively feels kinship with other plant and fungus creatures, and thus vegepygmy tribes coexist well with creatures such as myconids, shriekers, and violet fungi.",
+												"Vegepygmies, also called mold folk or moldies, inhabit dark areas that are warm and wet, so they are most commonly found underground or in dense forests where little sunlight penetrates. A vegepygmy instinctively feels kinship with other plant and fungus creatures, and thus vegepygmy tribes coexist well with creatures such as myconids, shriekers, and violet fungi.",
 												"Although they prefer to eat fresh meat, bone, and blood, vegepygmies can absorb nutrients from soil and many sorts of organic matter, meaning that they rarely go hungry. A vegepygmy can hiss and make other noises by forcing air through its mouth, but it can't speak in a conventional sense. Among themselves, vegepygmies communicate by hissing, gestures, and rhythmic tapping on the body. Vegepygmies build and craft little; any gear they have is acquired from other creatures or built by copying simple construction they have witnessed.",
 												"As a vegepygmy ages, it grows tougher and develops spore clusters on its body. Spore-bearing vegepygmies are deferred to by other vegepygmies, so outsiders refer to such vegepygmies as chiefs. A chief can expel its spores in a burst, infecting nearby creatures. If a creature dies while infected, its corpse produces vegepygmies the same way russet mold does.",
 												"No one knows for sure where russet mold came from. One historical account tells of adventurers in a forbidding mountain range discovering russet mold and vegepygmies in a peculiar metal dungeon full of strange life. Another story says that explorers found russet mold in a crater left by a falling star, with vegepygmies infesting the dense jungle nearby."
@@ -5160,7 +5165,7 @@
 										{
 											"name": "Mold Begets Mold",
 											"entries": [
-												" Vegepygmies originate from the remains left behind when a humanoid or a giant is killed by russet mold. One or more vegepygmies emerge from the corpse a day later. If a beast such as a dog or a bear dies from russet mold, the result is a bestial moldie called a thorny result instead of a humanoid-shaped vegepygmy. Thornies are less intelligent than vegepygmies, but have greater size and ferocity, as well as a thorn-covered body."
+												"Vegepygmies originate from the remains left behind when a humanoid or a giant is killed by russet mold. One or more vegepygmies emerge from the corpse a day later. If a beast such as a dog or a bear dies from russet mold, the result is a bestial moldie called a thorny result instead of a humanoid-shaped vegepygmy. Thornies are less intelligent than vegepygmies, but have greater size and ferocity, as well as a thorn-covered body."
 											],
 											"type": "entries"
 										}
@@ -5207,35 +5212,35 @@
 										{
 											"name": "Desert Nomads",
 											"entries": [
-												" Tlincallis live austerely. They range across arid lands, hunting at dawn and dusk. In the hours between, they wait out the day's heat or the night's cold by burying themselves in loose sand or earth or, if the terrain proves too inflexible, lurking in ruins or shallow caves. A tribe of tlincallis stays in one place for only as long as the hunting is good in the immediate area, though they might visit the same way stations over and over during their wanderings. The tribe also settles down temporarily whenever it's time to lay eggs and hatch a new brood of young."
+												"Tlincallis live austerely. They range across arid lands, hunting at dawn and dusk. In the hours between, they wait out the day's heat or the night's cold by burying themselves in loose sand or earth or, if the terrain proves too inflexible, lurking in ruins or shallow caves. A tribe of tlincallis stays in one place for only as long as the hunting is good in the immediate area, though they might visit the same way stations over and over during their wanderings. The tribe also settles down temporarily whenever it's time to lay eggs and hatch a new brood of young."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Poisonous Eggs",
 											"entries": [
-												" Tlincallis deposit their eggs in warm places out of direct sunlight, often amid a stand of cacti near their present encampment. There the eggs lie protected by hard shells coated in paralytic poison similar to that produced by their stingers. A would-be predator that dares to break an egg is defenseless against the tlincallis that come to investigate."
+												"Tlincallis deposit their eggs in warm places out of direct sunlight, often amid a stand of cacti near their present encampment. There the eggs lie protected by hard shells coated in paralytic poison similar to that produced by their stingers. A would-be predator that dares to break an egg is defenseless against the tlincallis that come to investigate."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Horrid Kidnappers",
 											"entries": [
-												" Tlincallis eat what they kill, but they also take some of their prey alive when they have new mouths to feed. After using their stingers to paralyze victims and their spiked chains to bind them, tlincallis take these prisoners back to their encampment and tie them to cactus or rock formations. There, victims wait until the sun sets and the newly hatched young emerge from the lair to eat them alive."
+												"Tlincallis eat what they kill, but they also take some of their prey alive when they have new mouths to feed. After using their stingers to paralyze victims and their spiked chains to bind them, tlincallis take these prisoners back to their encampment and tie them to cactus or rock formations. There, victims wait until the sun sets and the newly hatched young emerge from the lair to eat them alive."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Prideful Hunters",
 											"entries": [
-												" Tlincallis see themselves as great hunters. If a tlincalli tribe encounters a more powerful hunter, such as a blue dragon, the tribe's leader must decide whether the group becomes obedient to the superior hunter, moves on, or fights to the death to defeat it."
+												"Tlincallis see themselves as great hunters. If a tlincalli tribe encounters a more powerful hunter, such as a blue dragon, the tribe's leader must decide whether the group becomes obedient to the superior hunter, moves on, or fights to the death to defeat it."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Makeshift Weapons and Objects",
 											"entries": [
-												" Tlincallis are uncivilized and don't build cities, make clothing, or mine metals. Instead, they scavenge what they need or want. They do, however, know how to melt down scavenged metal to forge crude weapons and tools."
+												"Tlincallis are uncivilized and don't build cities, make clothing, or mine metals. Instead, they scavenge what they need or want. They do, however, know how to melt down scavenged metal to forge crude weapons and tools."
 											],
 											"type": "entries"
 										}
@@ -5295,7 +5300,7 @@
 										{
 											"name": "Versatile Camouflage",
 											"entries": [
-												" A trapper can alter the color and texture of its outer side to match its surroundings. It can blend in with any surface made of stone, earth, or wood, masking its presence to any but the most rigorous scrutiny. It can't change its texture to that of a grassy or snow-covered surface, but it can change its color to match and then conceal itself under a thin layer of vegetation or actual snow.",
+												"A trapper can alter the color and texture of its outer side to match its surroundings. It can blend in with any surface made of stone, earth, or wood, masking its presence to any but the most rigorous scrutiny. It can't change its texture to that of a grassy or snow-covered surface, but it can change its color to match and then conceal itself under a thin layer of vegetation or actual snow.",
 												"Trappers know when prey draws near, so explore ruins and dungeons with equal wariness. For dumb beasts, they know very well what treasure is, what treasure chests are, and how these lure the likes of us.",
 												"-Volo"
 											],
@@ -5304,14 +5309,14 @@
 										{
 											"name": "Stationary Hunters",
 											"entries": [
-												" A trapper needs to eat about a halfling-sized meal once a week to remain sated. It is content to stay in one place, given a steady supply of food, and thus trappers are a threat along any well-traveled dungeon corridor and on routes through the wilderness that see a lot of traffic. When prey is scarce, a trapper enters a state of hibernation that can last for months, though it is still aware when prey comes near. A trapper on the verge of starvation might defy its instincts and begin creeping along, abandoning its old territory in search of better hunting."
+												"A trapper needs to eat about a halfling-sized meal once a week to remain sated. It is content to stay in one place, given a steady supply of food, and thus trappers are a threat along any well-traveled dungeon corridor and on routes through the wilderness that see a lot of traffic. When prey is scarce, a trapper enters a state of hibernation that can last for months, though it is still aware when prey comes near. A trapper on the verge of starvation might defy its instincts and begin creeping along, abandoning its old territory in search of better hunting."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Beware of Leftovers",
 											"entries": [
-												" When its prey is dead, a trapper dissolves and absorbs the fleshy parts, leaving a scattering of bones, metal, treasure, and other indigestible bits in the place where the creature had been. A trapper that lurks on the floor of its hunting grounds can cover these remains with own body, making them look like irregularities in the surface. The creature might also attach itself to a wall or a ceiling close to a recent kill, effectively using the remnants as bait: a creature that stops to investigate the bones for valuables stands a good chance of becoming the trapper's next meal."
+												"When its prey is dead, a trapper dissolves and absorbs the fleshy parts, leaving a scattering of bones, metal, treasure, and other indigestible bits in the place where the creature had been. A trapper that lurks on the floor of its hunting grounds can cover these remains with own body, making them look like irregularities in the surface. The creature might also attach itself to a wall or a ceiling close to a recent kill, effectively using the remnants as bait: a creature that stops to investigate the bones for valuables stands a good chance of becoming the trapper's next meal."
 											],
 											"type": "entries"
 										}
@@ -5349,21 +5354,21 @@
 										{
 											"name": "Master Minds",
 											"entries": [
-												" Illithids innately recognize that an ulitharid's survival is more important than their own. An elder brain's reaction to the rise of an ulitharid varies. In most colonies, the ulitharid becomes an elder brain's most favored servant, invested with power and authority. In others, the elder brain perceives an ulitharid as a potential rival for power, and it manipulates or quashes the ulitharid's ambitions accordingly."
+												"Illithids innately recognize that an ulitharid's survival is more important than their own. An elder brain's reaction to the rise of an ulitharid varies. In most colonies, the ulitharid becomes an elder brain's most favored servant, invested with power and authority. In others, the elder brain perceives an ulitharid as a potential rival for power, and it manipulates or quashes the ulitharid's ambitions accordingly."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Birth of a Colony",
 											"entries": [
-												" When an ulitharid finds sharing leadership with an elder brain to be insufferable, it breaks off from the colony, taking a group of mind flayers with it, and moves to another location to form a new colony. After the death of the ulitharid's body, mind flayers take its brain and place it in a brine pool, where it grows into an elder brain over a few days. This process doesn't work on the brain of an ulitharid that dies a natural death, as a brain that succumbs to old age is too decrepit to be used in the creation of an elder brain."
+												"When an ulitharid finds sharing leadership with an elder brain to be insufferable, it breaks off from the colony, taking a group of mind flayers with it, and moves to another location to form a new colony. After the death of the ulitharid's body, mind flayers take its brain and place it in a brine pool, where it grows into an elder brain over a few days. This process doesn't work on the brain of an ulitharid that dies a natural death, as a brain that succumbs to old age is too decrepit to be used in the creation of an elder brain."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Extractor Staff",
 											"entries": [
-												" Each ulitharid carries a psionically enhanced staff made of black metal. When the ulitharid is ready to give up its life, it attaches the staff to the back of its head, and the staff cracks open its skull and peels it apart, enabling its brain to be extracted. The brain and the staff are then planted in the ulitharid's corpse, causing it to dissolve into ichor. This psionically potent slime helps to fuel the transformation of the area into a brine pool that surrounds an embryonic elder brain."
+												"Each ulitharid carries a psionically enhanced staff made of black metal. When the ulitharid is ready to give up its life, it attaches the staff to the back of its head, and the staff cracks open its skull and peels it apart, enabling its brain to be extracted. The brain and the staff are then planted in the ulitharid's corpse, causing it to dissolve into ichor. This psionically potent slime helps to fuel the transformation of the area into a brine pool that surrounds an embryonic elder brain."
 											],
 											"type": "entries"
 										}
@@ -5401,7 +5406,7 @@
 										{
 											"name": "Abyssal Nuisances",
 											"entries": [
-												" Swarms of vargouilles flap through the caverns and skies of the Abyss. They are given little regard by powerful and intelligent demons since vargouilles can do them no harm. Even the weakest demon, such as a manes or a dretch, fears vargouilles only if they appear in great numbers. In the Lower Planes, vargouilles rarely get the chance to eat live prey other than vermin. More often, they lap up the ichor left behind when one fiend kills another.",
+												"Swarms of vargouilles flap through the caverns and skies of the Abyss. They are given little regard by powerful and intelligent demons since vargouilles can do them no harm. Even the weakest demon, such as a manes or a dretch, fears vargouilles only if they appear in great numbers. In the Lower Planes, vargouilles rarely get the chance to eat live prey other than vermin. More often, they lap up the ichor left behind when one fiend kills another.",
 												"The kiss of a vargouille infects a humanoid with a fiendish curse. If allowed to run its course, the curse brings about a gruesome transformation as an abyssal spirit invades the person's body. Over a period of hours, the victim's head takes on fiendish aspects such as fangs, tentacles, and horns. At the same time, the person's ears grow larger, expanding and transforming into wing-like appendages. In the final moments, the victim's head tears away from the body in a fountain of blood, becoming another vargouille, which often then eagerly laps up its own life fluids. Sunlight or the brilliant illumination of a {@spell daylight} spell can delay this transformation, and vargouilles instinctively shun bright light as a result."
 											],
 											"type": "entries"
@@ -5409,14 +5414,14 @@
 										{
 											"name": "The World Awaits",
 											"entries": [
-												" Because of their instinctive hunger for living prey, vargouilles are eager to escape the Lower Planes. On rare occasions, the summoning of a demon to another plane can bring a vargouille along for the ride, attaching itself like a tick. The precautions a mortal takes to contain and control a summoned demon rarely account for a stowaway, and thus a vargouille enters the world unbidden."
+												"Because of their instinctive hunger for living prey, vargouilles are eager to escape the Lower Planes. On rare occasions, the summoning of a demon to another plane can bring a vargouille along for the ride, attaching itself like a tick. The precautions a mortal takes to contain and control a summoned demon rarely account for a stowaway, and thus a vargouille enters the world unbidden."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Ghastly Reproduction",
 											"entries": [
-												" Vargouilles that roam free on the Material Plane are a dire threat to all creatures, especially humanoids. Their awful shrieking can paralyze other creatures with fear, and such victims are helpless to resist a vargouille's accursed kiss."
+												"Vargouilles that roam free on the Material Plane are a dire threat to all creatures, especially humanoids. Their awful shrieking can paralyze other creatures with fear, and such victims are helpless to resist a vargouille's accursed kiss."
 											],
 											"type": "entries"
 										}
@@ -5454,7 +5459,7 @@
 										{
 											"name": "Primitive Plants",
 											"entries": [
-												" Vegepygmies, also called mold folk or moldies, inhabit dark areas that are warm and wet, so they are most commonly found underground or in dense forests where little sunlight penetrates. A vegepygmy instinctively feels kinship with other plant and fungus creatures, and thus vegepygmy tribes coexist well with creatures such as myconids, shriekers, and violet fungi.",
+												"Vegepygmies, also called mold folk or moldies, inhabit dark areas that are warm and wet, so they are most commonly found underground or in dense forests where little sunlight penetrates. A vegepygmy instinctively feels kinship with other plant and fungus creatures, and thus vegepygmy tribes coexist well with creatures such as myconids, shriekers, and violet fungi.",
 												"Although they prefer to eat fresh meat, bone, and blood, vegepygmies can absorb nutrients from soil and many sorts of organic matter, meaning that they rarely go hungry. A vegepygmy can hiss and make other noises by forcing air through its mouth, but it can't speak in a conventional sense. Among themselves, vegepygmies communicate by hissing, gestures, and rhythmic tapping on the body. Vegepygmies build and craft little; any gear they have is acquired from other creatures or built by copying simple construction they have witnessed.",
 												"As a vegepygmy ages, it grows tougher and develops spore clusters on its body. Spore-bearing vegepygmies are deferred to by other vegepygmies, so outsiders refer to such vegepygmies as chiefs. A chief can expel its spores in a burst, infecting nearby creatures. If a creature dies while infected, its corpse produces vegepygmies the same way russet mold does.",
 												"No one knows for sure where russet mold came from. One historical account tells of adventurers in a forbidding mountain range discovering russet mold and vegepygmies in a peculiar metal dungeon full of strange life. Another story says that explorers found russet mold in a crater left by a falling star, with vegepygmies infesting the dense jungle nearby."
@@ -5464,7 +5469,7 @@
 										{
 											"name": "Mold Begets Mold",
 											"entries": [
-												" Vegepygmies originate from the remains left behind when a humanoid or a giant is killed by russet mold. One or more vegepygmies emerge from the corpse a day later. If a beast such as a dog or a bear dies from russet mold, the result is a bestial moldie called a thorny result instead of a humanoid-shaped vegepygmy. Thornies are less intelligent than vegepygmies, but have greater size and ferocity, as well as a thorn-covered body."
+												"Vegepygmies originate from the remains left behind when a humanoid or a giant is killed by russet mold. One or more vegepygmies emerge from the corpse a day later. If a beast such as a dog or a bear dies from russet mold, the result is a bestial moldie called a thorny result instead of a humanoid-shaped vegepygmy. Thornies are less intelligent than vegepygmies, but have greater size and ferocity, as well as a thorn-covered body."
 											],
 											"type": "entries"
 										}
@@ -5511,7 +5516,7 @@
 										{
 											"name": "Primitive Plants",
 											"entries": [
-												" Vegepygmies, also called mold folk or moldies, inhabit dark areas that are warm and wet, so they are most commonly found underground or in dense forests where little sunlight penetrates. A vegepygmy instinctively feels kinship with other plant and fungus creatures, and thus vegepygmy tribes coexist well with creatures such as myconids, shriekers, and violet fungi.",
+												"Vegepygmies, also called mold folk or moldies, inhabit dark areas that are warm and wet, so they are most commonly found underground or in dense forests where little sunlight penetrates. A vegepygmy instinctively feels kinship with other plant and fungus creatures, and thus vegepygmy tribes coexist well with creatures such as myconids, shriekers, and violet fungi.",
 												"Although they prefer to eat fresh meat, bone, and blood, vegepygmies can absorb nutrients from soil and many sorts of organic matter, meaning that they rarely go hungry. A vegepygmy can hiss and make other noises by forcing air through its mouth, but it can't speak in a conventional sense. Among themselves, vegepygmies communicate by hissing, gestures, and rhythmic tapping on the body. Vegepygmies build and craft little; any gear they have is acquired from other creatures or built by copying simple construction they have witnessed.",
 												"As a vegepygmy ages, it grows tougher and develops spore clusters on its body. Spore-bearing vegepygmies are deferred to by other vegepygmies, so outsiders refer to such vegepygmies as chiefs. A chief can expel its spores in a burst, infecting nearby creatures. If a creature dies while infected, its corpse produces vegepygmies the same way russet mold does.",
 												"No one knows for sure where russet mold came from. One historical account tells of adventurers in a forbidding mountain range discovering russet mold and vegepygmies in a peculiar metal dungeon full of strange life. Another story says that explorers found russet mold in a crater left by a falling star, with vegepygmies infesting the dense jungle nearby."
@@ -5521,7 +5526,7 @@
 										{
 											"name": "Mold Begets Mold",
 											"entries": [
-												" Vegepygmies originate from the remains left behind when a humanoid or a giant is killed by russet mold. One or more vegepygmies emerge from the corpse a day later. If a beast such as a dog or a bear dies from russet mold, the result is a bestial moldie called a thorny result instead of a humanoid-shaped vegepygmy. Thornies are less intelligent than vegepygmies, but have greater size and ferocity, as well as a thorn-covered body."
+												"Vegepygmies originate from the remains left behind when a humanoid or a giant is killed by russet mold. One or more vegepygmies emerge from the corpse a day later. If a beast such as a dog or a bear dies from russet mold, the result is a bestial moldie called a thorny result instead of a humanoid-shaped vegepygmy. Thornies are less intelligent than vegepygmies, but have greater size and ferocity, as well as a thorn-covered body."
 											],
 											"type": "entries"
 										}
@@ -5717,7 +5722,7 @@
 										{
 											"name": "Born of Sacrifice",
 											"entries": [
-												" The ritual to create a wood woad is a primeval secret passed down through generations of savage societies and dark druid circles. Performing the ritual isn't necessarily an act of evil, if the victim-to-be has entered into a bargain that requires it to be a willing sacrifice.",
+												"The ritual to create a wood woad is a primeval secret passed down through generations of savage societies and dark druid circles. Performing the ritual isn't necessarily an act of evil, if the victim-to-be has entered into a bargain that requires it to be a willing sacrifice.",
 												"In the ritual a living person's chest is pierced and the heart removed. A seed is then pushed into the heart, and it is placed in a tree. Any hollow or crook will do, but often a special cavity is carved out of the trunk. The tree is then bathed and watered with the blood of the sacrificed victim, and the body is buried among the tree's roots. After three days, a sprout emerges from the ground at the base of the tree and swiftly grows into a humanoid form.",
 												"This new body, armored in tough bark and bearing a gnarled club and shield, is at once ready to perform its duty. The one who performed the ritual sets the wood woad to its task, and the creature follows those orders unceasingly.",
 												"Wood woads are drawn to creatures that have close ties to nature, and that protect and respect the land, such as druids and treants. Some treants have wood woad servants by virtue of age-old pacts with druids or fey that performed the rituals, while others acquire the services of freed wood woads that find renewed purpose in the domain of a kindred guardian."
@@ -5727,14 +5732,14 @@
 										{
 											"name": "Pitiless Protectors",
 											"entries": [
-												" A wood woad has a hole where its heart would be, just as does the body of its former self, buried in the earth. Those who become wood woads trade their free will and all sense of sentiment for supernatural strength and a deathless duty. They exist only to protect woodlands and the people who tend them. A wood woad's face is void and expressionless, except for the motes of light that swim about in its eye sockets. Wood woads speak little, and when not being called upon to take action, they root themselves in the earth and silently take sustenance from it."
+												"A wood woad has a hole where its heart would be, just as does the body of its former self, buried in the earth. Those who become wood woads trade their free will and all sense of sentiment for supernatural strength and a deathless duty. They exist only to protect woodlands and the people who tend them. A wood woad's face is void and expressionless, except for the motes of light that swim about in its eye sockets. Wood woads speak little, and when not being called upon to take action, they root themselves in the earth and silently take sustenance from it."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Uprooted by Immortality",
 											"entries": [
-												" Like a tree, a wood woad needs only sunlight, air, and nutrients from the earth to go on living. Because they are undying, some wood woads outlive their original purpose. The site a wood woad guards might lose its power or significance over time, or those whom it was assigned to guard might themselves die. If it is freed from its specific duties, a wood woad might roam to find another place of natural beauty or fey influence to watch over."
+												"Like a tree, a wood woad needs only sunlight, air, and nutrients from the earth to go on living. Because they are undying, some wood woads outlive their original purpose. The site a wood woad guards might lose its power or significance over time, or those whom it was assigned to guard might themselves die. If it is freed from its specific duties, a wood woad might roam to find another place of natural beauty or fey influence to watch over."
 											],
 											"type": "entries"
 										}
@@ -5773,7 +5778,7 @@
 										{
 											"name": "Raxivort's Betrayal",
 											"entries": [
-												" All xvarts are the degenerate offspring of an entity named Raxivort, who once served Graz'zt the Dark Prince as treasurer. Raxivort spent long centuries watching over the treasury, and in time he grew to lust after his master's riches. In one bold move, he plundered a treasure vault and fled to the Material Plane. One of the treasures he stole was the Infinity Spindle, a crystalline shard from the early days of the multiverse that could transform even a creature as low as Raxivort into a demigod.",
+												"All xvarts are the degenerate offspring of an entity named Raxivort, who once served Graz'zt the Dark Prince as treasurer. Raxivort spent long centuries watching over the treasury, and in time he grew to lust after his master's riches. In one bold move, he plundered a treasure vault and fled to the Material Plane. One of the treasures he stole was the Infinity Spindle, a crystalline shard from the early days of the multiverse that could transform even a creature as low as Raxivort into a demigod.",
 												"After he ascended to godhood, Raxivort forged a realm called the Black Sewers, within Pandesmos, the topmost layer of Pandemonium. He enjoyed his divine ascension only briefly, though, before Graz'zt unleashed his vengeance. The demon prince had no need to regain the Infinity Spindle, since he already possessed power greater than what it could grant. Instead, he dispatched agents far and wide to spread news of what the spindle could do and the puny, pathetic creature that claimed its ownership. Soon enough, Raxivort was pursued by a variety of enemies, all eager to claim the Spindle as their own.",
 												"In the face of his imminent destruction, Raxivort hatched a plan. Fleeing to the Material Plane, he wandered across a variety of worlds and spawned creatures that were his exact duplicate. These are the xvarts, creatures that not only look identical to Raxivort in appearance but also foil any magic used to track him down. Spells, rituals, and other effects that could reveal Raxivort's location instead point to the nearest xvart.",
 												"Although the initial rush of enemies against him has subsided, Raxivort knows that the planar powers are patient. He remains in hiding, a wretch of a demigod who does little more than wander the planes, spawning ever more xvarts to ensure his continued safety.",
@@ -5788,28 +5793,28 @@
 										{
 											"name": "Greedy Thugs",
 											"entries": [
-												" Xvarts have all of their creator's flaws and few redeeming qualities. They lack the physical equipment to reproduce, as well as the inclination to do so. They are greedy, conniving, and obsessed with the acquisition of valuables-the more ornate or bizarre, the better. They know they are flawed, and this minor amount of self-awareness only magnifies their other deficiencies . They hate almost any creature they perceive as better than they are, which includes almost anyone, but they lack the courage or wherewithal to act on their hatred most of the time. Their fear has led them to dwell either in gloomy places on the far fringes of civilized lands or in areas neglected or forgotten by mightier creatures. In other words, xvarts usually live in places where normal vermin might flourish."
+												"Xvarts have all of their creator's flaws and few redeeming qualities. They lack the physical equipment to reproduce, as well as the inclination to do so. They are greedy, conniving, and obsessed with the acquisition of valuables-the more ornate or bizarre, the better. They know they are flawed, and this minor amount of self-awareness only magnifies their other deficiencies . They hate almost any creature they perceive as better than they are, which includes almost anyone, but they lack the courage or wherewithal to act on their hatred most of the time. Their fear has led them to dwell either in gloomy places on the far fringes of civilized lands or in areas neglected or forgotten by mightier creatures. In other words, xvarts usually live in places where normal vermin might flourish."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Vermin Masters",
 											"entries": [
-												" Rats and bats (including giant-sized specimens) are naturally attracted to xvarts, and xvarts domesticate such beasts for food and battle. Xvarts also form alliances with wererats, although the lycanthropes are dominant in any such arrangement. This relationship traces back to Raxivort's divine nature. Even though the xvarts inherited Raxivort's greed and cowardice, they also gained his ability to form bonds with such creatures."
+												"Rats and bats (including giant-sized specimens) are naturally attracted to xvarts, and xvarts domesticate such beasts for food and battle. Xvarts also form alliances with wererats, although the lycanthropes are dominant in any such arrangement. This relationship traces back to Raxivort's divine nature. Even though the xvarts inherited Raxivort's greed and cowardice, they also gained his ability to form bonds with such creatures."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Xvart Warlocks",
 											"entries": [
-												" A xvart can forge a pact with Raxivort by stealing an item of such great value that the demigod himself appears before the xvart to claim it. After surrendering the item to Raxivort, the xvart asks for magical power so that it can find and deliver more great treasures into Raxivort's custody. If the demigod feels so inclined, he imbues the xvart with greater wisdom and charisma and grants it the spellcasting abilities of a warlock before returning to the howling chaos of"
+												"A xvart can forge a pact with Raxivort by stealing an item of such great value that the demigod himself appears before the xvart to claim it. After surrendering the item to Raxivort, the xvart asks for magical power so that it can find and deliver more great treasures into Raxivort's custody. If the demigod feels so inclined, he imbues the xvart with greater wisdom and charisma and grants it the spellcasting abilities of a warlock before returning to the howling chaos of"
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Pandemonium",
 											"entries": [
-												" Raxivort's warlocks are respected and feared in xvart society, but they have little interest in political power. They scour the wilderness, old ruins, and dungeons for treasures, often with a handful of xvart sycophants and giant rat bodyguards in tow."
+												"Raxivort's warlocks are respected and feared in xvart society, but they have little interest in political power. They scour the wilderness, old ruins, and dungeons for treasures, often with a handful of xvart sycophants and giant rat bodyguards in tow."
 											],
 											"type": "entries"
 										}
@@ -5856,7 +5861,7 @@
 										{
 											"name": "Raxivort's Betrayal",
 											"entries": [
-												" All xvarts are the degenerate offspring of an entity named Raxivort, who once served Graz'zt the Dark Prince as treasurer. Raxivort spent long centuries watching over the treasury, and in time he grew to lust after his master's riches. In one bold move, he plundered a treasure vault and fled to the Material Plane. One of the treasures he stole was the Infinity Spindle, a crystalline shard from the early days of the multiverse that could transform even a creature as low as Raxivort into a demigod.",
+												"All xvarts are the degenerate offspring of an entity named Raxivort, who once served Graz'zt the Dark Prince as treasurer. Raxivort spent long centuries watching over the treasury, and in time he grew to lust after his master's riches. In one bold move, he plundered a treasure vault and fled to the Material Plane. One of the treasures he stole was the Infinity Spindle, a crystalline shard from the early days of the multiverse that could transform even a creature as low as Raxivort into a demigod.",
 												"After he ascended to godhood, Raxivort forged a realm called the Black Sewers, within Pandesmos, the topmost layer of Pandemonium. He enjoyed his divine ascension only briefly, though, before Graz'zt unleashed his vengeance. The demon prince had no need to regain the Infinity Spindle, since he already possessed power greater than what it could grant. Instead, he dispatched agents far and wide to spread news of what the spindle could do and the puny, pathetic creature that claimed its ownership. Soon enough, Raxivort was pursued by a variety of enemies, all eager to claim the Spindle as their own.",
 												"In the face of his imminent destruction, Raxivort hatched a plan. Fleeing to the Material Plane, he wandered across a variety of worlds and spawned creatures that were his exact duplicate. These are the xvarts, creatures that not only look identical to Raxivort in appearance but also foil any magic used to track him down. Spells, rituals, and other effects that could reveal Raxivort's location instead point to the nearest xvart.",
 												"Although the initial rush of enemies against him has subsided, Raxivort knows that the planar powers are patient. He remains in hiding, a wretch of a demigod who does little more than wander the planes, spawning ever more xvarts to ensure his continued safety.",
@@ -5871,28 +5876,28 @@
 										{
 											"name": "Greedy Thugs",
 											"entries": [
-												" Xvarts have all of their creator's flaws and few redeeming qualities. They lack the physical equipment to reproduce, as well as the inclination to do so. They are greedy, conniving, and obsessed with the acquisition of valuables-the more ornate or bizarre, the better. They know they are flawed, and this minor amount of self-awareness only magnifies their other deficiencies . They hate almost any creature they perceive as better than they are, which includes almost anyone, but they lack the courage or wherewithal to act on their hatred most of the time. Their fear has led them to dwell either in gloomy places on the far fringes of civilized lands or in areas neglected or forgotten by mightier creatures. In other words, xvarts usually live in places where normal vermin might flourish."
+												"Xvarts have all of their creator's flaws and few redeeming qualities. They lack the physical equipment to reproduce, as well as the inclination to do so. They are greedy, conniving, and obsessed with the acquisition of valuables-the more ornate or bizarre, the better. They know they are flawed, and this minor amount of self-awareness only magnifies their other deficiencies . They hate almost any creature they perceive as better than they are, which includes almost anyone, but they lack the courage or wherewithal to act on their hatred most of the time. Their fear has led them to dwell either in gloomy places on the far fringes of civilized lands or in areas neglected or forgotten by mightier creatures. In other words, xvarts usually live in places where normal vermin might flourish."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Vermin Masters",
 											"entries": [
-												" Rats and bats (including giant-sized specimens) are naturally attracted to xvarts, and xvarts domesticate such beasts for food and battle. Xvarts also form alliances with wererats, although the lycanthropes are dominant in any such arrangement. This relationship traces back to Raxivort's divine nature. Even though the xvarts inherited Raxivort's greed and cowardice, they also gained his ability to form bonds with such creatures."
+												"Rats and bats (including giant-sized specimens) are naturally attracted to xvarts, and xvarts domesticate such beasts for food and battle. Xvarts also form alliances with wererats, although the lycanthropes are dominant in any such arrangement. This relationship traces back to Raxivort's divine nature. Even though the xvarts inherited Raxivort's greed and cowardice, they also gained his ability to form bonds with such creatures."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Xvart Warlocks",
 											"entries": [
-												" A xvart can forge a pact with Raxivort by stealing an item of such great value that the demigod himself appears before the xvart to claim it. After surrendering the item to Raxivort, the xvart asks for magical power so that it can find and deliver more great treasures into Raxivort's custody. If the demigod feels so inclined, he imbues the xvart with greater wisdom and charisma and grants it the spellcasting abilities of a warlock before returning to the howling chaos of"
+												"A xvart can forge a pact with Raxivort by stealing an item of such great value that the demigod himself appears before the xvart to claim it. After surrendering the item to Raxivort, the xvart asks for magical power so that it can find and deliver more great treasures into Raxivort's custody. If the demigod feels so inclined, he imbues the xvart with greater wisdom and charisma and grants it the spellcasting abilities of a warlock before returning to the howling chaos of"
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Pandemonium",
 											"entries": [
-												" Raxivort's warlocks are respected and feared in xvart society, but they have little interest in political power. They scour the wilderness, old ruins, and dungeons for treasures, often with a handful of xvart sycophants and giant rat bodyguards in tow."
+												"Raxivort's warlocks are respected and feared in xvart society, but they have little interest in political power. They scour the wilderness, old ruins, and dungeons for treasures, often with a handful of xvart sycophants and giant rat bodyguards in tow."
 											],
 											"type": "entries"
 										}
@@ -5921,7 +5926,7 @@
 										{
 											"name": "Minions of a Dark Master",
 											"entries": [
-												" A pack of yeth hounds can be created by powerful fey such as the Queen of Air and Darkness. Once it is brought into existence, a pack must have a master, who is often someone the creator wishes to reward. The master can telepathically communicate with its yeth hounds to give them commands from afar. If the master of a pack is killed, the hounds seek and choose a new master, typically an individual of great evil such as a vampire, a necromancer, or a hag.",
+												"A pack of yeth hounds can be created by powerful fey such as the Queen of Air and Darkness. Once it is brought into existence, a pack must have a master, who is often someone the creator wishes to reward. The master can telepathically communicate with its yeth hounds to give them commands from afar. If the master of a pack is killed, the hounds seek and choose a new master, typically an individual of great evil such as a vampire, a necromancer, or a hag.",
 												"A yeth hound stands about 5 feet tall at the shoulder and weighs around 400 pounds. Often all that can be seen of one in the darkness is the red glow of its eyes against its night-black fur. The head of a yeth hound has a human-like face, held up by a neck more flexible than a dog's. The creature gives off an odor like smoke.",
 												"Those that stand their ground and fight back discover that mundane weapons partially pass through the hound as if it was made of fog, but magic weapons and silvered weapons can strike true."
 											],
@@ -5930,14 +5935,14 @@
 										{
 											"name": "Sound of Looming Death",
 											"entries": [
-												" Yeth hounds make a ghastly baying sound that can be heard all around. Creatures that can see a hound when it bays are filled with supernatural fear and usually flee in terror. When a victim tries to run away, a hound delights in chasing after it and tormenting it before bringing the hunt to a close."
+												"Yeth hounds make a ghastly baying sound that can be heard all around. Creatures that can see a hound when it bays are filled with supernatural fear and usually flee in terror. When a victim tries to run away, a hound delights in chasing after it and tormenting it before bringing the hunt to a close."
 											],
 											"type": "entries"
 										},
 										{
 											"name": "Foiled by Sunlight",
 											"entries": [
-												" Yeth hounds can't stand sunlight. A pack never willingly prolongs a hunt beyond the night hours and always seeks to return to its dark den before the first rays of dawn. No amount of coercion by a pack's master can deter this behavior. If a yeth hound is exposed to natural sunlight, it fades away, vanishing into the Ethereal Plane, from where its master can retrieve it only after the sun has set."
+												"Yeth hounds can't stand sunlight. A pack never willingly prolongs a hunt beyond the night hours and always seeks to return to its dark den before the first rays of dawn. No amount of coercion by a pack's master can deter this behavior. If a yeth hound is exposed to natural sunlight, it fades away, vanishing into the Ethereal Plane, from where its master can retrieve it only after the sun has set."
 											],
 											"type": "entries"
 										}
@@ -5983,7 +5988,7 @@
 										{
 											"name": "Not Quite Divine",
 											"entries": [
-												" An anathema considers itself a demigod on the path to greater divinity. It demands obeisance from weaker yuan-ti and uses every resource at its disposal to launch small-scale wars against its neighbors. Each conquest brings new slaves and sacrifices, as well as glory and riches, that the anathema thinks it needs to achieve true divinity.",
+												"An anathema considers itself a demigod on the path to greater divinity. It demands obeisance from weaker yuan-ti and uses every resource at its disposal to launch small-scale wars against its neighbors. Each conquest brings new slaves and sacrifices, as well as glory and riches, that the anathema thinks it needs to achieve true divinity.",
 												"An anathema's most loyal yuan-ti followers see it as the pinnacle of the serpentine form, an unbelievable improvement on the nearly perfect abomination. Its devoted human followers think of it as \"divine flesh in a mortal body,\" and cultists serving an anathema tend to be more bloodthirsty and self-sacrificing in its presence."
 											],
 											"type": "entries"
@@ -5991,7 +5996,7 @@
 										{
 											"name": "Immortal",
 											"entries": [
-												" Anathemas don't age, allowing them to pursue their goals until the end of days. Truly powerful ones can grow to rule multiple yuan-ti cities and bring entire regions, including humanoid realms, under yuan-ti control."
+												"Anathemas don't age, allowing them to pursue their goals until the end of days. Truly powerful ones can grow to rule multiple yuan-ti cities and bring entire regions, including humanoid realms, under yuan-ti control."
 											],
 											"type": "entries"
 										}
@@ -6037,7 +6042,7 @@
 										{
 											"name": "Human No More",
 											"entries": [
-												" Most broodguards are made from human prisoners forced to consume a magical brew that renders them helpless and unable to fight off the inevitable. A human transformed into a broodguard loses all semblance of who it once was, and even its human origin is barely discernible. A broodguard is hairless and emaciated, with yellow-green, scaly skin. It has beady, bloodshot eyes and a forked tongue, and smells faintly of rotting meat. Broodguards can speak but rarely do so, preferring to use snake-like hisses and guttural noises."
+												"Most broodguards are made from human prisoners forced to consume a magical brew that renders them helpless and unable to fight off the inevitable. A human transformed into a broodguard loses all semblance of who it once was, and even its human origin is barely discernible. A broodguard is hairless and emaciated, with yellow-green, scaly skin. It has beady, bloodshot eyes and a forked tongue, and smells faintly of rotting meat. Broodguards can speak but rarely do so, preferring to use snake-like hisses and guttural noises."
 											],
 											"type": "entries"
 										}
@@ -6069,92 +6074,32 @@
 		{
 			"name": "Yuan-ti Malison (Type 4)",
 			"source": "VGM",
-			"entries": [
-				{
-					"type": "entries",
-					"entries": [
-						{
+			"_copy": {
+				"name": "Yuan-ti Malison",
+				"source": "MM",
+				"_mod": {
+					"entries": {
+						"mode": "prependArr",
+						"items": {
 							"type": "entries",
 							"entries": [
 								{
 									"type": "entries",
 									"entries": [
-										"A malison is a hideous blend of human and serpentine features. Three different types of malisons are known to exist, and other types are possible. Malisons form the middle caste of yuan-ti society and hunt with arrows tipped with their own venom. They use their magical powers of suggestion to force their enemies' surrender."
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Yuan-ti",
-									"entries": [
-										"Yuan-ti are devious serpent folk devoid of compassion. From remote temples in jungles, swamps, and deserts, the yuan-ti plot to supplant and dominate all other races and to make themselves gods.",
 										{
-											"name": "Forsaken Humanity",
+											"type": "entries",
+											"name": "Yuan-ti Malison Variants: Types 4 and 5",
 											"entries": [
-												" The yuan-ti were once humans who thrived in the earliest days of civilization and worshiped serpents as totem animals. They lauded the serpent's sinuous flexibility, its calculated poise, and its deadly strike. Their advanced philosophy taught the virtue of detachment from emotion and of clear, focused thought.",
-												"Yuan-ti culture was among the richest in the mortal world. Their warriors were legendary, their empires always expanding. Yuan-ti temples stood at the centers of ancient metropolises, reaching ever higher in prayer to the gods they longed to emulate. In time, the serpent gods heard those prayers, their sibilant voices responding from the darkness as they told the yuan-ti what they must do. The yuan-ti religion grew more fanatical in its devotion. Cults bound themselves to the worship of the serpent gods and imitated their ways, indulging in cannibalism and humanoid sacrifice. Through foul sorcery, the yuan-ti bred with snakes, utterly sacrificing their humanity to become like the serpent gods in form, as well as in thought and emotion.",
-												"Yuan-ti know that the world they hope to rule can't be bound for long by brute force, and that many creatures will refuse to serve. As a result, yuan-ti first influence other creatures with the promise of wealth and power. Time and again, humanoid cultures make the fatal mistake of trusting the yuan-ti. They forget that a yuan-ti that acts honorably or lends aid in a time of trouble does so only as part of a grander design.",
-												"Yuan-ti leaders are cunning and ruthless tacticians who readily sacrifice lesser yuan-ti if potential victory justifies such losses. They have no sense of honorable combat and strike first in decisive ambush if they can.",
-												"Serpent Gods",
-												"The yuan-ti revere a number of powerful entities as gods, including the following."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Serpent Kings of Fallen Empires",
-											"entries": [
-												" The yuan-ti view their physical transformation as a transcendent moment for their race, allowing them to shed their frail humanity like dead skin. Those that did not transform eventually became slaves or food for the blessed of the serpent gods. The yuan-ti empires withered or were defeated by those who fought against their cannibalism and slavery, and the serpent folk were left in the ruins of their great capitals, far removed from other races."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Cold of Heart",
-											"entries": [
-												" Humanoid emotions are foreign to most yuan-ti, which understand sentiment only as an exploitable weakness. A yuan-ti views the world and the events of its own life with such extreme pragmatism that it is nearly impossible to manipulate, influence, or control by nonmagical means, even as it seeks to control other creatures through terror, pleasure, and awe."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "False Worship",
-											"entries": [
-												" Yuan-ti life revolves around their temples, yet yuan-ti don't love the gods they worship. Instead, they see worship as a means to attain power. A yuan-ti believes an individual who attains enough power can devour and replace one of the yuan-ti gods. The yuan-ti strive for ascension and are willing to commit the darkest atrocities to achieve it."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Dendar, the Night Serpent",
-											"entries": [
-												" Dendar's followers say that one day she will grow so large from feasting on the fears and nightmares of the world that she will devour it whole. Yuan-ti that serve Dendar terrorize other creatures in any way they can, growing and nurturing the fears of humanoids to feed the Night Serpent."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Merrshaulk, Master of the Pit",
-											"entries": [
-												" Merrshaulk is the long-slumbering chief deity of the yuan-ti. As worship of Merrshaulk waned, he went into slumber. Merrshaulk's priests are yuan-ti abominations that maintain traditions of living sacrifice and cause suffering in the god's name. With enough vile acts, the abominations believe that Merrshaulk will reawaken and restore the yuan-ti to their rightful place."
-											],
-											"type": "entries"
-										},
-										{
-											"name": "Sseth, the Sibilant Death",
-											"entries": [
-												" Sseth appeared to the yuan-ti of antiquity in the form of a winged yuan-ti claiming to be an avatar of Merrshaulk. Speaking with Merrshaulk's voice, Sseth vowed to pull the yuan-ti out of decline and build a new empire. Many of Merrshaulk's devout turned to the worship of Sseth. Some yuan-ti have long suspected Sseth as an usurper taking advantage of Merrshaulk's slumber to make himself a god. They believe that Sseth might even have devoured Merrshaulk, and now answers the prayers of Merrshaulk's followers, as his priests convert or consume Merrshaulk's more stubborn adherents."
-											],
-											"type": "entries"
+												"A malison is a yuan-ti that has a blend of human and serpentine features. Three different types of malisons are described in the Monster Manual, and two rarer types are described here. Type 4 and type 5 malisons are the lowest-ranking members of the malison caste, and neither type is venomous in its yuan-ti form."
+											]
 										}
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Yuan-ti Malison Variants: Types 4 and 5",
-									"entries": [
-										"A malison is a yuan-ti that has a blend of human and serpentine features. Three different types of malisons are described in the Monster Manual, and two rarer types are described here. Type 4 and type 5 malisons are the lowest-ranking members of the malison caste, and neither type is venomous in its yuan-ti form."
 									]
 								}
 							]
 						}
-					]
+					}
 				}
-			],
+			},
 			"images": [
 				{
 					"type": "image",


### PR DESCRIPTION
The MME2 v2 brew references a lot of fluff from the MM, and all the `_copy`ing made me notice that a lot of the fluff is... suboptimal, formatting-wise. So, I went through pretty much all of the MM, removing duplicate fluff with `_copy`, setting up header levels to be consistent with the book, and adding missing entries.

The MM diff is pretty huge due to the large number of 'trivial' changes (like removing leading whitespace from strings), but I've gone through everything and seen no errors pop up, plus it passes `npm run test`. It's 99.9% fluff fixes; statblock and art is unchanged _except_ for:
- MM Devils now have their variant "Summon Devil (1/day)" action added to their statblocks (the equivalent in demons and yugoloths was already there, so this is just bringing them in line with those)
- Mummy Lord now also uses the full-scale art from Mummy (it already shares a token, and the book doesn't really distinguish the art as being only for low-tier mummies)

### Rest of the changelog
(See commit messages for a tiny bit more detail)
- Touch up MM monster fluff: deduplicate text with `_copy` and regularise header levels
- Add missing handwritten notes from MM into relevant creatures' monster fluff (formatted as `quote`s inside `insetReadaloud`s to distinguish from the normal infoboxes)
- Leading whitespace within strings removed (a _lot_ of MM had strings like `" Blah..."`)
- Minor tagging and typos in MM, VGM, and MPMM monster fluff