### PR TITLE
Add missing Grid Data

### DIFF
--- a/data/adventure/adventure-coa.json
+++ b/data/adventure/adventure-coa.json
@@ -3133,7 +3133,11 @@
 									"width": 1611,
 									"height": 2195,
 									"imageType": "map",
-									"id": "362"
+									"id": "362",
+									"grid": {
+										"type": "none",
+										"size": 105
+									}
 								},
 								{
 									"type": "image",
@@ -3141,13 +3145,17 @@
 										"type": "internal",
 										"path": "adventure/CoA/041-0.webp"
 									},
-									"title": "(Player Version)",
+									"title": "Player Version",
 									"credit": "John Stevenson",
 									"width": 1611,
 									"height": 2195,
 									"imageType": "mapPlayer",
 									"mapParent": {
 										"id": "362"
+									},
+									"grid": {
+										"type": "none",
+										"size": 105
 									}
 								}
 							]
@@ -3497,6 +3505,9 @@
 									"hrefThumbnail": {
 										"type": "internal",
 										"path": "adventure/CoA/thumbnail/044-0-dm.webp"
+									},
+									"grid": {
+										"type": "none"
 									}
 								},
 								{
@@ -3508,10 +3519,13 @@
 									"credit": "John Stevenson",
 									"width": 3443,
 									"height": 2253,
-									"title": "(Player Version)",
+									"title": "Player Version",
 									"imageType": "mapPlayer",
 									"mapParent": {
 										"id": "363"
+									},
+									"grid": {
+										"type": "none"
 									}
 								}
 							]
@@ -5518,7 +5532,10 @@
 									"width": 1623,
 									"height": 1160,
 									"imageType": "map",
-									"id": "364"
+									"id": "364",
+									"grid": {
+										"type": "none"
+									}
 								},
 								{
 									"type": "image",
@@ -5526,13 +5543,16 @@
 										"type": "internal",
 										"path": "adventure/CoA/070-0.webp"
 									},
-									"title": "(Player Version)",
+									"title": "Player Version",
 									"credit": "John Stevenson",
 									"imageType": "mapPlayer",
 									"width": 1623,
 									"height": 1160,
 									"mapParent": {
 										"id": "364"
+									},
+									"grid": {
+										"type": "none"
 									}
 								}
 							]
@@ -5762,6 +5782,12 @@
 											"hrefThumbnail": {
 												"type": "internal",
 												"path": "adventure/CoA/thumbnail/072-0-dm.webp"
+											},
+											"grid": {
+												"type": "none",
+												"size": 75,
+												"distance": 0.5,
+												"units": "miles"
 											}
 										},
 										{
@@ -5770,13 +5796,19 @@
 												"type": "internal",
 												"path": "adventure/CoA/072-0.webp"
 											},
-											"title": "(Player Version)",
+											"title": "Player Version",
 											"credit": "John Stevenson",
 											"width": 1633,
 											"height": 1304,
 											"imageType": "mapPlayer",
 											"mapParent": {
 												"id": "365"
+											},
+											"grid": {
+												"type": "none",
+												"size": 75,
+												"distance": 0.5,
+												"units": "miles"
 											}
 										}
 									]
@@ -6023,7 +6055,10 @@
 													"width": 868,
 													"height": 923,
 													"imageType": "map",
-													"id": "366"
+													"id": "366",
+													"grid": {
+														"type": "none"
+													}
 												},
 												{
 													"type": "image",
@@ -6031,13 +6066,16 @@
 														"type": "internal",
 														"path": "adventure/CoA/075-0.webp"
 													},
-													"title": "(Player Version)",
+													"title": "Player Version",
 													"credit": "John Stevenson",
 													"width": 868,
 													"height": 923,
 													"imageType": "mapPlayer",
 													"mapParent": {
 														"id": "366"
+													},
+													"grid": {
+														"type": "none"
 													}
 												}
 											]
