### PR TITLE
feat(maps): Add grid alignment for recent sources

### DIFF
--- a/data/adventure/adventure-gotsf.json
+++ b/data/adventure/adventure-gotsf.json
@@ -2236,6 +2236,14 @@
 											"hrefThumbnail": {
 												"type": "internal",
 												"path": "adventure/GotSF/thumbnail/000-map-0.01-star-forge.webp"
+											},
+											"grid": {
+												"type": "square",
+												"size": 180,
+												"offsetX": -7,
+												"offsetY": -2,
+												"scale": 3,
+												"distance": 10
 											}
 										},
 										{
@@ -2250,6 +2258,14 @@
 											"height": 5700,
 											"mapParent": {
 												"id": "03a"
+											},
+											"grid": {
+												"type": "square",
+												"size": 180,
+												"offsetX": -7,
+												"offsetY": -2,
+												"scale": 3,
+												"distance": 10
 											}
 										}
 									]

--- a/data/adventure/adventure-lk.json
+++ b/data/adventure/adventure-lk.json
@@ -794,6 +794,13 @@
 									"hrefThumbnail": {
 										"type": "internal",
 										"path": "adventure/LK/thumbnail/000-map-0.01-lightning-keep.webp"
+									},
+									"grid": {
+										"type": "square",
+										"size": 289,
+										"offsetX": 29,
+										"offsetY": 124,
+										"scale": 3
 									}
 								},
 								{
@@ -809,7 +816,14 @@
 									"mapParent": {
 										"id": "040"
 									},
-									"credit": "Sean Macdonald"
+									"credit": "Sean Macdonald",
+									"grid": {
+										"type": "square",
+										"size": 289,
+										"offsetX": 29,
+										"offsetY": 124,
+										"scale": 3
+									}
 								}
 							]
 						},

--- a/data/adventure/adventure-pabtso.json
+++ b/data/adventure/adventure-pabtso.json
@@ -221,7 +221,16 @@
 													"title": "Sword Coast region surrounding Phandalin",
 													"credit": "Mike Schley",
 													"width": 1700,
-													"height": 2216
+													"height": 2216,
+													"id": "4CD",
+													"grid": {
+														"type": "hexColsOdd",
+														"size": 240,
+														"offsetX": 17,
+														"offsetY": -35,
+														"scale": 3,
+														"units": "miles"
+													}
 												},
 												{
 													"type": "image",
@@ -232,7 +241,18 @@
 													"imageType": "mapPlayer",
 													"title": "Unlabeled Version",
 													"width": 1700,
-													"height": 2216
+													"height": 2216,
+													"mapParent": {
+														"id": "4CD"
+													},
+													"grid": {
+														"type": "hexColsOdd",
+														"size": 240,
+														"offsetX": 17,
+														"offsetY": -35,
+														"scale": 3,
+														"units": "miles"
+													}
 												}
 											]
 										}
@@ -654,7 +674,14 @@
 											"credit": "Mike Schley",
 											"width": 1002,
 											"height": 1369,
-											"id": "49b"
+											"id": "49b",
+											"grid": {
+												"type": "square",
+												"size": 150,
+												"offsetX": 84,
+												"offsetY": 31,
+												"scale": 3
+											}
 										},
 										{
 											"type": "image",
@@ -669,7 +696,14 @@
 											"mapParent": {
 												"id": "49b"
 											},
-											"credit": "Mike Schley"
+											"credit": "Mike Schley",
+											"grid": {
+												"type": "square",
+												"size": 150,
+												"offsetX": 84,
+												"offsetY": 31,
+												"scale": 3
+											}
 										}
 									]
 								},
@@ -3652,6 +3686,13 @@
 											"hrefThumbnail": {
 												"type": "internal",
 												"path": "adventure/PaBTSO/thumbnail/012-map-1.02-cragmaw-hideout.webp"
+											},
+											"grid": {
+												"type": "square",
+												"size": 213,
+												"offsetX": 17,
+												"offsetY": 160,
+												"scale": 3
 											}
 										},
 										{
@@ -3667,7 +3708,14 @@
 											"mapParent": {
 												"id": "49c"
 											},
-											"credit": "Mike Schley"
+											"credit": "Mike Schley",
+											"grid": {
+												"type": "square",
+												"size": 213,
+												"offsetX": 17,
+												"offsetY": 160,
+												"scale": 3
+											}
 										}
 									]
 								},
@@ -4714,6 +4762,11 @@
 									"hrefThumbnail": {
 										"type": "internal",
 										"path": "adventure/PaBTSO/thumbnail/018-map-2.01-phandalin.webp"
+									},
+									"grid": {
+										"type": "none",
+										"size": 90,
+										"distance": 50
 									}
 								},
 								{
@@ -4729,7 +4782,12 @@
 									"mapParent": {
 										"id": "49d"
 									},
-									"credit": "Mike Schley"
+									"credit": "Mike Schley",
+									"grid": {
+										"type": "none",
+										"size": 90,
+										"distance": 50
+									}
 								}
 							]
 						},
@@ -5943,6 +6001,13 @@
 											"hrefThumbnail": {
 												"type": "internal",
 												"path": "adventure/PaBTSO/thumbnail/027-map-2.02-redbrand-hideout.webp"
+											},
+											"grid": {
+												"type": "square",
+												"size": 212,
+												"offsetX": -63,
+												"offsetY": -25,
+												"scale": 3
 											}
 										},
 										{
@@ -5958,7 +6023,14 @@
 											"mapParent": {
 												"id": "49e"
 											},
-											"credit": "Mike Schley"
+											"credit": "Mike Schley",
+											"grid": {
+												"type": "square",
+												"size": 212,
+												"offsetX": -63,
+												"offsetY": -25,
+												"scale": 3
+											}
 										}
 									]
 								},
@@ -6798,7 +6870,14 @@
 							"credit": "Mike Schley",
 							"width": 1002,
 							"height": 1369,
-							"imageType": "map"
+							"imageType": "map",
+							"grid": {
+								"type": "square",
+								"size": 167,
+								"offsetX": 74,
+								"offsetY": 53,
+								"scale": 3
+							}
 						},
 						"Twelve {@creature Zombie||zombies} lurk inside the crumbled shell of the old watchtower and can't be seen from outside. However, any character who succeeds on a DC 15 Wisdom ({@skill Perception}) check smells a deathly odor wafting from the tower's direction.",
 						"When characters approach the tower or the tent, the zombies shamble from the tower. If a battle breaks out, Hamun Kost, a human {@creature mage}, emerges from his tent and asks, \"What is the meaning of this?\"",
@@ -7330,6 +7409,13 @@
 											"hrefThumbnail": {
 												"type": "internal",
 												"path": "adventure/PaBTSO/thumbnail/037-map-3.02-ruins-of-thundertree.webp"
+											},
+											"grid": {
+												"type": "square",
+												"size": 105,
+												"offsetX": 29,
+												"offsetY": 77,
+												"scale": 3
 											}
 										},
 										{
@@ -7345,7 +7431,14 @@
 											"mapParent": {
 												"id": "49f"
 											},
-											"credit": "Mike Schley"
+											"credit": "Mike Schley",
+											"grid": {
+												"type": "square",
+												"size": 105,
+												"offsetX": 29,
+												"offsetY": 77,
+												"scale": 3
+											}
 										}
 									]
 								},
