### PR TITLE
Show cost for magic items if available

### DIFF
--- a/items.html
+++ b/items.html
@@ -217,6 +217,7 @@
 					<div id="filtertools-magic" class="ele-magic input-group input-group--bottom ve-flex no-shrink">
 						<button class="fullborder col-3-5 sort btn btn-default btn-xs" data-sort="name" data-sortby="asc">Name</button>
 						<button class="fullborder col-4 sort btn btn-default btn-xs" data-sort="type" data-sortby="asc">Type</button>
+						<button class="fullborder col-1-5 sort btn btn-default btn-xs" data-sort="cost" data-sortby="asc">Value</button>
 						<button class="fullborder col-1-5 sort btn btn-default btn-xs" data-sort="weight" data-sortby="asc">Weight</button>
 						<button class="col-0-6 sort btn btn-default btn-xs" data-sort="attunement" title="Can Be Attuned">A.</button>
 						<button class="fullborder col-1-4 sort btn btn-default btn-xs" data-sort="rarity" data-sortby="asc">Rarity</button>

--- a/js/items.js
+++ b/js/items.js
@@ -275,6 +275,7 @@ class ItemsPage extends ListPage {
 						children: [
 							e_({tag: "span", clazz: `col-3-5 pl-0 bold`, text: item.name}),
 							e_({tag: "span", clazz: `col-4`, text: type}),
+							e_({tag: "span", clazz: `col-1-5 ve-text-center`, text: `${item.value || item.valueMult ? Parser.itemValueToFullMultiCurrency(item, {isShortForm: true}).replace(/ +/g, "\u00A0") : "\u2014"}`}),
 							e_({tag: "span", clazz: `col-1-5 ve-text-center`, text: Parser.itemWeightToFull(item, true) || "\u2014"}),
 							e_({tag: "span", clazz: `col-0-6 ve-text-center`, text: item._attunementCategory !== VeCt.STR_NO_ATTUNEMENT ? "×" : ""}),
 							e_({tag: "span", clazz: `col-1-4 ve-text-center`, text: (item.rarity || "").toTitleCase()}),
@@ -300,6 +301,7 @@ class ItemsPage extends ListPage {
 					type,
 					rarity: item.rarity,
 					attunement: item._attunementCategory !== VeCt.STR_NO_ATTUNEMENT,
+					cost: item.value || Infinity,
 					weight: Parser.weightValueToNumber(item.weight),
 				},
 			);


### PR DESCRIPTION
Supplements like Sane Magic Item Prices (and even certain items in the DMG) have a cost. We should display this to match the mundane items table and allow sorting by it.