@@ -6650,6 +6688,9 @@
 													"hrefThumbnail": {
 														"type": "internal",
 														"path": "adventure/CoA/thumbnail/077-1-dm.webp"
+													},
+													"grid": {
+														"type": "none"
 													}
 												},
 												{
@@ -6658,13 +6699,16 @@
 														"type": "internal",
 														"path": "adventure/CoA/077-1.webp"
 													},
-													"title": "(Player Version)",
+													"title": "Player Version",
 													"credit": "John Stevenson",
 													"width": 850,
 													"height": 1013,
 													"imageType": "mapPlayer",
 													"mapParent": {
 														"id": "367"
+													},
+													"grid": {
+														"type": "none"
 													}
 												}
 											]
@@ -7092,7 +7136,10 @@
 									"width": 1612,
 									"height": 1148,
 									"imageType": "map",
-									"id": "368"
+									"id": "368",
+									"grid": {
+										"type": "none"
+									}
 								},
 								{
 									"type": "image",
@@ -7100,13 +7147,16 @@
 										"type": "internal",
 										"path": "adventure/CoA/083-0.webp"
 									},
-									"title": "(Player Version)",
+									"title": "Player Version",
 									"credit": "John Stevenson",
 									"width": 1612,
 									"height": 1148,
 									"imageType": "mapPlayer",
 									"mapParent": {
 										"id": "368"
+									},
+									"grid": {
+										"type": "none"
 									}
 								}
 							]
@@ -7496,6 +7546,11 @@
 											"hrefThumbnail": {
 												"type": "internal",
 												"path": "adventure/CoA/thumbnail/086-0-dm.webp"
+											},
+											"grid": {
+												"type": "none",
+												"size": 83,
+												"distance": 50
 											}
 										},
 										{
@@ -7504,13 +7559,18 @@
 												"type": "internal",
 												"path": "adventure/CoA/086-0.webp"
 											},
-											"title": "(Player Version)",
+											"title": "Player Version",
 											"credit": "John Stevenson",
 											"width": 1601,
 											"height": 2185,
 											"imageType": "mapPlayer",
 											"mapParent": {
 												"id": "369"
+											},
+											"grid": {
+												"type": "none",
+												"size": 83,
+												"distance": 50
 											}
 										}
 									]
@@ -8349,7 +8409,10 @@
 									"width": 1594,
 									"height": 1144,
 									"imageType": "map",
-									"id": "36a"
+									"id": "36a",
+									"grid": {
+										"type": "none"
+									}
 								},
 								{
 									"type": "image",
@@ -8357,13 +8420,16 @@
 										"type": "internal",
 										"path": "adventure/CoA/098-0.webp"
 									},
-									"title": "(Player Version)",
+									"title": "Player Version",
 									"credit": "John Stevenson",
 									"width": 1594,
 									"height": 1144,
 									"imageType": "mapPlayer",
 									"mapParent": {
 										"id": "36a"
+									},
+									"grid": {
+										"type": "none"
 									}
 								}
 							]
@@ -8577,6 +8643,12 @@
 											"hrefThumbnail": {
 												"type": "internal",
 												"path": "adventure/CoA/thumbnail/101-0-dm.webp"
+											},
+											"grid": {
+												"type": "none",
+												"size": 75,
+												"distance": 0.5,
+												"units": "miles"
 											}
 										},
 										{
@@ -8585,13 +8657,19 @@
 												"type": "internal",
 												"path": "adventure/CoA/101-0.webp"
 											},
-											"title": "(Player Version)",
+											"title": "Player Version",
 											"credit": "John Stevenson",
 											"width": 1606,
 											"height": 2172,
 											"imageType": "mapPlayer",
 											"mapParent": {
 												"id": "36b"
+											},
+											"grid": {
+												"type": "none",
+												"size": 75,
+												"distance": 0.5,
+												"units": "miles"
 											}
 										}
 									]
@@ -9210,7 +9288,10 @@
 									"width": 1609,
 									"height": 1138,
 									"imageType": "map",
-									"id": "36c"
+									"id": "36c",
+									"grid": {
+										"type": "none"
+									}
 								},
 								{
 									"type": "image",
@@ -9218,13 +9299,16 @@
 										"type": "internal",
 										"path": "adventure/CoA/110-0.webp"
 									},