@@ -7748,7 +7841,14 @@
 									"credit": "Mike Schley",
 									"width": 1010,
 									"height": 1372,
-									"imageType": "map"
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 158,
+										"offsetX": 95,
+										"offsetY": 76,
+										"scale": 3
+									}
 								},
 								"The camp is depicted on map 3.3. When the characters find the camp, read the following:",
 								{
@@ -8808,6 +8908,13 @@
 											"hrefThumbnail": {
 												"type": "internal",
 												"path": "adventure/PaBTSO/thumbnail/044-map-3.04-cragmaw-castle.webp"
+											},
+											"grid": {
+												"type": "square",
+												"size": 201,
+												"offsetX": 44,
+												"offsetY": 69,
+												"scale": 3
 											}
 										},
 										{
@@ -8823,7 +8930,14 @@
 											"mapParent": {
 												"id": "4a0"
 											},
-											"credit": "Mike Schley"
+											"credit": "Mike Schley",
+											"grid": {
+												"type": "square",
+												"size": 201,
+												"offsetX": 44,
+												"offsetY": 69,
+												"scale": 3
+											}
 										}
 									]
 								},
@@ -13351,6 +13465,13 @@
 											"hrefThumbnail": {
 												"type": "internal",
 												"path": "adventure/PaBTSO/thumbnail/048-map-4.01-wave-echo-cave.webp"
+											},
+											"grid": {
+												"type": "square",
+												"size": 118,
+												"offsetX": 35,
+												"offsetY": 4,
+												"scale": 4
 											}
 										},
 										{
@@ -13366,7 +13487,14 @@
 											"mapParent": {
 												"id": "4a1"
 											},
-											"credit": "Mike Schley"
+											"credit": "Mike Schley",
+											"grid": {
+												"type": "square",
+												"size": 118,
+												"offsetX": 35,
+												"offsetY": 4,
+												"scale": 4
+											}
 										}
 									]
 								},
@@ -14395,7 +14523,14 @@
 													"credit": "Mike Schley",
 													"width": 1002,
 													"height": 1369,
-													"id": "4a2"
+													"id": "4a2",
+													"grid": {
+														"type": "square",
+														"size": 194,
+														"offsetX": 44,
+														"offsetY": 24,
+														"scale": 3
+													}
 												},
 												{
 													"type": "image",
@@ -14410,7 +14545,14 @@
 													"mapParent": {
 														"id": "4a2"
 													},
-													"credit": "Mike Schley"
+													"credit": "Mike Schley",
+													"grid": {
+														"type": "square",
+														"size": 194,
+														"offsetX": 44,
+														"offsetY": 24,
+														"scale": 3
+													}
 												}
 											]
 										},
@@ -14538,7 +14680,14 @@
 											"credit": "Mike Schley",
 											"width": 1010,
 											"height": 1372,
-											"imageType": "map"
+											"imageType": "map",
+											"grid": {
+												"type": "square",
+												"size": 150,
+												"offsetX": -62,
+												"offsetY": 33,
+												"scale": 3
+											}
 										},
 										"The makeshift camp, shown on map 5.2, consists of a few tents and a small fire. The camp is situated in the center of a small clearing. As the characters approach the camp, they overhear one of the goblins complaining about their leader in Common:",
 										{
@@ -14638,7 +14787,14 @@
 															"credit": "Mike Schley",
 															"width": 1002,
 															"height": 1369,
-															"id": "4a3"
+															"id": "4a3",
+															"grid": {
+																"type": "square",
+																"size": 188,
+																"offsetX": -90,
+																"offsetY": -102,
+																"scale": 3
+															}
 														},
 														{
 															"type": "image",
@@ -14653,7 +14809,14 @@
 															"mapParent": {
 																"id": "4a3"
 															},
-															"credit": "Mike Schley"
+															"credit": "Mike Schley",
+															"grid": {
+																"type": "square",
+																"size": 188,
+																"offsetX": -90,
+																"offsetY": -102,
+																"scale": 3
+															}
 														}
 													]
 												}
@@ -14828,7 +14991,14 @@
 													"credit": "Mike Schley",
 													"width": 1002,
 													"height": 1369,
-													"id": "4a4"
+													"id": "4a4",
+													"grid": {
+														"type": "square",
+														"size": 162,
+														"offsetX": -36,
+														"offsetY": -48,
+														"scale": 3
+													}
 												},
 												{
 													"type": "image",
@@ -14843,7 +15013,14 @@
 													"mapParent": {
 														"id": "4a4"
 													},
-													"credit": "Mike Schley"
+													"credit": "Mike Schley",
+													"grid": {
+														"type": "square",
+														"size": 162,
+														"offsetX": -36,
+														"offsetY": -48,
+														"scale": 3
+													}
 												}
 											]
 										},
@@ -17413,6 +17590,13 @@
 											"hrefThumbnail": {
 												"type": "internal",
 												"path": "adventure/PaBTSO/thumbnail/069-map-5.05-zorzulas-rest.webp"
+											},
+											"grid": {
+												"type": "square",
+												"size": 189,
+												"offsetX": 79,
+												"offsetY": 60,
+												"scale": 3
 											}
 										},
 										{
@@ -17428,7 +17612,14 @@
 											"mapParent": {
 												"id": "4a5"
 											},
-											"credit": "Mike Schley"
+											"credit": "Mike Schley",
+											"grid": {
+												"type": "square",
+												"size": 189,
+												"offsetX": 79,
+												"offsetY": 60,
+												"scale": 3
+											}
 										}
 									]
 								},
@@ -18071,7 +18262,14 @@
 											"credit": "Mike Schley",
 											"width": 1010,
 											"height": 1372,
-											"id": "4a6"
+											"id": "4a6",
+											"grid": {
+												"type": "square",
+												"size": 143,
+												"offsetX": 4,
+												"offsetY": 55,
+												"scale": 3
+											}
 										},
 										{
 											"type": "image",
@@ -18086,7 +18284,14 @@
 											"mapParent": {
 												"id": "4a6"
 											},
-											"credit": "Mike Schley"
+											"credit": "Mike Schley",
+											"grid": {
+												"type": "square",
+												"size": 143,
+												"offsetX": 4,
+												"offsetY": 55,
+												"scale": 3
+											}
 										}
 									]
 								},
@@ -18305,7 +18510,10 @@
 									"credit": "Hex Sharpe",
 									"width": 1173,
 									"height": 1626,
-									"imageType": "map"
+									"imageType": "map",
+									"grid": {
+										"type": "none"
+									}
 								},
 								"The characters learned in {@adventure chapter 5|PaBTSO|5} about four obelisk shards around Phandalin that the Sawplee goblins gathered. The mind flayer fanatics possess these shards now, but the fanatics need as many obelisk fragments as possible to ensure their ritual will succeed.",
 								"The Sawplees' map reveals the locations of three other fragments: an abandoned dwarven temple called Talhundereth, the crypt beneath it, and a subterranean trading nexus called Gibbet Crossing. These locations are in the Starmetal Hills, several days northeast of Phandalin.",
