### PR TITLE
Fix dwarven toughness

### DIFF
--- a/data/foundry-races.json
+++ b/data/foundry-races.json
@@ -49,9 +49,9 @@
 					"transfer": true,
 					"changes": [
 						{
-							"key": "data.attributes.hp.max",
+							"key": "system.attributes.hp.bonuses.level",
 							"mode": "ADD",
-							"value": "@details.level"
+							"value": "1"
 						}
 					]
 				}


### PR DESCRIPTION
Fix dwarven Thougness not upgrading the max HP correctly.
Note that oddly in foundry I see `system.attributes.hp.max`  (versus data) but this may be some old syntax

![image](https://github.com/5etools-mirror-1/5etools-mirror-1.github.io/assets/1089363/c2b8e8d1-53f0-4d10-87a7-5ba5d2b660ef)