-									"title": "(Player Version)",
+									"title": "Player Version",
 									"credit": "John Stevenson",
 									"width": 1609,
 									"height": 1138,
 									"imageType": "mapPlayer",
 									"mapParent": {
 										"id": "36c"
+									},
+									"grid": {
+										"type": "none"
 									}
 								}
 							]
@@ -9569,6 +9653,12 @@
 													"hrefThumbnail": {
 														"type": "internal",
 														"path": "adventure/CoA/thumbnail/115-0-dm.webp"
+													},
+													"grid": {
+														"type": "none",
+														"scale": 2,
+														"distance": 1,
+														"units": "miles"
 													}
 												},
 												{
@@ -9577,13 +9667,19 @@
 														"type": "internal",
 														"path": "adventure/CoA/115-0.webp"
 													},
-													"title": "(Player Version)",
+													"title": "Player Version",
 													"credit": "John Stevenson",
 													"width": 1589,
 													"height": 2171,
 													"imageType": "mapPlayer",
 													"mapParent": {
 														"id": "36d"
+													},
+													"grid": {
+														"type": "none",
+														"scale": 2,
+														"distance": 1,
+														"units": "miles"
 													}
 												}
 											]
@@ -10196,7 +10292,10 @@
 									"width": 1646,
 									"height": 1174,
 									"imageType": "map",
-									"id": "36e"
+									"id": "36e",
+									"grid": {
+										"type": "none"
+									}
 								},
 								{
 									"type": "image",
@@ -10204,13 +10303,16 @@
 										"type": "internal",
 										"path": "adventure/CoA/125-0.webp"
 									},
-									"title": "(Player Version)",
+									"title": "Player Version",
 									"credit": "John Stevenson",
 									"width": 1646,
 									"height": 1174,
 									"imageType": "mapPlayer",
 									"mapParent": {
 										"id": "36e"
+									},
+									"grid": {
+										"type": "none"
 									}
 								}
 							]
@@ -10859,6 +10961,11 @@
 											"hrefThumbnail": {
 												"type": "internal",
 												"path": "adventure/CoA/thumbnail/126-0-dm.webp"
+											},
+											"grid": {
+												"type": "none",
+												"size": 91,
+												"distance": 50
 											}
 										},
 										{
@@ -10867,13 +10974,18 @@
 												"type": "internal",
 												"path": "adventure/CoA/126-0.webp"
 											},
-											"title": "(Player Version)",
+											"title": "Player Version",
 											"credit": "John Stevenson",
 											"width": 1627,
 											"height": 2175,
 											"imageType": "mapPlayer",
 											"mapParent": {
 												"id": "36f"
+											},
+											"grid": {
+												"type": "none",
+												"size": 91,
+												"distance": 50
 											}
 										}
 									]
@@ -11444,7 +11556,10 @@
 									"width": 1625,
 									"height": 1163,
 									"imageType": "map",
-									"id": "370"
+									"id": "370",
+									"grid": {
+										"type": "none"
+									}
 								},
 								{
 									"type": "image",
@@ -11452,13 +11567,16 @@
 										"type": "internal",
 										"path": "adventure/CoA/137-0.webp"
 									},
-									"title": "(Player Version)",
+									"title": "Player Version",
 									"credit": "John Stevenson",
 									"width": 1625,
 									"height": 1163,
 									"imageType": "mapPlayer",
 									"mapParent": {
 										"id": "370"
+									},
+									"grid": {
+										"type": "none"
 									}
 								}
 							]
@@ -12331,6 +12449,13 @@
 											"hrefThumbnail": {
 												"type": "internal",
 												"path": "adventure/CoA/thumbnail/139-0-dm.webp"
+											},
+											"grid": {
+												"type": "square",
+												"size": 112,
+												"offsetX": -50,
+												"offsetY": 8,
+												"scale": 5
 											}
 										},
 										{
@@ -12339,13 +12464,20 @@
 												"type": "internal",
 												"path": "adventure/CoA/139-0.webp"
 											},