@@ -18511,7 +18719,14 @@
 															"credit": "Mike Schley",
 															"width": 1006,
 															"height": 1372,
-															"id": "4a7"
+															"id": "4a7",
+															"grid": {
+																"type": "square",
+																"size": 322,
+																"offsetX": 55,
+																"offsetY": -79,
+																"scale": 3
+															}
 														},
 														{
 															"type": "image",
@@ -18526,7 +18741,14 @@
 															"mapParent": {
 																"id": "4a7"
 															},
-															"credit": "Mike Schley"
+															"credit": "Mike Schley",
+															"grid": {
+																"type": "square",
+																"size": 322,
+																"offsetX": 55,
+																"offsetY": -79,
+																"scale": 3
+															}
 														}
 													]
 												},
@@ -18628,7 +18850,14 @@
 													"credit": "Mike Schley",
 													"width": 1378,
 													"height": 1002,
-													"imageType": "map"
+													"imageType": "map",
+													"grid": {
+														"type": "square",
+														"size": 189,
+														"offsetX": 82,
+														"offsetY": 80,
+														"scale": 3
+													}
 												},
 												{
 													"type": "insetReadaloud",
@@ -19928,6 +20157,13 @@
 											"hrefThumbnail": {
 												"type": "internal",
 												"path": "adventure/PaBTSO/thumbnail/086-map-6.03-talhundereth.webp"
+											},
+											"grid": {
+												"type": "square",
+												"size": 339,
+												"offsetX": 105,
+												"offsetY": -100,
+												"scale": 3
 											}
 										},
 										{
@@ -19943,7 +20179,14 @@
 											"mapParent": {
 												"id": "4a8"
 											},
-											"credit": "Mike Schley"
+											"credit": "Mike Schley",
+											"grid": {
+												"type": "square",
+												"size": 339,
+												"offsetX": 105,
+												"offsetY": -100,
+												"scale": 3
+											}
 										}
 									]
 								},
@@ -22005,6 +22248,13 @@
 											"hrefThumbnail": {
 												"type": "internal",
 												"path": "adventure/PaBTSO/thumbnail/092-map-6.04-crypt-of-the-talhund.webp"
+											},
+											"grid": {
+												"type": "square",
+												"size": 125,
+												"offsetX": 77,
+												"offsetY": 51,
+												"scale": 3
 											}
 										},
 										{
@@ -22020,7 +22270,14 @@
 											"mapParent": {
 												"id": "4a9"
 											},
-											"credit": "Mike Schley"
+											"credit": "Mike Schley",
+											"grid": {
+												"type": "square",
+												"size": 125,
+												"offsetX": 77,
+												"offsetY": 51,
+												"scale": 3
+											}
 										}
 									]
 								},
@@ -27457,6 +27714,13 @@
 											"hrefThumbnail": {
 												"type": "internal",
 												"path": "adventure/PaBTSO/thumbnail/098-map-6.05-gibbet-crossing.webp"
+											},
+											"grid": {
+												"type": "square",
+												"size": 121,
+												"offsetX": -17,
+												"offsetY": -35,
+												"scale": 4
 											}
 										},
 										{
@@ -27472,7 +27736,14 @@
 											"mapParent": {
 												"id": "4aa"
 											},
-											"credit": "Mike Schley"
+											"credit": "Mike Schley",
+											"grid": {
+												"type": "square",
+												"size": 121,
+												"offsetX": -17,
+												"offsetY": -35,
+												"scale": 4
+											}
 										}
 									]
 								},
@@ -30696,6 +30967,13 @@
 											"hrefThumbnail": {
 												"type": "internal",
 												"path": "adventure/PaBTSO/thumbnail/106-map-7.01-tunnels-of-the-deep.webp"
+											},
+											"grid": {
+												"type": "square",
+												"size": 121,
+												"offsetX": -14,
+												"offsetY": -32,
+												"scale": 3
 											}
 										},
 										{
@@ -30711,7 +30989,14 @@
 											"mapParent": {
 												"id": "4ab"
 											},
-											"credit": "Mike Schley"
+											"credit": "Mike Schley",
+											"grid": {
+												"type": "square",
+												"size": 121,
+												"offsetX": -14,
+												"offsetY": -32,
+												"scale": 3
+											}
 										}
 									]
 								},
@@ -32323,6 +32608,13 @@
 											"hrefThumbnail": {
 												"type": "internal",
 												"path": "adventure/PaBTSO/thumbnail/111-map-7.02-illithinoch.webp"
+											},
+											"grid": {
+												"type": "square",
+												"size": 193,
+												"offsetX": -58,
+												"offsetY": 56,
+												"scale": 3
 											}
 										},
 										{
@@ -32338,7 +32630,14 @@
 											"mapParent": {
 												"id": "4ac"
 											},
-											"credit": "Mike Schley"
+											"credit": "Mike Schley",
+											"grid": {
+												"type": "square",
+												"size": 193,
+												"offsetX": -58,
+												"offsetY": 56,
+												"scale": 3
+											}
 										}
 									]
 								},
@@ -33673,6 +33972,13 @@
 											"hrefThumbnail": {
 												"type": "internal",
 												"path": "adventure/PaBTSO/thumbnail/119-map-7.03-feeder-trenches.webp"
+											},
+											"grid": {
+												"type": "square",
+												"size": 200,
+												"offsetX": 64,
+												"offsetY": 93,
+												"scale": 3
 											}
 										},
 										{
@@ -33688,7 +33994,14 @@
 											"mapParent": {
 												"id": "4ad"
 											},
-											"credit": "Mike Schley"
+											"credit": "Mike Schley",
+											"grid": {
+												"type": "square",
+												"size": 200,
+												"offsetX": 64,
+												"offsetY": 93,
+												"scale": 3
+											}
 										}
 									]
 								},
@@ -35633,6 +35946,13 @@
 											"hrefThumbnail": {
 												"type": "internal",
 												"path": "adventure/PaBTSO/thumbnail/121-map-7.04-spawn-hollow.webp"
+											},
+											"grid": {
+												"type": "square",
+												"size": 181,
+												"offsetX": 79,
+												"offsetY": 94,
+												"scale": 3
 											}
 										},
 										{
@@ -35648,7 +35968,14 @@
 											"mapParent": {
 												"id": "4ae"
 											},
-											"credit": "Mike Schley"
+											"credit": "Mike Schley",
+											"grid": {
+												"type": "square",
+												"size": 181,
+												"offsetX": 79,
+												"offsetY": 94,
+												"scale": 3
+											}
 										}
 									]
 								},
