### PR TITLE
feat(proporder): Extend coverage to all in-use brew properties

### DIFF
--- a/js/utils-proporder.js
+++ b/js/utils-proporder.js
@@ -169,9 +169,12 @@ PropOrder._MONSTER = [
 			"name",
 			"headerEntries",
 
+			"constant",
 			"will",
 			"rest",
 			"daily",
+			"weekly",
+			"yearly",
 			"recharge",
 			"charges",
 
@@ -186,6 +189,7 @@ PropOrder._MONSTER = [
 			"ability",
 			"displayAs",
 			"hidden",
+			"type",
 		],
 	}),
 	"trait",
@@ -205,9 +209,12 @@ PropOrder._MONSTER = [
 	"mythic",
 	"legendaryGroup",
 	"variant",
+	"footer",
+
+	"resource",
+	"foundryImg",
 
 	"environment",
-	"fluff",
 	"familiar",
 	"dragonCastingColor",
 	"dragonAge",
@@ -247,6 +254,7 @@ PropOrder._MONSTER = [
 			new PropOrder._ObjectKey("_mod", {
 				fnGetOrder: () => PropOrder._MONSTER__COPY_MOD,
 			}),
+			"_preserve",
 			"_template",
 			"_implementations",
 			...PropOrder._MONSTER,
@@ -306,10 +314,31 @@ PropOrder._MONSTER_TEMPLATE = [
 		],
 	}),
 ];