-											"title": "(Player Version)",
+											"title": "Player Version",
 											"credit": "John Stevenson",
 											"width": 1602,
 											"height": 2174,
 											"imageType": "mapPlayer",
 											"mapParent": {
 												"id": "371"
+											},
+											"grid": {
+												"type": "square",
+												"size": 112,
+												"offsetX": -50,
+												"offsetY": 8,
+												"scale": 5
 											}
 										}
 									]
@@ -13026,7 +13158,10 @@
 									"width": 1633,
 									"height": 1156,
 									"imageType": "map",
-									"id": "372"
+									"id": "372",
+									"grid": {
+										"type": "none"
+									}
 								},
 								{
 									"type": "image",
@@ -13034,13 +13169,16 @@
 										"type": "internal",
 										"path": "adventure/CoA/150-0.webp"
 									},
-									"title": "(Player Version)",
+									"title": "Player Version",
 									"credit": "John Stevenson",
 									"width": 1633,
 									"height": 1156,
 									"imageType": "mapPlayer",
 									"mapParent": {
 										"id": "372"
+									},
+									"grid": {
+										"type": "none"
 									}
 								}
 							]
@@ -13549,6 +13687,11 @@
 											"hrefThumbnail": {
 												"type": "internal",
 												"path": "adventure/CoA/thumbnail/154-0-dm.webp"
+											},
+											"grid": {
+												"type": "none",
+												"size": 57,
+												"distance": 25
 											}
 										},
 										{
@@ -13557,13 +13700,18 @@
 												"type": "internal",
 												"path": "adventure/CoA/154-0.webp"
 											},
-											"title": "(Player Version)",
+											"title": "Player Version",
 											"credit": "John Stevenson",
 											"width": 1611,
 											"height": 2191,
 											"imageType": "mapPlayer",
 											"mapParent": {
 												"id": "373"
+											},
+											"grid": {
+												"type": "none",
+												"size": 57,
+												"distance": 25
 											}
 										}
 									]
@@ -14136,7 +14284,10 @@
 									"width": 1642,
 									"height": 1166,
 									"imageType": "map",
-									"id": "375"
+									"id": "375",
+									"grid": {
+										"type": "none"
+									}
 								},
 								{
 									"type": "image",
@@ -14144,13 +14295,16 @@
 										"type": "internal",
 										"path": "adventure/CoA/164-0.webp"
 									},
-									"title": "(Player Version)",
+									"title": "Player Version",
 									"credit": "John Stevenson",
 									"width": 1642,
 									"height": 1166,
 									"imageType": "mapPlayer",
 									"mapParent": {
 										"id": "375"
+									},
+									"grid": {
+										"type": "none"
 									}
 								}
 							]
@@ -14756,6 +14910,13 @@
 											"hrefThumbnail": {
 												"type": "internal",
 												"path": "adventure/CoA/thumbnail/169-0-dm.webp"
+											},
+											"grid": {
+												"type": "square",
+												"size": 124,
+												"offsetX": -10,
+												"offsetY": -13,
+												"scale": 8
 											}
 										},
 										{
@@ -14764,13 +14925,20 @@
 												"type": "internal",
 												"path": "adventure/CoA/169-0.webp"
 											},
-											"title": "(Player Version)",
+											"title": "Player Version",
 											"credit": "John Stevenson",
 											"width": 1626,
 											"height": 2214,
 											"imageType": "mapPlayer",
 											"mapParent": {
 												"id": "376"
+											},
+											"grid": {
+												"type": "square",
+												"size": 124,
+												"offsetX": -10,
+												"offsetY": -13,
+												"scale": 8
 											}
 										}
 									]
@@ -16563,6 +16731,11 @@
 													"hrefThumbnail": {
 														"type": "internal",
 														"path": "adventure/CoA/thumbnail/181-0-dm.webp"
+													},
+													"grid": {
+														"type": "none",
+														"size": 78,
+														"scale": 2
 													}
 												},
 												{
@@ -16571,13 +16744,18 @@
 														"type": "internal",
 														"path": "adventure/CoA/181-0.webp"
 													},