@@ -36091,6 +36418,12 @@
 											"hrefThumbnail": {
 												"type": "internal",
 												"path": "adventure/PaBTSO/thumbnail/123-map-7.05-labyrinth-of-eyes.webp"
+											},
+											"grid": {
+												"type": "square",
+												"offsetX": 17,
+												"offsetY": 81,
+												"scale": 3
 											}
 										},
 										{
@@ -36106,7 +36439,13 @@
 											"mapParent": {
 												"id": "4af"
 											},
-											"credit": "Mike Schley"
+											"credit": "Mike Schley",
+											"grid": {
+												"type": "square",
+												"offsetX": 17,
+												"offsetY": 81,
+												"scale": 3
+											}
 										}
 									]
 								},
@@ -36533,6 +36872,12 @@
 															"hrefThumbnail": {
 																"type": "internal",
 																"path": "adventure/PaBTSO/thumbnail/125-map-7.06-labyrinth-of-eyes-alternate-configuration.webp"
+															},
+															"grid": {
+																"type": "square",
+																"offsetX": 17,
+																"offsetY": 81,
+																"scale": 3
 															}
 														},
 														{
@@ -36548,7 +36893,13 @@
 															"mapParent": {
 																"id": "4b0"
 															},
-															"credit": "Mike Schley"
+															"credit": "Mike Schley",
+															"grid": {
+																"type": "square",
+																"offsetX": 17,
+																"offsetY": 81,
+																"scale": 3
+															}
 														}
 													]
 												}
@@ -40618,6 +40969,11 @@
 											"hrefThumbnail": {
 												"type": "internal",
 												"path": "adventure/PaBTSO/thumbnail/130-map-8.01-briny-maze.webp"
+											},
+											"grid": {
+												"type": "square",
+												"size": 94,
+												"scale": 3
 											}
 										},
 										{
@@ -40633,7 +40989,12 @@
 											"mapParent": {
 												"id": "4b2"
 											},
-											"credit": "Mike Schley"
+											"credit": "Mike Schley",
+											"grid": {
+												"type": "square",
+												"size": 94,
+												"scale": 3
+											}
 										}
 									]
 								},
@@ -41597,7 +41958,14 @@
 									"credit": "Mike Schley",
 									"width": 1002,
 									"height": 1369,
-									"imageType": "map"
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 90,
+										"offsetX": -28,
+										"offsetY": -15,
+										"scale": 3
+									}
 								},
 								{
 									"type": "insetReadaloud",
@@ -41679,7 +42047,14 @@
 									"credit": "Mike Schley",
 									"width": 1010,
 									"height": 1372,
-									"imageType": "map"
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 90,
+										"offsetX": -15,
+										"offsetY": -17,
+										"scale": 3
+									}
 								},
 								{
 									"type": "insetReadaloud",
@@ -42016,6 +42391,13 @@
 											"hrefThumbnail": {
 												"type": "internal",
 												"path": "adventure/PaBTSO/thumbnail/139-map-8.04-mire-of-doubt.webp"
+											},
+											"grid": {
+												"type": "square",
+												"size": 115,
+												"offsetX": -9,
+												"offsetY": -17,
+												"scale": 4
 											}
 										},
 										{
@@ -42031,7 +42413,14 @@
 											"mapParent": {
 												"id": "4b3"
 											},
-											"credit": "Mike Schley"
+											"credit": "Mike Schley",
+											"grid": {
+												"type": "square",
+												"size": 115,
+												"offsetX": -9,
+												"offsetY": -17,
+												"scale": 4
+											}
 										}
 									]
 								},
@@ -42633,6 +43022,13 @@
 											"hrefThumbnail": {
 												"type": "internal",
 												"path": "adventure/PaBTSO/thumbnail/141-map-8.05-the-nematode.webp"
+											},
+											"grid": {
+												"type": "square",
+												"size": 115,
+												"offsetX": 7,
+												"offsetY": -17,
+												"scale": 4
 											}
 										},
 										{
@@ -42648,7 +43044,14 @@
 											"mapParent": {
 												"id": "4b4"
 											},
-											"credit": "Mike Schley"
+											"credit": "Mike Schley",
+											"grid": {
+												"type": "square",
+												"size": 115,
+												"offsetX": 7,
+												"offsetY": -17,
+												"scale": 4
+											}
 										}
 									]
 								},
@@ -42788,7 +43191,14 @@
 									"credit": "Mike Schley",
 									"width": 1002,
 									"height": 1369,
-									"imageType": "map"
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 106,
+										"offsetX": 37,
+										"offsetY": 49,
+										"scale": 4
+									}
 								},
 								{
 									"type": "insetReadaloud",
@@ -42832,7 +43242,14 @@
 									"credit": "Mike Schley",
 									"width": 1010,
 									"height": 1373,
-									"imageType": "map"
+									"imageType": "map",
+									"grid": {
+										"type": "square",
+										"size": 121,
+										"offsetX": 16,
+										"offsetY": 14,
+										"scale": 4
+									}
 								},
 								{
 									"type": "insetReadaloud",
@@ -42977,6 +43394,12 @@
 											"hrefThumbnail": {
 												"type": "internal",
 												"path": "adventure/PaBTSO/thumbnail/145-map-8.08-wailing-battlefield.webp"
+											},
+											"grid": {
+												"type": "square",
+												"size": 109,
+												"offsetY": -60,
+												"scale": 4
 											}
 										},
 										{
@@ -42992,7 +43415,13 @@
 											"mapParent": {
 												"id": "4b5"
 											},
-											"credit": "Mike Schley"
+											"credit": "Mike Schley",
+											"grid": {
+												"type": "square",
+												"size": 109,
+												"offsetY": -60,
+												"scale": 4
+											}
 										}
 									]
 								},
@@ -44484,6 +44913,13 @@
 											"hrefThumbnail": {
 												"type": "internal",
 												"path": "adventure/PaBTSO/thumbnail/147-map-8.09-ilvaashs-anima.webp"
+											},
+											"grid": {
+												"type": "square",
+												"size": 165,
+												"offsetX": -44,
+												"offsetY": -65,
+												"scale": 4
 											}
 										},
 										{
@@ -44499,7 +44935,14 @@
 											"mapParent": {
 												"id": "4b6"
 											},
-											"credit": "Mike Schley"
+											"credit": "Mike Schley",
+											"grid": {
+												"type": "square",
+												"size": 165,
+												"offsetX": -44,
+												"offsetY": -65,
+												"scale": 4
+											}
 										}
 									]
 								},

--- a/data/adventure/adventure-tofw.json
+++ b/data/adventure/adventure-tofw.json
@@ -497,7 +497,14 @@
 											"credit": "Marco Bernardini",
 											"width": 2550,
 											"height": 1650,
-											"id": "225"
+											"id": "225",
+											"grid": {
+												"type": "square",
+												"size": 200,
+												"offsetX": 65,
+												"offsetY": -86,
+												"scale": 3
+											}
 										},
 										{
 											"type": "image",
@@ -512,7 +519,14 @@
 											"mapParent": {
 												"id": "225"
 											},
-											"credit": "Marco Bernardini"
+											"credit": "Marco Bernardini",
+											"grid": {
+												"type": "square",
+												"size": 200,
+												"offsetX": 65,
+												"offsetY": -86,
+												"scale": 3
+											}
 										}
 									]
 								},
@@ -1159,7 +1173,14 @@
 													"credit": "Mike Schley",
 													"width": 1200,
 													"height": 1500,
