### PR TITLE
Allow entities to have a slug and prefer slug to name when searching one

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -3940,8 +3940,7 @@ globalThis.DataUtil = {
 		},
 
 		getUid (ent, {isMaintainCase = false} = {}) {
-			const {name} = ent;
-			const {slug} = ent;
+			const {name, slug} = ent;
 			const source = SourceUtil.getEntitySource(ent);
 			if (!name || !source) throw new Error(`Entity did not have a name and source!`);
 			const out = [slug || name, source].join("|");

--- a/js/utils.js
+++ b/js/utils.js
@@ -2785,7 +2785,7 @@ UrlUtil.PG_MAPS = "maps.html";
 UrlUtil.PG_SEARCH = "search.html";
 UrlUtil.PG_DECKS = "decks.html";
 
-UrlUtil.URL_TO_HASH_GENERIC = (it) => UrlUtil.encodeArrayForHash(it.name, it.source);
+UrlUtil.URL_TO_HASH_GENERIC = (it) => UrlUtil.encodeArrayForHash(it.slug || it.name, it.source);
 
 UrlUtil.URL_TO_HASH_BUILDER = {};
 UrlUtil.URL_TO_HASH_BUILDER[UrlUtil.PG_BESTIARY] = UrlUtil.URL_TO_HASH_GENERIC;
@@ -3929,7 +3929,7 @@ globalThis.DataUtil = {
 			// <name>|<source>
 			const sourceDefault = Parser.getTagSource(tag);
 			return [
-				ent.name,
+				ent.slug || ent.name,
 				(ent.source || "").toLowerCase() === sourceDefault.toLowerCase() ? "" : ent.source,
 			].join("|").replace(/\|+$/, ""); // Trim trailing pipes
 		},
@@ -3941,9 +3941,10 @@ globalThis.DataUtil = {
 
 		getUid (ent, {isMaintainCase = false} = {}) {
 			const {name} = ent;
+			const {slug} = ent;
 			const source = SourceUtil.getEntitySource(ent);
 			if (!name || !source) throw new Error(`Entity did not have a name and source!`);
-			const out = [name, source].join("|");
+			const out = [slug || name, source].join("|");
 			if (isMaintainCase) return out;
 			return out.toLowerCase();
 		},


### PR DESCRIPTION
Hello, thanks for this awesome site, truly amazing work.

Currently most entities are refer to by name. For example the spell `Mage Hand` will be refferred to in tags using `{@spell mage hand} and the URL of the Mage Hand spell is linked to it's name. 

- All tags will break if an entity is renamed  (typo, wotc change)
- it prevents sites like  https://5etools-translated.github.io to translate entity names as it would breaks all tags (tags are not translated as it is a bit risky).


The idea would be to have a slug (basically the current name lowercased) on entities and to use this to:
- get the entities from the tags
- generate the pages URLs

Looking at the code and from my understanding it could be done with small changes.
If this PR is deemed acceptable I can work on a script to add slugs to all entities.

Nicolas