-													"title": "(Player Version)",
+													"title": "Player Version",
 													"credit": "John Stevenson",
 													"width": 1617,
 													"height": 2196,
 													"imageType": "mapPlayer",
 													"mapParent": {
 														"id": "377"
+													},
+													"grid": {
+														"type": "none",
+														"size": 78,
+														"scale": 2
 													}
 												}
 											]
@@ -17335,6 +17513,11 @@
 									"hrefThumbnail": {
 										"type": "internal",
 										"path": "adventure/CoA/thumbnail/190-0-dm.webp"
+									},
+									"grid": {
+										"type": "none",
+										"size": 78,
+										"scale": 2
 									}
 								},
 								{
@@ -17343,13 +17526,18 @@
 										"type": "internal",
 										"path": "adventure/CoA/190-0.webp"
 									},
-									"title": "(Player Version)",
+									"title": "Player Version",
 									"credit": "John Stevenson",
 									"width": 1607,
 									"height": 2182,
 									"imageType": "mapPlayer",
 									"mapParent": {
 										"id": "378"
+									},
+									"grid": {
+										"type": "none",
+										"size": 78,
+										"scale": 2
 									}
 								}
 							]
@@ -17824,7 +18012,10 @@
 									"width": 1622,
 									"height": 1155,
 									"imageType": "map",
-									"id": "379"
+									"id": "379",
+									"grid": {
+										"type": "none"
+									}
 								},
 								{
 									"type": "image",
@@ -17832,13 +18023,16 @@
 										"type": "internal",
 										"path": "adventure/CoA/196-0.webp"
 									},
-									"title": "(Player Version)",
+									"title": "Player Version",
 									"credit": "John Stevenson",
 									"width": 1622,
 									"height": 1155,
 									"imageType": "mapPlayer",
 									"mapParent": {
 										"id": "379"
+									},
+									"grid": {
+										"type": "none"
 									}
 								}
 							]
@@ -18233,6 +18427,11 @@
 											"hrefThumbnail": {
 												"type": "internal",
 												"path": "adventure/CoA/thumbnail/203-0-dm.webp"
+											},
+											"grid": {
+												"type": "none",
+												"size": 91,
+												"distance": 50
 											}
 										},
 										{
@@ -18241,13 +18440,18 @@
 												"type": "internal",
 												"path": "adventure/CoA/203-0.webp"
 											},
-											"title": "(Player Version)",
+											"title": "Player Version",
 											"credit": "John Stevenson",
 											"width": 1618,
 											"height": 2192,
 											"imageType": "mapPlayer",
 											"mapParent": {
 												"id": "37a"
+											},
+											"grid": {
+												"type": "none",
+												"size": 91,
+												"distance": 50
 											}
 										}
 									]
@@ -19561,7 +19765,13 @@
 									"credit": "John Stevenson",
 									"imageType": "map",
 									"width": 1585,
-									"height": 1230
+									"height": 1230,
+									"grid": {
+										"type": "none",
+										"size": 75,
+										"distance": 0.5,
+										"units": "miles"
+									}
 								},
 								{
 									"type": "image",
@@ -19573,7 +19783,13 @@
 									"credit": "John Stevenson",
 									"imageType": "map",
 									"width": 1578,
-									"height": 2082
+									"height": 2082,
+									"grid": {
+										"type": "none",
+										"size": 75,
+										"distance": 0.5,
+										"units": "miles"
+									}
 								},
 								{
 									"type": "image",
@@ -19585,7 +19801,13 @@
 									"credit": "John Stevenson",
 									"imageType": "map",
 									"width": 1585,
-									"height": 2081
+									"height": 2081,
+									"grid": {
+										"type": "none",
+										"scale": 2,
+										"distance": 1,
+										"units": "miles"
+									}
 								},
 								{
 									"type": "image",
@@ -19597,7 +19819,12 @@
 									"credit": "John Stevenson",
 									"imageType": "map",
 									"width": 1578,
-									"height": 2083
+									"height": 2083,
+									"grid": {
+										"type": "none",
+										"size": 91,
+										"distance": 50
+									}
 								}
 							]
 						}