-													"id": "226"
+													"id": "226",
+													"grid": {
+														"type": "square",
+														"size": 123,
+														"offsetX": 93,
+														"offsetY": 79,
+														"scale": 2
+													}
 												},
 												{
 													"type": "image",
@@ -1174,7 +1195,14 @@
 													"mapParent": {
 														"id": "226"
 													},
-													"credit": "Mike Schley"
+													"credit": "Mike Schley",
+													"grid": {
+														"type": "square",
+														"size": 123,
+														"offsetX": 93,
+														"offsetY": 79,
+														"scale": 2
+													}
 												}
 											]
 										},
@@ -1452,7 +1480,14 @@
 											"credit": "Jared Blando",
 											"width": 2550,
 											"height": 1650,
-											"id": "227"
+											"id": "227",
+											"grid": {
+												"type": "square",
+												"size": 171,
+												"offsetX": 4,
+												"offsetY": 22,
+												"scale": 3
+											}
 										},
 										{
 											"type": "image",
@@ -1467,7 +1502,14 @@
 											"mapParent": {
 												"id": "227"
 											},
-											"credit": "Jared Blando"
+											"credit": "Jared Blando",
+											"grid": {
+												"type": "square",
+												"size": 171,
+												"offsetX": 4,
+												"offsetY": 22,
+												"scale": 3
+											}
 										}
 									]
 								},
@@ -2330,7 +2372,14 @@
 											"credit": "Marco Bernardini",
 											"width": 2550,
 											"height": 3300,
-											"id": "228"
+											"id": "228",
+											"grid": {
+												"type": "square",
+												"size": 210,
+												"offsetX": 45,
+												"offsetY": 38,
+												"scale": 3
+											}
 										},
 										{
 											"type": "image",
@@ -2345,7 +2394,14 @@
 											"mapParent": {
 												"id": "228"
 											},
-											"credit": "Marco Bernardini"
+											"credit": "Marco Bernardini",
+											"grid": {
+												"type": "square",
+												"size": 210,
+												"offsetX": 45,
+												"offsetY": 38,
+												"scale": 3
+											}
 										}
 									]
 								},
@@ -2954,7 +3010,14 @@
 											"credit": "Mike Schley",
 											"width": 1200,
 											"height": 1500,
-											"id": "229"
+											"id": "229",
+											"grid": {
+												"type": "square",
+												"size": 163,
+												"offsetX": 5,
+												"offsetY": -31,
+												"scale": 3
+											}
 										},
 										{
 											"type": "image",
@@ -2969,7 +3032,14 @@
 											"mapParent": {
 												"id": "229"
 											},
-											"credit": "Mike Schley"
+											"credit": "Mike Schley",
+											"grid": {
+												"type": "square",
+												"size": 162,
+												"offsetX": 15,
+												"offsetY": -18,
+												"scale": 3
+											}
 										}
 									]
 								},
@@ -3334,7 +3404,14 @@
 													"credit": "Mike Schley",
 													"width": 1200,
 													"height": 1500,
-													"id": "22a"
+													"id": "22a",
+													"grid": {
+														"type": "square",
+														"size": 146,
+														"offsetX": -24,
+														"offsetY": -15,
+														"scale": 3
+													}
 												},
 												{
 													"type": "image",
@@ -3349,7 +3426,14 @@
 													"mapParent": {
 														"id": "22a"
 													},
-													"credit": "Mike Schley"
+													"credit": "Mike Schley",
+													"grid": {
+														"type": "square",
+														"size": 146,
+														"offsetX": -24,
+														"offsetY": -15,
+														"scale": 3
+													}
 												}
 											]
 										}
@@ -4025,7 +4109,14 @@
 													"credit": "Mike Schley",
 													"width": 1200,
 													"height": 1500,
-													"id": "22b"
+													"id": "22b",
+													"grid": {
+														"type": "square",
+														"size": 144,
+														"offsetX": -70,
+														"offsetY": -50,
+														"scale": 3
+													}
 												},
 												{
 													"type": "image",
@@ -4040,7 +4131,14 @@
 													"mapParent": {
 														"id": "22b"
 													},
-													"credit": "Mike Schley"
+													"credit": "Mike Schley",
+													"grid": {
+														"type": "square",
+														"size": 144,
+														"offsetX": -70,
+														"offsetY": -50,
+														"scale": 3
+													}
 												}
 											]
 										}
@@ -4387,7 +4485,14 @@
 									"title": "Map 9.1: Courier",
 									"credit": "Mike Schley",
 									"width": 1200,
-									"height": 1500
+									"height": 1500,
+									"grid": {
+										"type": "square",
+										"size": 181,
+										"offsetX": 58,
+										"offsetY": -57,
+										"scale": 3.42
+									}
 								},
 								{
 									"type": "entries",
@@ -4636,7 +4741,14 @@
 											"credit": "Mike Schley",
 											"width": 1200,
 											"height": 1500,
-											"id": "22c"
+											"id": "22c",
+											"grid": {
+												"type": "square",
+												"size": 178,
+												"offsetX": 18,
+												"offsetY": 4,
+												"scale": 3
+											}
 										},
 										{
 											"type": "image",
@@ -4651,7 +4763,14 @@
 											"mapParent": {
 												"id": "22c"
 											},
-											"credit": "Mike Schley"
+											"credit": "Mike Schley",
+											"grid": {
+												"type": "square",
+												"size": 178,
+												"offsetX": 18,
+												"offsetY": 4,
+												"scale": 3
+											}
 										}
 									]
 								},
@@ -5153,8 +5272,7 @@
 											"title": "{@creature Shariel|ToFW}, Star Player of the Righteous Hands",
 											"credit": "Nikki Dawes",
 											"width": 850,
-											"height": 1532,
-											"imageType": "mapPlayer"
+											"height": 1532
 										},
 										"Spireball takes place on a flat, triangular diamond surrounded by a ringed field. Three low pedestals at each of the triangle's points serve as bases. The last of these, where batters take their swings, is known as home plate. During the game, batters navigate these bases in order from home plate to first base, first base to second base, and second base back to home plate. The game has the following rules."
 									]
@@ -6138,7 +6256,14 @@
 											"credit": "Jared Blando",
 											"width": 2550,
 											"height": 3300,
-											"id": "22d"
+											"id": "22d",
+											"grid": {
+												"type": "square",
+												"size": 104,
+												"offsetX": -26,
+												"offsetY": -8,
+												"scale": 3
+											}
 										},
 										{
 											"type": "image",
@@ -6153,7 +6278,14 @@
 											"mapParent": {
 												"id": "22d"
 											},
-											"credit": "Jared Blando"
+											"credit": "Jared Blando",
+											"grid": {
+												"type": "square",
+												"size": 104,
+												"offsetX": -26,
+												"offsetY": -8,
+												"scale": 3
+											}
 										}
 									]
 								},
@@ -6940,7 +7072,14 @@
 													"credit": "Jared Blando",
 													"width": 2550,
 													"height": 3300,