+PropOrder._MAKE_BREW_CREATURE_TRAIT = [
+	"name",
+	"source",
+
+	"entries",
+];
+PropOrder._MAKE_BREW_CREATURE_ACTION = [
+	"name",
+	"source",
+
+	"entries",
+];
 PropOrder._MONSTER_TEMPLATE__COPY_MOD = [
 	"*",
 	"_",
 	...PropOrder._MONSTER_TEMPLATE,
+];
+PropOrder._FOUNDRY_MONSTER = [
+	"name",
+	"source",
+
+	"system",
+	"effects",
+	"flags",
+	"img",
 ];
 PropOrder._GENERIC_FLUFF = [
 	"name",
@@ -357,6 +386,18 @@ PropOrder._SPELL = [
 
 	"scalingLevelDice",
 
+	new PropOrder._ObjectKey("classes", {
+		order: [
+			"fromClassList",
+			"fromClassListVariant",
+			"fromSubclass",
+		],
+	}),
+	"races",
+	"backgrounds",
+	"optionalfeatures",
+	"feats",
+
 	"damageResist",
 	"damageImmune",
 	"damageVulnerable",
@@ -377,7 +418,57 @@ PropOrder._SPELL = [
 	"hasFluff",
 	"hasFluffImages",
 
+	new PropOrder._ObjectKey("roll20Spell", {
+		order: PropOrder._ROLL20_SPELL,
+	}),
+
+	"foundrySystem",
+	"foundryFlags",
+	"foundryEffects",
+	"foundryImg",
+
 	"fluff",
+];
+PropOrder._ROLL20_SPELL = [
+	"name",
+	"source",
+
+	new PropOrder._ObjectKey("data", {
+		order: [
+			"Save",
+			"Damage",
+			"Damage Type",
+			"Damage Progression",
+			"Target",
+			"Healing",
+			"Spell Attack",
+			"Save Success",
+			"Higher Spell Slot Die",
+			"Higher Spell Slot Dice",
+			"Add Casting Modifier",
+			"Secondary Damage",
+			"Secondary Damage Type",
+			"Higher Level Healing",
+			"Higher Spell Slot Bonus",
+			"Secondary Higher Spell Slot Die",
+			"Secondary Higher Spell Slot Dice",
+			"Secondary Damage Progression",
+			"Secondary Add Casting Modifier",
+			"data-Cantrip Scaling",
+			"Crit",
+			"Crit Range",
+		],
+	}),
+	"shapedData",
+];
+PropOrder._FOUNDRY_SPELL = [
+	"name",
+	"source",
+
+	"system",
+	"effects",
+	"flags",
+	"img",
 ];
 PropOrder._SPELL__COPY_MOD = [
 	"*",
@@ -424,7 +515,19 @@ PropOrder._ADVENTURE = [
 	"storyline",
 	"level",
 
+	"alAveragePlayerLevel",
+	"alLength",
+	"alId",
+
 	"contents",
+];
+PropOrder._ADVENTURE_DATA = [
+	"name",
+
+	"id",
+	"source",
+
+	"data",
 ];
 PropOrder._BOOK = [
 	"name",
@@ -491,6 +594,18 @@ PropOrder._BACKGROUND = [
 
 	"hasFluff",
 	"hasFluffImages",
+
+	"expertise",
+	"resist",
+	"immune",
+	"vulnerable",
+	"conditionImmune",
+
+	"foundrySystem",
+	"foundryFlags",
+	"foundryEffects",
+	"foundryAdvancement",
+	"foundryImg",
 
 	"fluff",
 ];
@@ -571,7 +686,26 @@ PropOrder._CLASS = [
 
 	"subclassTitle",
 
+	"foundrySystem",
+	"foundryFlags",
+	"foundryAdvancement",
+	"foundryImg",
+
 	"fluff",
+];
+PropOrder._FOUNDRY_CLASS = [
+	"name",
+
+	"source",
+
+	"advancement",
+	"chooseSystem",
+	"isChooseSystemRenderEntries",
+	"isChooseFlagsRenderEntries",
+	"isIgnored",
+	"ignoreSrdEffects",
+	"actorDataMod",
+	"actorTokenMod",
 ];
 PropOrder._SUBCLASS = [
 	"name",
@@ -609,15 +743,42 @@ PropOrder._SUBCLASS = [
 
 	"additionalSpells",
 
+	"subclassSpells",
+	"subSubclassSpells",
+
 	"optionalfeatureProgression",
 
 	"subclassTableGroups",
 	"subclassFeatures",
+
+	"foundrySystem",
+	"foundryFlags",
+	"foundryAdvancement",
+	"foundryImg",
 ];
 PropOrder._SUBCLASS__COPY_MOD = [
 	"*",
 	"_",
 	...PropOrder._SUBCLASS,
+];
+PropOrder._ENTRY_DATA_OBJECT = [
+	"languageProficiencies",
+	"skillProficiencies",
+	"weaponProficiencies",
+	"armorProficiencies",
+	"toolProficiencies",
+	"savingThrowProficiencies",
+
+	"expertise",
+
+	"resist",
+	"immune",
+	"vulnerable",
+	"conditionImmune",
+
+	"resources",
+
+	"senses",
 ];
 PropOrder._CLASS_FEATURE = [
 	"name",
@@ -634,12 +795,18 @@ PropOrder._CLASS_FEATURE = [
 
 	"isClassFeatureVariant",
 
+	...PropOrder._ENTRY_DATA_OBJECT,
+
 	"header",
 	"type",
 
 	"consumes",
 
 	"entries",
+
+	"foundrySystem",
+	"foundryFlags",
+	"foundryImg",
 ];
 PropOrder._SUBCLASS_FEATURE = [
 	"name",
@@ -660,12 +827,78 @@ PropOrder._SUBCLASS_FEATURE = [
 
 	"isGainAtNextFeatureLevel",
 
+	...PropOrder._ENTRY_DATA_OBJECT,
+
 	"header",
 	"type",
 
 	"consumes",
 
 	"entries",
+
+	"foundrySystem",
+	"foundryFlags",
+	"foundryImg",
+];
+PropOrder._FOUNDRY_CLASS_FEATURE = [
+	"name",
+	"source",
+
+	"className",
+	"classSource",
+	"level",
+
+	"system",
+	"effects",
+	"flags",
+	"img",
+
+	"entries",
+
+	new PropOrder._ObjectKey("entryData", {
+		fnGetOrder: () => PropOrder._ENTRY_DATA_OBJECT,
+	}),
+
+	"chooseSystem",
+	"isChooseSystemRenderEntries",
+	"isChooseFlagsRenderEntries",
+	"isIgnored",
+	"ignoreSrdEffects",
+	"actorDataMod",
+	"actorTokenMod",
+
+	"subEntities",
+];
+PropOrder._FOUNDRY_SUBCLASS_FEATURE = [
+	"name",
+	"source",
+
+	"className",
+	"classSource",
+	"subclassShortName",
+	"subclassSource",
+	"level",
+
+	"system",
+	"effects",
+	"flags",
+	"img",
+
+	"entries",
+
+	new PropOrder._ObjectKey("entryData", {
+		fnGetOrder: () => PropOrder._ENTRY_DATA_OBJECT,
+	}),
+
+	"chooseSystem",
+	"isChooseSystemRenderEntries",
+	"isChooseFlagsRenderEntries",
+	"isIgnored",
+	"ignoreSrdEffects",
+	"actorDataMod",
+	"actorTokenMod",
+
+	"subEntities",
 ];
 PropOrder._LANGUAGE = [
 	"name",
@@ -695,6 +928,15 @@ PropOrder._LANGUAGE_SCRIPT = [
 	"name",
 	"fonts",
 ];
+PropOrder._NAME = [
+	"name",
+
+	"source",
+	"page",
+	"legacy",
+
+	"tables",
+];
 PropOrder._CONDITION = [
 	"name",
 
@@ -719,6 +961,13 @@ PropOrder._DISEASE = [
 	"srd",
 	"basicRules",
 	"otherSources",
+
+	"color",
+	"fluff",
+	"foundrySystem",
+	"foundryFlags",
+	"foundryEffects",
+	"foundryImg",
 
 	"entries",
 ];
@@ -811,6 +1060,9 @@ PropOrder._DEITY = [
 
 	"piety",
 
+	"foundryImg",
+	"customProperties",
+
 	"entries",
 ];
 PropOrder._DEITY__COPY_MOD = [
@@ -860,6 +1112,11 @@ PropOrder._FEAT = [
 	"hasFluffImages",
 
 	"fluff",
+
+	"foundrySystem",
+	"foundryFlags",
+	"foundryEffects",
+	"foundryImg",
 ];
 PropOrder._VEHICLE = [
 	"name",
@@ -923,6 +1180,10 @@ PropOrder._VEHICLE = [
 	"hasFluffImages",
 
 	"fluff",
+
+	"foundrySystem",
+	"foundryFlags",
+	"foundryImg",
 ];
 PropOrder._VEHICLE_UPGRADE = [
 	"name",
@@ -1008,11 +1269,14 @@ PropOrder._ITEM = [
 	"valueMult",
 	"valueExpression",
 	"quantity",
+	"currencyConversion",
 
 	"weaponCategory",
 	"age",
 
 	"property",
+	"propertyAdd",
+	"propertyRemove",
 	"mastery",
 
 	"range",
@@ -1025,6 +1289,7 @@ PropOrder._ITEM = [
 	"ac",
 	"strength",
 	"dexterityMax",
+	"acSpecial",
 
 	"crew",
 	"crewMin",
@@ -1106,6 +1371,14 @@ PropOrder._ITEM = [
 
 	"hasFluff",
 	"hasFluffImages",
+
+	"customProperties",
+
+	"foundryType",
+	"foundrySystem",
+	"foundryFlags",
+	"foundryEffects",
+	"foundryImg",
 
 	"fluff",
 ];
@@ -1207,6 +1480,7 @@ PropOrder._OPTIONALFEATURE = [
 	"toolProficiencies",
 	"weaponProficiencies",
 	"armorProficiencies",
+	"skillToolLanguageProficiencies",
 
 	"senses",
 
@@ -1215,8 +1489,19 @@ PropOrder._OPTIONALFEATURE = [
 	"optionalfeatureProgression",
 
 	"consumes",
+	"expertise",
+
+	"resist",
+	"immune",
+	"vulnerable",
+	"conditionImmune",
 
 	"entries",
+
+	"foundrySystem",
+	"foundryFlags",
+	"foundryEffects",
+	"foundryImg",
 ];
 PropOrder._PSIONIC = [
 	"name",
@@ -1305,6 +1590,7 @@ PropOrder._RACE_SUBRACE = [
 	"weaponProficiencies",
 	"armorProficiencies",
 	"skillToolLanguageProficiencies",
+	"expertise",
 
 	"resist",
 	"immune",
@@ -1324,6 +1610,11 @@ PropOrder._RACE_SUBRACE = [
 
 	"fluff",
 
+	"foundrySystem",
+	"foundryFlags",
+	"foundryEffects",
+	"foundryImg",
+
 	new PropOrder._ArrayKey("_versions", {
 		fnGetOrder: () => [
 			"name",
@@ -1331,6 +1622,7 @@ PropOrder._RACE_SUBRACE = [
 			new PropOrder._ObjectKey("_mod", {
 				fnGetOrder: () => PropOrder._RACE__COPY_MOD,
 			}),
+			"_preserve",
 			"_template",
 			"_implementations",
 			...PropOrder._RACE,
@@ -1362,6 +1654,19 @@ PropOrder._SUBRACE = [
 
 	...PropOrder._RACE_SUBRACE,
 ];
+PropOrder._FOUNDRY_RACE_FEATURE = [
+	"name",
+
+	"source",
+
+	"raceName",
+	"raceSource",
+
+	"system",
+	"effects",
+	"flags",
+	"img",
+];
 PropOrder._TABLE = [
 	"name",
 
@@ -1371,13 +1676,26 @@ PropOrder._TABLE = [
 	"basicRules",
 
 	"otherSources",
+	"chapter",
+
+	"type",
 
 	"caption",
 
 	"colLabels",
+	"colLabelGroups",
 	"colStyles",
 
+	"intro",
 	"rows",
+	new PropOrder._ArrayKey("tables", {
+		fnGetOrder: () => PropOrder._TABLE,
+	}),
+	"outro",
+	"footnotes",
+
+	"isNameGenerator",
+	"isStriped",
 ];
 PropOrder._TRAP = [
 	"name",
@@ -1390,6 +1708,7 @@ PropOrder._TRAP = [
 	"trapHazType",
 
 	"tier",
+	"level",
 	"threat",
 	"effect",
 
@@ -1545,8 +1864,11 @@ PropOrder._CARD = [
 
 PropOrder._PROP_TO_LIST = {
 	"monster": PropOrder._MONSTER,
+	"foundryMonster": PropOrder._FOUNDRY_MONSTER,
 	"monsterFluff": PropOrder._GENERIC_FLUFF,
 	"monsterTemplate": PropOrder._MONSTER_TEMPLATE,
+	"makebrewCreatureTrait": PropOrder._MAKE_BREW_CREATURE_TRAIT,
+	"makebrewCreatureAction": PropOrder._MAKE_BREW_CREATURE_ACTION,
 	"backgroundFluff": PropOrder._GENERIC_FLUFF,
 	"featFluff": PropOrder._GENERIC_FLUFF,
 	"conditionFluff": PropOrder._GENERIC_FLUFF,
@@ -1557,19 +1879,26 @@ PropOrder._PROP_TO_LIST = {
 	"raceFluff": PropOrder._RACE_FLUFF,
 	"rewardFluff": PropOrder._GENERIC_FLUFF,
 	"spell": PropOrder._SPELL,
+	"roll20Spell": PropOrder._ROLL20_SPELL,
+	"foundrySpell": PropOrder._FOUNDRY_SPELL,
 	"spellList": PropOrder._SPELL_LIST,
 	"action": PropOrder._ACTION,
 	"adventure": PropOrder._ADVENTURE,
+	"adventureData": PropOrder._ADVENTURE_DATA,
 	"book": PropOrder._BOOK,
 	"bookData": PropOrder._BOOK_DATA,
 	"background": PropOrder._BACKGROUND,
 	"legendaryGroup": PropOrder._LEGENDARY_GROUP,
 	"class": PropOrder._CLASS,
+	"foundryClass": PropOrder._FOUNDRY_CLASS,
 	"subclass": PropOrder._SUBCLASS,
 	"classFeature": PropOrder._CLASS_FEATURE,
 	"subclassFeature": PropOrder._SUBCLASS_FEATURE,
+	"foundryClassFeature": PropOrder._FOUNDRY_CLASS_FEATURE,
+	"foundrySubclassFeature": PropOrder._FOUNDRY_SUBCLASS_FEATURE,
 	"language": PropOrder._LANGUAGE,
 	"languageScript": PropOrder._LANGUAGE_SCRIPT,
+	"name": PropOrder._NAME,
 	"condition": PropOrder._CONDITION,
 	"disease": PropOrder._DISEASE,
 	"status": PropOrder._STATUS,
@@ -1592,6 +1921,7 @@ PropOrder._PROP_TO_LIST = {
 	"spellFluff": PropOrder._GENERIC_FLUFF,
 	"race": PropOrder._RACE,
 	"subrace": PropOrder._SUBRACE,
+	"foundryRaceFeature": PropOrder._FOUNDRY_RACE_FEATURE,
 	"table": PropOrder._TABLE,
 	"trap": PropOrder._TRAP,
 	"hazard": PropOrder._HAZARD,

--- a/node/prettify-data.js
+++ b/node/prettify-data.js
@@ -26,15 +26,132 @@ const FILE_BLOCKLIST = new Set([
 	"renderdemo.json",
 	"foundry.json",
 	"makebrew-creature.json",
+
+	"index-meta.json",
+	"index-props.json",
+	"index-sources.json",
+	"index-timestamps.json",
+
+	"package.json",
+	"package-lock.json",
 ]);
 
 const _FILE_PROP_ORDER = [
 	"_meta",
 
+	"$schema",
+	"blocklist",
+
+	"adventure",
+	"adventureData",
+	"book",
+	"bookData",
+
+	"variantrule",
+	"table",
+
+	"monster",
+	"monsterFluff",
+	"foundryMonster",
+	"legendaryGroup",
+
 	"class",
+	"foundryClass",
 	"subclass",
+	"foundrySubclass",
 	"classFeature",
+	"foundryClassFeature",
 	"subclassFeature",
+	"foundrySubclassFeature",
+
+	"optionalfeature",
+
+	"spell",
+	"spellFluff",
+	"foundrySpell",
+	"roll20Spell",
+	"spellList",
+
+	"psionic",
+	"psionicDisciplineFocus",
+	"psionicDisciplineActive",
+	"action",
+
+	"baseitem",
+	"item",
+	"itemGroup",
+	"magicvariant",
+	"itemFluff",
+
+	"itemProperty",
+	"itemType",
+	"itemEntry",
+	"itemTypeAdditionalEntries",
+	"itemMastery",
+	"linkedLootTables",
+
+	"object",
+	"objectFluff",
+
+	"background",
+	"backgroundFeature",
+	"backgroundFluff",
+
+	"charoption",
+	"charoptionFluff",
+
+	"status",
+	"disease",
+	"condition",
+	"conditionFluff",
+
+	"skill",
+
+	"sense",
+
+	"cult",
+	"boon",
+
+	"deity",
+
+	"encounter",
+
+	"feat",
+	"featFluff",
+
+	"language",
+	"languageFluff",
+
+	"makebrewCreatureTrait",
+	"makebrewCreatureAction",
+	"monsterfeatures",
+	"reducedItemProperty",
+	"reducedItemType",
+
+	"name",
+
+	"race",
+	"subrace",
+	"foundryRace",
+	"foundryRaceFeature",
+	"raceFluff",
+	"raceFluffMeta",
+
+	"recipe",
+	"recipeFluff",
+
+	"reward",
+	"rewardFluff",
+
+	"trap",
+	"hazard",
+
+	"deck",
+	"card",
+
+	"vehicle",
+	"vehicleUpgrade",
+	"vehicleFluff",
 ];
 
 const KEY_BLOCKLIST = new Set(["data", "itemTypeAdditionalEntries", "itemType", "itemProperty", "itemEntry"]);
@@ -44,15 +161,21 @@ const PROPS_TO_UNHANDLED_KEYS = {};
 function getFnListSort (prop) {
 	switch (prop) {
 		case "spell":
+		case "roll20Spell":
+		case "foundrySpell":
 		case "spellList":
 		case "monster":
+		case "foundryMonster":
 		case "monsterFluff":
 		case "monsterTemplate":
+		case "makebrewCreatureTrait":
+		case "makebrewCreatureAction":
 		case "action":
 		case "background":
 		case "legendaryGroup":
 		case "language":
 		case "languageScript":
+		case "name":
 		case "condition":
 		case "disease":
 		case "status":
@@ -82,6 +205,7 @@ function getFnListSort (prop) {
 		case "rewardFluff":
 		case "variantrule":
 		case "race":
+		case "foundryRaceFeature":
 		case "table":
 		case "trap":
 		case "hazard":
@@ -98,15 +222,20 @@ function getFnListSort (prop) {
 		case "card":
 			return SortUtil.ascSortCard.bind(SortUtil);
 		case "class":
+		case "foundryClass":
 			return (a, b) => SortUtil.ascSortDateString(Parser.sourceJsonToDate(b.source), Parser.sourceJsonToDate(a.source)) || SortUtil.ascSortLower(a.name, b.name) || SortUtil.ascSortLower(a.source, b.source);
 		case "subclass":
 			return (a, b) => SortUtil.ascSortDateString(Parser.sourceJsonToDate(b.source), Parser.sourceJsonToDate(a.source)) || SortUtil.ascSortLower(a.name, b.name);
-		case "classFeature": return (a, b) => SortUtil.ascSortLower(a.classSource, b.classSource)
+		case "classFeature":
+		case "foundryClassFeature":
+			return (a, b) => SortUtil.ascSortLower(a.classSource, b.classSource)
 			|| SortUtil.ascSortLower(a.className, b.className)
 			|| SortUtil.ascSort(a.level, b.level)
 			|| SortUtil.ascSortLower(a.name, b.name)
 			|| SortUtil.ascSortLower(a.source, b.source);
-		case "subclassFeature": return (a, b) => SortUtil.ascSortLower(a.classSource, b.classSource)
+		case "subclassFeature":
+		case "foundrySubclassFeature":
+			return (a, b) => SortUtil.ascSortLower(a.classSource, b.classSource)
 			|| SortUtil.ascSortLower(a.className, b.className)
 			|| SortUtil.ascSortLower(a.subclassSource, b.subclassSource)
 			|| SortUtil.ascSortLower(a.subclassShortName, b.subclassShortName)
@@ -120,7 +249,9 @@ function getFnListSort (prop) {
 			|| SortUtil.ascSortLower(a.source, b.source);
 		case "adventure": return SortUtil.ascSortAdventure.bind(SortUtil);
 		case "book": return SortUtil.ascSortBook.bind(SortUtil);
-		case "bookData": return SortUtil.ascSortBookData.bind(SortUtil);
+		case "adventureData":
+		case "bookData":
+			return SortUtil.ascSortBookData.bind(SortUtil);
 		default: throw new Error(`Unhandled prop "${prop}"`);
 	}
 }


### PR DESCRIPTION
This is an inherently opinionated PR, however, my only opinion of consequence is that this should cover the brew properties as well. In terms of the actual order please do whatever you like.

Notes:
- The removed `fluff` line is due to `fluff` already appearing later in the same order in a more logical position.
- This includes the new `customProperties` object for items
- The file blocklist now covers the homebrew repo indexes and package files
- The `_FILE_PROP_ORDER` is now much more extensive as brew files contain all props in one.
   - The order for file props is inspired by the `homebrew.json` root schema file [homebrew.json](https://github.com/TheGiddyLimit/5etools-utils/blob/master/schema-template/homebrew.json)
- The two `_preserve` lines for `_versions` may not be necessary, please remove if not needed.