@@ -19623,7 +19850,12 @@
 									"credit": "John Stevenson",
 									"imageType": "map",
 									"width": 1578,
-									"height": 2082
+									"height": 2082,
+									"grid": {
+										"type": "none",
+										"size": 83,
+										"distance": 50
+									}
 								},
 								{
 									"type": "image",
@@ -19635,7 +19867,12 @@
 									"credit": "John Stevenson",
 									"imageType": "map",
 									"width": 1578,
-									"height": 2082
+									"height": 2082,
+									"grid": {
+										"type": "none",
+										"size": 57,
+										"distance": 25
+									}
 								}
 							]
 						}

--- a/data/adventure/adventure-dsotdq.json
+++ b/data/adventure/adventure-dsotdq.json
@@ -27212,7 +27212,14 @@
 					"title": "Poster Map",
 					"credit": "Francesca Baerald",
 					"width": 4096,
-					"height": 2926
+					"height": 2926,
+					"grid": {
+						"type": "none",
+						"size": 51,
+						"scale": 1.206,
+						"distance": 25,
+						"units": "miles"
+					}
 				}
 			]
 		}

--- a/data/book/book-bmt.json
+++ b/data/book/book-bmt.json
@@ -4986,7 +4986,14 @@
 											"credit": "Mike Schley",
 											"width": 1700,
 											"height": 2227,
-											"id": "072"
+											"id": "072",
+											"grid": {
+												"type": "square",
+												"size": 130,
+												"offsetX": 80,
+												"offsetY": 77,
+												"scale": 3
+											}
 										},
 										{
 											"type": "image",
@@ -5001,6 +5008,13 @@
 											"credit": "Mike Schley",
 											"mapParent": {
 												"id": "072"
+											},
+											"grid": {
+												"type": "square",
+												"size": 130,
+												"offsetX": 80,
+												"offsetY": 77,
+												"scale": 3
 											}
 										}
 									]
@@ -5546,7 +5560,14 @@
 													"credit": "Mike Schley",
 													"width": 1700,
 													"height": 1196,
-													"id": "073"
+													"id": "073",
+													"grid": {
+														"type": "square",
+														"size": 110,
+														"offsetX": 50,
+														"offsetY": 40,
+														"scale": 2
+													}
 												},
 												{
 													"type": "image",
@@ -5561,6 +5582,13 @@
 													"credit": "Mike Schley",
 													"mapParent": {
 														"id": "073"
+													},
+													"grid": {
+														"type": "square",
+														"size": 110,
+														"offsetX": 50,
+														"offsetY": 40,
+														"scale": 2
 													}
 												}
 											]
@@ -6446,7 +6474,14 @@
 											"credit": "Mike Schley",
 											"width": 1700,
 											"height": 1198,
-											"id": "074"
+											"id": "074",
+											"grid": {
+												"type": "square",
+												"size": 108,
+												"offsetX": 28,
+												"offsetY": 47,
+												"scale": 4
+											}
 										},
 										{
 											"type": "image",
@@ -6461,6 +6496,13 @@
 											"credit": "Mike Schley",
 											"mapParent": {
 												"id": "074"
+											},
+											"grid": {
+												"type": "square",
+												"size": 108,
+												"offsetX": 28,
+												"offsetY": 47,
+												"scale": 4
 											}
 										}
 									]
@@ -6696,7 +6738,10 @@
 									"credit": "Francesca Baerald",
 									"width": 1700,
 									"height": 1194,
-									"id": "075"
+									"id": "075",
+									"grid": {
+										"type": "none"
+									}
 								},
 								{
 									"type": "image",
@@ -6711,6 +6756,9 @@
 									"credit": "Francesca Baerald",
 									"mapParent": {
 										"id": "075"
+									},
+									"grid": {
+										"type": "none"
 									}
 								}
 							]