-													"id": "22e"
+													"id": "22e",
+													"grid": {
+														"type": "square",
+														"size": 219,
+														"offsetX": 50,
+														"offsetY": -72,
+														"scale": 3
+													}
 												},
 												{
 													"type": "image",
@@ -6955,7 +7094,14 @@
 													"mapParent": {
 														"id": "22e"
 													},
-													"credit": "Jared Blando"
+													"credit": "Jared Blando",
+													"grid": {
+														"type": "square",
+														"size": 219,
+														"offsetX": 50,
+														"offsetY": -72,
+														"scale": 3
+													}
 												}
 											]
 										}

--- a/data/book/book-aatm.json
+++ b/data/book/book-aatm.json
@@ -488,7 +488,14 @@
 													"credit": "Marco Bernardini",
 													"width": 3840,
 													"height": 2160,
-													"id": "032"
+													"id": "032",
+													"grid": {
+														"type": "square",
+														"size": 232,
+														"offsetX": 42,
+														"offsetY": -19,
+														"scale": 3
+													}
 												},
 												{
 													"type": "image",
@@ -503,7 +510,14 @@
 													"mapParent": {
 														"id": "032"
 													},
-													"credit": "Marco Bernardini"
+													"credit": "Marco Bernardini",
+													"grid": {
+														"type": "square",
+														"size": 232,
+														"offsetX": 42,
+														"offsetY": -19,
+														"scale": 3
+													}
 												}
 											]
 										},
@@ -593,7 +607,14 @@
 													"credit": "Jared Blando",
 													"width": 3400,
 													"height": 4400,
-													"id": "033"
+													"id": "033",
+													"grid": {
+														"type": "square",
+														"size": 180,
+														"offsetX": 41,
+														"offsetY": 7,
+														"scale": 3
+													}
 												},
 												{
 													"type": "image",
@@ -608,7 +629,14 @@
 													"mapParent": {
 														"id": "033"
 													},
-													"credit": "Jared Blando"
+													"credit": "Jared Blando",
+													"grid": {
+														"type": "square",
+														"size": 180,
+														"offsetX": 41,
+														"offsetY": 7,
+														"scale": 3
+													}
 												}
 											]
 										},
@@ -673,7 +701,14 @@
 													"credit": "Marco Bernardini",
 													"width": 3840,
 													"height": 2160,
-													"id": "034"
+													"id": "034",
+													"grid": {
+														"type": "square",
+														"size": 232,
+														"offsetX": 74,
+														"offsetY": -124,
+														"scale": 3
+													}
 												},
 												{
 													"type": "image",
@@ -688,7 +723,14 @@
 													"mapParent": {
 														"id": "034"
 													},
-													"credit": "Marco Bernardini"
+													"credit": "Marco Bernardini",
+													"grid": {
+														"type": "square",
+														"size": 232,
+														"offsetX": 74,
+														"offsetY": -124,
+														"scale": 3
+													}
 												}
 											]
 										},
@@ -790,7 +832,14 @@
 											"title": "Map 1.4: Factol Skall's Orrery",
 											"credit": "Jared Blando",
 											"width": 3400,
-											"height": 4400
+											"height": 4400,
+											"grid": {
+												"type": "square",
+												"size": 162,
+												"offsetX": 62,
+												"offsetY": -26,
+												"scale": 3
+											}
 										},
 										"{@creature Factol Skall|AATM} (see the {@area appendix|02e|x}) has repeatedly used the orrery, which has attracted the spirit of a dead and vengeful god (use the {@creature planar incarnate|MPP} stat block; see the {@area appendix|031|x}). The spirit bursts forth from the orrery and attacks the characters.",
 										"Skall aids the characters in combat against the spirit but withholds his more potent abilities unless the characters are about to be defeated. If the spirit is reduced to 0 hit points, it is sucked back into the orrery and sent back to the plane from whence it came.",
@@ -852,7 +901,14 @@
 													"credit": "Jared Blando",
 													"width": 3400,
 													"height": 4400,
-													"id": "035"
+													"id": "035",
+													"grid": {
+														"type": "square",
+														"size": 126,
+														"offsetX": 33,
+														"offsetY": 18,
+														"scale": 3
+													}
 												},
 												{
 													"type": "image",
@@ -867,7 +923,14 @@
 													"mapParent": {
 														"id": "035"
 													},
-													"credit": "Jared Blando"
+													"credit": "Jared Blando",
+													"grid": {
+														"type": "square",
+														"size": 126,
+														"offsetX": 33,
+														"offsetY": 18,
+														"scale": 3
+													}
 												}
 											]
 										}

--- a/data/book/book-bgg.json
+++ b/data/book/book-bgg.json
@@ -4336,7 +4336,16 @@
 											"credit": "Dyson Logos",
 											"width": 4200,
 											"height": 5700,
-											"id": "016"
+											"id": "016",
+											"grid": {
+												"type": "hexColsOdd",
+												"size": 799,
+												"offsetX": -426,
+												"offsetY": 81,
+												"scale": 2,
+												"distance": 6,
+												"units": "miles"
+											}
 										},
 										{
 											"type": "image",
@@ -4351,7 +4360,16 @@
 											"mapParent": {
 												"id": "016"
 											},
-											"credit": "Dyson Logos"
+											"credit": "Dyson Logos",
+											"grid": {
+												"type": "hexColsOdd",
+												"size": 799,
+												"offsetX": -426,
+												"offsetY": 81,
+												"scale": 2,
+												"distance": 6,
+												"units": "miles"
+											}
 										}
 									]
 								},
@@ -4475,7 +4493,15 @@
 											"credit": "Dyson Logos",
 											"width": 4200,
 											"height": 5700,
-											"id": "017"
+											"id": "017",
+											"grid": {
+												"type": "square",
+												"size": 274,
+												"offsetX": -13,
+												"offsetY": 56,
+												"scale": 3,
+												"distance": 10
+											}
 										},
 										{
 											"type": "image",
@@ -4490,7 +4516,15 @@
 											"mapParent": {
 												"id": "017"
 											},
-											"credit": "Dyson Logos"
+											"credit": "Dyson Logos",
+											"grid": {
+												"type": "square",
+												"size": 274,
+												"offsetX": -13,
+												"offsetY": 56,
+												"scale": 3,
+												"distance": 10
+											}
 										}
 									]
 								},
@@ -4623,7 +4657,14 @@
 									"title": "Map 4.3: Dreamer's Reach",
 									"credit": "Dyson Logos",
 									"width": 4177,