@@ -7458,7 +7506,14 @@
 											"credit": "Mike Schley",
 											"width": 1700,
 											"height": 2225,
-											"id": "076"
+											"id": "076",
+											"grid": {
+												"type": "square",
+												"size": 106,
+												"offsetX": 1,
+												"offsetY": 40,
+												"scale": 5
+											}
 										},
 										{
 											"type": "image",
@@ -7473,6 +7528,13 @@
 											"credit": "Mike Schley",
 											"mapParent": {
 												"id": "076"
+											},
+											"grid": {
+												"type": "square",
+												"size": 106,
+												"offsetX": 1,
+												"offsetY": 40,
+												"scale": 5
 											}
 										}
 									]
@@ -7875,7 +7937,10 @@
 									"credit": "Mike Schley",
 									"width": 1700,
 									"height": 2230,
-									"id": "077"
+									"id": "077",
+									"grid": {
+										"type": "none"
+									}
 								},
 								{
 									"type": "image",
@@ -7890,6 +7955,9 @@
 									"credit": "Mike Schley",
 									"mapParent": {
 										"id": "077"
+									},
+									"grid": {
+										"type": "none"
 									}
 								}
 							]
@@ -8107,7 +8175,14 @@
 											"credit": "Mike Schley",
 											"width": 1700,
 											"height": 1192,
-											"id": "078"
+											"id": "078",
+											"grid": {
+												"type": "square",
+												"size": 107,
+												"offsetX": -9,
+												"offsetY": -6,
+												"scale": 6
+											}
 										},
 										{
 											"type": "image",
@@ -8122,6 +8197,13 @@
 											"credit": "Mike Schley",
 											"mapParent": {
 												"id": "078"
+											},
+											"grid": {
+												"type": "square",
+												"size": 107,
+												"offsetX": -9,
+												"offsetY": -6,
+												"scale": 6
 											}
 										}
 									]
@@ -8189,7 +8271,10 @@
 									"title": "Map 17.1: Donjon Sphere",
 									"credit": "Mike Schley",
 									"width": 1700,
-									"height": 2391
+									"height": 2391,
+									"grid": {
+										"type": "none"
+									}
 								},
 								"A character with a {@item Deck of Many Things} can deduce the Donjon Sphere's location by spending 8 hours studying the night sky and using the cards as a divination tool. Afterward, the character must succeed on a DC 22 Intelligence ({@skill Arcana}) check to determine the sphere's coordinates in the Astral Sea. On a failed check, the character fails to calculate the sphere's location but can try again the next day, reducing the DC of the check by 1 for each consecutive attempt. Other methods of finding the sphere are detailed in the \"Adventure Hooks\" section below.",
 								"Once the sphere is located in the Astral Sea, the characters must reach it, probably using teleportation magic or a spelljamming vessel.",
@@ -8537,7 +8622,14 @@
 									"credit": "Mike Schley",
 									"width": 1700,
 									"height": 2226,
-									"id": "079"
+									"id": "079",
+									"grid": {
+										"type": "square",
+										"size": 112,
+										"offsetX": -51,
+										"offsetY": 52,
+										"scale": 8
+									}
 								},
 								{
 									"type": "image",
@@ -8552,6 +8644,13 @@
 									"credit": "Mike Schley",
 									"mapParent": {
 										"id": "079"
+									},
+									"grid": {
+										"type": "square",
+										"size": 112,
+										"offsetX": -51,
+										"offsetY": 52,
+										"scale": 8
 									}
 								}
 							]
@@ -9313,7 +9412,14 @@
 											"credit": "Mike Schley",
 											"width": 1700,
 											"height": 1194,
-											"id": "07a"
+											"id": "07a",
+											"grid": {
+												"type": "square",
+												"size": 119,
+												"offsetX": -4,
+												"offsetY": 62,
+												"scale": 5
+											}
 										},
 										{
 											"type": "image",
@@ -9328,6 +9434,13 @@
 											"credit": "Mike Schley",
 											"mapParent": {
 												"id": "07a"
+											},
+											"grid": {
+												"type": "square",
+												"size": 119,
+												"offsetX": -4,
+												"offsetY": 62,
+												"scale": 5
 											}
 										}
 									]