-									"height": 5214
+									"height": 5214,
+									"grid": {
+										"type": "square",
+										"size": 263,
+										"offsetX": -81,
+										"scale": 3,
+										"distance": 10
+									}
 								},
 								"The mound around the stone fingers has been smoothed to a circular plateau. Giant-sized shelters are carved into the sides of the plateau, and several free-standing structures made of fitted stones surround the mound. Map 4.3 depicts Dreamer's Reach, including the following features:",
 								{
@@ -4741,7 +4782,15 @@
 									"title": "Map 4.4: Endless Rockslide",
 									"credit": "Dyson Logos",
 									"width": 4179,
-									"height": 5222
+									"height": 5222,
+									"grid": {
+										"type": "square",
+										"size": 263,
+										"offsetX": -36,
+										"offsetY": -48,
+										"scale": 3,
+										"distance": 10
+									}
 								},
 								"The Endless Rockslide plunges down the mountainside with tremendous force and thunderous sound. Creatures within 100 feet of the earth slide make ability checks that require hearing with disadvantage. A creature that starts its turn in the rockslide must make a DC 20 Strength saving throw. On a failed save, the creature descends 200 feet and takes 33 ({@dice 6d10}) bludgeoning damage. On a successful save, it takes half as much damage and can grab a stable handhold within reach to avoid descending. After descending 1,000 feet from the rockslide's origin, the creature passes through a permanent portal to the Plane of Earth. A creature with a burrow speed can use that speed to move in the slide, has advantage on the saving throw, and takes half damage on a failed save and no damage on a successful save. A creature with the Earth Glide trait automatically succeeds on the saving throw. The source of the slide is also a permanent portal to the Plane of Earth.",
 								"Map 4.4 shows the following features surrounding the Endless Rockslide:",
@@ -4859,7 +4908,15 @@
 									"title": "Map 4.5: Forest Crystal",
 									"credit": "Dyson Logos",
 									"width": 4137,
-									"height": 5237
+									"height": 5237,
+									"grid": {
+										"type": "square",
+										"size": 262,
+										"offsetX": 9,
+										"offsetY": -20,
+										"scale": 3,
+										"distance": 10
+									}
 								},
 								"Map 4.5 depicts the forest crystal and its surrounding glade, including the following features:",
 								{
@@ -4982,7 +5039,15 @@
 											"credit": "Dyson Logos",
 											"width": 4179,
 											"height": 5665,
-											"id": "018"
+											"id": "018",
+											"grid": {
+												"type": "square",
+												"size": 225,
+												"offsetX": -26,
+												"offsetY": -18,
+												"scale": 3,
+												"distance": 10
+											}
 										},
 										{
 											"type": "image",
@@ -4997,7 +5062,15 @@
 											"mapParent": {
 												"id": "018"
 											},
-											"credit": "Dyson Logos"
+											"credit": "Dyson Logos",
+											"grid": {
+												"type": "square",
+												"size": 225,
+												"offsetX": -26,
+												"offsetY": -18,
+												"scale": 3,
+												"distance": 10
+											}
 										}
 									]
 								},
@@ -5118,7 +5191,15 @@
 									"title": "Map 4.7: Gale's Eye Tower",
 									"credit": "Dyson Logos",
 									"width": 4137,
-									"height": 5451
+									"height": 5451,
+									"grid": {
+										"type": "square",
+										"size": 263,
+										"offsetX": 71,
+										"offsetY": 112,
+										"scale": 3,
+										"distance": 10
+									}
 								},
 								"Map 4.7 depicts Gale's Eye Tower, including the following features:",
 								{
@@ -5237,7 +5318,15 @@
 									"title": "Map 4.8: Grolantor's Larder",
 									"credit": "Dyson Logos",
 									"width": 4179,
-									"height": 5235
+									"height": 5235,
+									"grid": {
+										"type": "square",
+										"size": 261,
+										"offsetX": -19,
+										"offsetY": 84,
+										"scale": 3,
+										"distance": 10
+									}
 								},
 								"Map 4.8 depicts Grolantor's Larder, including the following features:",
 								{
@@ -5368,7 +5457,15 @@
 											"credit": "Dyson Logos",
 											"width": 4157,
 											"height": 5186,
-											"id": "019"
+											"id": "019",
+											"grid": {
+												"type": "square",
+												"size": 263,
+												"offsetX": -72,
+												"offsetY": 70,
+												"scale": 3,
+												"distance": 10
+											}
 										},
 										{
 											"type": "image",
@@ -5383,7 +5480,15 @@
 											"mapParent": {
 												"id": "019"
 											},
-											"credit": "Dyson Logos"
+											"credit": "Dyson Logos",
+											"grid": {
+												"type": "square",
+												"size": 263,
+												"offsetX": -72,
+												"offsetY": 70,
+												"scale": 3,
+												"distance": 10
+											}
 										}
 									]
 								},
@@ -5512,7 +5617,14 @@
 									"title": "Map 4.10: Horizon's Edge",
 									"credit": "Dyson Logos",
 									"width": 4200,
-									"height": 5285
+									"height": 5285,
+									"grid": {
+										"type": "square",
+										"size": 180,
+										"offsetY": 47,
+										"scale": 3,
+										"distance": 10
+									}
 								},
 								"Map 4.10 depicts Horizon's Edge, including the following features:",
 								{
@@ -5625,7 +5737,15 @@
 											"credit": "Dyson Logos",
 											"width": 4182,
 											"height": 5674,
-											"id": "01a"
+											"id": "01a",
+											"grid": {
+												"type": "square",
+												"size": 225,
+												"offsetX": 59,
+												"offsetY": -22,
+												"scale": 3,
+												"distance": 10
+											}
 										},
 										{
 											"type": "image",
@@ -5640,7 +5760,15 @@
 											"mapParent": {
 												"id": "01a"
 											},
-											"credit": "Dyson Logos"
+											"credit": "Dyson Logos",
+											"grid": {
+												"type": "square",
+												"size": 225,
+												"offsetX": 59,
+												"offsetY": -22,
+												"scale": 3,
+												"distance": 10
+											}
 										}
 									]
 								},
@@ -5790,7 +5918,14 @@
 											"credit": "Dyson Logos",
 											"width": 4200,
 											"height": 5700,
-											"id": "01b"
+											"id": "01b",
+											"grid": {
+												"type": "square",
+												"size": 263,
+												"offsetY": 8,
+												"scale": 3,
+												"distance": 10
+											}
 										},
 										{
 											"type": "image",
@@ -5805,7 +5940,15 @@
 											"mapParent": {
 												"id": "01b"
 											},
-											"credit": "Dyson Logos"
+											"credit": "Dyson Logos",
+											"grid": {
+												"type": "square",
+												"size": 263,
+												"offsetX": 8,
+												"offsetY": 3,
+												"scale": 3,
+												"distance": 10
+											}
 										}
 									]
 								},
@@ -5918,7 +6061,14 @@
 									"title": "Map 4.13: Misty Vale",
 									"credit": "Dyson Logos",
 									"width": 4200,
-									"height": 5700
+									"height": 5700,
+									"grid": {
+										"type": "square",
+										"size": 263,
+										"offsetY": -106,
+										"scale": 3,
+										"distance": 10
+									}
 								},
 								"Map 4.13 shows the Misty Vale, including the following features:",
 								{
@@ -6034,7 +6184,15 @@
 									"title": "Map 4.14: Runic Circle",
 									"credit": "Dyson Logos",
 									"width": 4179,
-									"height": 5242
+									"height": 5242,
+									"grid": {
+										"type": "square",
+										"size": 263,
+										"offsetX": -27,
+										"offsetY": -58,
+										"scale": 3,
+										"distance": 10
+									}
 								},
 								"Map 4.14 depicts the Runic Circle, including the following features:",
 								{
@@ -6159,7 +6317,15 @@
 											"credit": "Dyson Logos",
 											"width": 4158,
 											"height": 5354,
-											"id": "01e"
+											"id": "01e",
+											"grid": {
+												"type": "square",
+												"size": 261,
+												"offsetX": -40,
+												"offsetY": 169,
+												"scale": 3,
+												"distance": 10
+											}
 										},
 										{
 											"type": "image",
@@ -6174,7 +6340,15 @@
 											"mapParent": {
 												"id": "01e"
 											},
-											"credit": "Dyson Logos"
+											"credit": "Dyson Logos",
+											"grid": {
+												"type": "square",
+												"size": 261,
+												"offsetX": -40,
+												"offsetY": 169,
+												"scale": 3,
+												"distance": 10
+											}
 										}
 									]
 								},
@@ -6262,7 +6436,15 @@
 									"title": "Map 4.16: Star Forge",
 									"credit": "Dyson Logos",
 									"width": 4200,
-									"height": 5700
+									"height": 5700,
+									"grid": {
+										"type": "square",
+										"size": 180,
+										"offsetX": -9,
+										"offsetY": -1,
+										"scale": 3,
+										"distance": 10
+									}
 								},
 								"Map 4.16 shows the Star Forge, including the following features:",
 								{
@@ -6410,7 +6592,15 @@
 									"title": "Map 4.17: Thundering Observatory",
 									"credit": "Dyson Logos",
 									"width": 4136,
-									"height": 5506
+									"height": 5506,
+									"grid": {
+										"type": "square",
+										"size": 301,
+										"offsetX": 161,
+										"offsetY": 143,
+										"scale": 3,
+										"distance": 10
+									}
 								},
 								"Map 4.17 depicts the Thundering Observatory, including the following features:",
 								{
@@ -6527,7 +6717,14 @@
 									"title": "Map 4.18: Worldroot Sapling",
 									"credit": "Dyson Logos",
 									"width": 4179,
-									"height": 5309
+									"height": 5309,
+									"grid": {
+										"type": "square",
+										"size": 261,
+										"offsetY": 107,
+										"scale": 3,
+										"distance": 10
+									}
 								},
 								"Map 4.18 depicts the Worldroot Sapling, including the following features:",
 								{

--- a/data/book/book-sato.json
+++ b/data/book/book-sato.json
@@ -2023,7 +2023,10 @@
 											"title": "Map 2.1: Elloweth Theater in the Civic Festhall",
 											"credit": "Jared Blando",
 											"width": 4250,
-											"height": 3812
+											"height": 3812,
+											"grid": {
+												"type": "none"
+											}
 										},
 										"Creativity blossoms in the Civic Festhall, the headquarters of the Society of Sensation. Sensates spared no expense constructing this majestic building, which reaches nearly one thousand feet in height. Visitors find all manner of sensory delights within: gastronomic masterpieces served by innovative chefs; halls lined with fragrant, scratch-and-sniff statuaries; and pitch-black deprivation chambers bathed in supernatural silence.",
 										{
@@ -2381,7 +2384,10 @@
 											"title": "Map 2.2: Hall of Vigils in the Mortuary",
 											"credit": "Jared Blando",
 											"width": 4250,
-											"height": 3835
+											"height": 3835,
+											"grid": {
+												"type": "none"
+											}
 										},
 										"The Heralds of Dust look after Sigil's dead in the Mortuary, the city's morgue. Situated between Blackshade Lane and Ragpicker's Square, the menacing stone structure rises above the Hive like a corpse from the grave. The Mortuary's towers bear low, gloomy domes with buttresses bristling with blades and windowless vaults clustered around the structure's base. Its dark, mournful halls reek of embalming fluids, their sterile tang sparing nostrils from viler odors trapped within the musty tombs.",
 										{
@@ -2739,7 +2745,10 @@
 											"title": "Map 2.3: Spire of the Grixitt in the Prison",
 											"credit": "Jared Blando",
 											"width": 4250,
-											"height": 3631
+											"height": 3631,
+											"grid": {
+												"type": "none"
+											}
 										},
 										"A single grim blemish of gray stone and metal rises above Sigil's resplendent courthouses. Headquarters of the Mercykillers, the Prison is a warning to wrongdoers of the full penalty of law. The Prison's architecture is anathema to hope and light. During the dark and twilight hours, glaring searchlights affixed to the penitentiary's barbed watchtowers scan the ward below for runaways, but all that escapes its walls are the wails of the prisoners within.",
 										{
@@ -2978,7 +2987,10 @@
 											"title": "Map 2.4: Mithral Tower in the Great Foundry",
 											"credit": "Jared Blando",
 											"width": 4250,
-											"height": 3597
+											"height": 3597,
+											"grid": {
+												"type": "none"
+											}
 										},
 										"The thrumming heart of industry in Sigil, the Great Foundry is the headquarters of the Mind's Eye. The foundry's a sprawling complex of workshops, warehouses, storage yards, and furnaces. Seekers work it tirelessly. By day, the foundry obscures the sky with smoke and steam, and by night, it illuminates entire city blocks with roaring fires.",
 										"The Mind's Eye makes many of the tools and metalcrafts used throughout Sigil. The foundry's most talented smiths are magical sculptors who require neither coal nor flame. They fashion strong yet delicate objects from minimal materials, shaping an ounce of ore into a lightweight yet trustworthy tool with a wave of their palms.",
@@ -3305,7 +3317,10 @@
 											"title": "Map 2.5: Grounds of the Great Gymnasium",
 											"credit": "Jared Blando",
 											"width": 4250,
-											"height": 4003
+											"height": 4003,
+											"grid": {
+												"type": "none"
+											}
 										},
 										{
 											"type": "entries",
@@ -6424,7 +6439,10 @@
 							"width": 4096,
 							"height": 2867,
 							"imageType": "map",
-							"id": "00b"
+							"id": "00b",
+							"grid": {
+								"type": "none"
+							}
 						},
 						{
 							"type": "image",
@@ -6438,6 +6456,9 @@
 							"imageType": "mapPlayer",
 							"mapParent": {
 								"id": "00b"
+							},
+							"grid": {
+								"type": "none"
 							}
 						}
 					]
@@ -6455,7 +6476,10 @@
 							"width": 4096,
 							"height": 2867,
 							"imageType": "map",
-							"id": "00c"
+							"id": "00c",
+							"grid": {
+								"type": "none"
+							}
 						},
 						{
 							"type": "image",
@@ -6469,6 +6493,9 @@
 							"imageType": "mapPlayer",
 							"mapParent": {
 								"id": "00c"
+							},
+							"grid": {
+								"type": "none"
 							}
 						}
 					]


### PR DESCRIPTION
Noticed that the `PAitM` `book` is missing. 
It's supposed to contain some poster maps so those might need aligning in future.
Put a suggestion in typos'etc but think it would be good to get a test added that checks if all images designated `imageType map/mapPlayer` has associated `grid` data. This should catch ones we miss, or add retrospectively, and act as a reminder when new content is added for this to be done.