@@ -10191,7 +10304,10 @@
 											"credit": "Mike Schley",
 											"width": 1700,
 											"height": 1196,
-											"id": "07b"
+											"id": "07b",
+											"grid": {
+												"type": "none"
+											}
 										},
 										{
 											"type": "image",
@@ -10207,6 +10323,9 @@
 											"mapParent": {
 												"id": "07b",
 												"autoScale": true
+											},
+											"grid": {
+												"type": "none"
 											}
 										}
 									]
@@ -10544,7 +10663,10 @@
 											"credit": "Mike Schley",
 											"width": 1700,
 											"height": 1196,
-											"id": "07c"
+											"id": "07c",
+											"grid": {
+												"type": "none"
+											}
 										},
 										{
 											"type": "image",
@@ -10560,6 +10682,9 @@
 											"mapParent": {
 												"id": "07c",
 												"autoScale": true
+											},
+											"grid": {
+												"type": "none"
 											}
 										}
 									]
@@ -11236,7 +11361,14 @@
 											"credit": "Mike Schley",
 											"width": 1700,
 											"height": 1196,
-											"id": "07d"
+											"id": "07d",
+											"grid": {
+												"type": "square",
+												"size": 125,
+												"offsetX": -41,
+												"offsetY": -36,
+												"scale": 4
+											}
 										},
 										{
 											"type": "image",
@@ -11251,6 +11383,13 @@
 											"credit": "Mike Schley",
 											"mapParent": {
 												"id": "07d"
+											},
+											"grid": {
+												"type": "square",
+												"size": 125,
+												"offsetX": -41,
+												"offsetY": -36,
+												"scale": 4
 											}
 										}
 									]

--- a/data/book/book-sato.json
+++ b/data/book/book-sato.json
@@ -6590,7 +6590,7 @@
 								"type": "internal",
 								"path": "book/SatO/outlands-poster-map-player.webp"
 							},
-							"title": "(Player Version)",
+							"title": "Player Version",
 							"width": 4096,
 							"height": 2867,
 							"imageType": "mapPlayer",
@@ -6627,7 +6627,7 @@
 								"type": "internal",
 								"path": "book/SatO/sigil-poster-map-player.webp"
 							},
-							"title": "(Player Version)",
+							"title": "Player Version",
 							"width": 4096,
 							"height": 2867,
 							"imageType": "mapPlayer",

--- a/data/book/book-tdcsr.json
+++ b/data/book/book-tdcsr.json
@@ -3273,7 +3273,7 @@
 													"grid": {
 														"type": "none"
 													},
-													"mapName": "Stilben (Player Version)",
+													"mapName": "Player Version",
 													"width": 2550,
 													"height": 1731,
 													"mapParent": {
@@ -4268,7 +4268,7 @@
 													"grid": {
 														"type": "none"
 													},
-													"mapName": "The City of Whitestone (Player Version)",
+													"mapName": "Player Version",
 													"width": 2164,
 													"height": 3188,
 													"mapParent": {
@@ -5271,7 +5271,7 @@
 													"grid": {
 														"type": "none"
 													},
-													"mapName": "The City of Westruun (Player Version)",
+													"mapName": "Player Version",
 													"width": 2550,
 													"height": 1730,
 													"mapParent": {


### PR DESCRIPTION
Add Grid Data for CoA, BMT
All grids added except Solar Bastion which requires physical measurement of a handout.

```
##### Validating adventure/book map grids #####
Found maps with no "grid" in "./data/book/book-bmt.json"
        "Map 10.1: The Solar Bastion" (id "071"; closest entry id "151")
        "Player Version" (parent id "071"; closest entry id "151")
```
![image](https://github.com/5etools-mirror-1/5etools-mirror-1.github.io/assets/52298102/0a81b8c1-2b14-401b-b2ae-705d2a97c519)


